### PR TITLE
Add explicit staging for first-party optional apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ help:
 	@echo "  make stage-emulator EMULATOR=mupen64plus DEVICE=mlp1 stage standalone N64"
 	@echo "  make stage-emulators DEVICE=mlp1          stage standalone emulators"
 	@echo "  make stage-app APP=CentralScrutinizer DEVICE=mlp1 stage a single app repo"
+	@echo "  make stage-app APP=Leaf-Itchio-Pak DEVICE=mlp1 explicitly stage the optional Itch.io app"
 	@echo "  make release-zips DEVICE=mlp1             build end-user install + recovery ZIPs"
 	@echo "  make release-sd-zip DEVICE=mlp1           build end-user install ZIP"
 	@echo "  make release-recovery-zip DEVICE=mlp1     build end-user recovery ZIP"

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ help:
 	@echo "  make stage-app APP=CentralScrutinizer DEVICE=mlp1 stage a single app repo"
 	@echo "  make stage-app APP=Leaf-Itchio-Pak DEVICE=mlp1 explicitly stage the optional Itch.io app"
 	@echo "  make stage-app APP=DiscoBoy DEVICE=mlp1 explicitly stage the optional Disco Boy app"
+	@echo "  make stage-app APP=Nimbus DEVICE=mlp1       explicitly stage the optional Nimbus app"
+	@echo "  make stage-app APP=PortMaster-mlp1 DEVICE=mlp1 explicitly stage the optional PortMaster app"
 	@echo "  make release-zips DEVICE=mlp1             build end-user install + recovery ZIPs"
 	@echo "  make release-sd-zip DEVICE=mlp1           build end-user install ZIP"
 	@echo "  make release-recovery-zip DEVICE=mlp1     build end-user recovery ZIP"

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ help:
 	@echo "  make stage-emulators DEVICE=mlp1          stage standalone emulators"
 	@echo "  make stage-app APP=CentralScrutinizer DEVICE=mlp1 stage a single app repo"
 	@echo "  make stage-app APP=Leaf-Itchio-Pak DEVICE=mlp1 explicitly stage the optional Itch.io app"
+	@echo "  make stage-app APP=DiscoBoy DEVICE=mlp1 explicitly stage the optional Disco Boy app"
 	@echo "  make release-zips DEVICE=mlp1             build end-user install + recovery ZIPs"
 	@echo "  make release-sd-zip DEVICE=mlp1           build end-user install ZIP"
 	@echo "  make release-recovery-zip DEVICE=mlp1     build end-user recovery ZIP"

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ make stage-app APP=Thing-File DEVICE=mlp1
 make stage-app APP=CentralScrutinizer DEVICE=mlp1
 make stage-app APP=Fugazi DEVICE=mlp1
 make stage-app APP=Leaf-Itchio-Pak DEVICE=mlp1  # optional developer/acceptance stage only
+make stage-app APP=DiscoBoy DEVICE=mlp1         # optional developer/acceptance stage only
 
 make release-zips DEVICE=mlp1               # build end-user install + recovery ZIPs
 make release-sd-zip DEVICE=mlp1             # build end-user install ZIP only

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ make stage-app APP=ssh-server DEVICE=mlp1   # stage one app
 make stage-app APP=Thing-File DEVICE=mlp1
 make stage-app APP=CentralScrutinizer DEVICE=mlp1
 make stage-app APP=Fugazi DEVICE=mlp1
+make stage-app APP=Leaf-Itchio-Pak DEVICE=mlp1  # optional developer/acceptance stage only
 
 make release-zips DEVICE=mlp1               # build end-user install + recovery ZIPs
 make release-sd-zip DEVICE=mlp1             # build end-user install ZIP only

--- a/README.md
+++ b/README.md
@@ -84,11 +84,18 @@ make stage-app APP=CentralScrutinizer DEVICE=mlp1
 make stage-app APP=Fugazi DEVICE=mlp1
 make stage-app APP=Leaf-Itchio-Pak DEVICE=mlp1  # optional developer/acceptance stage only
 make stage-app APP=DiscoBoy DEVICE=mlp1         # optional developer/acceptance stage only
+make stage-app APP=Nimbus DEVICE=mlp1           # optional developer/acceptance stage only
+make stage-app APP=PortMaster-mlp1 DEVICE=mlp1  # optional developer/acceptance stage only
 
 make release-zips DEVICE=mlp1               # build end-user install + recovery ZIPs
 make release-sd-zip DEVICE=mlp1             # build end-user install ZIP only
 make release-recovery-zip DEVICE=mlp1       # build end-user recovery ZIP only
 ```
+
+The four first-party optional apps above are registered only for an explicit
+developer stage. They remain Pak Rat-owned and are excluded from default full
+staging, release ZIPs, `managed_apps`, and bootstrap requirements. Store
+install/update/uninstall testing must still use Pak Rat rather than `stage-app`.
 
 `make bootstrap` is idempotent. Existing sibling repos are reported as present
 and left untouched. Missing public repos are cloned into `Leaf/..`; optional

--- a/scripts/app-package-policy-smoke.sh
+++ b/scripts/app-package-policy-smoke.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LEAF_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKSPACE_ROOT="$(cd "$LEAF_ROOT/.." && pwd)"
+
+# shellcheck source=scripts/app-package-policy.sh
+. "$SCRIPT_DIR/app-package-policy.sh"
+
+assert_policy() {
+    local app="$1"
+    local expected_package="$2"
+    local expected_distribution="$3"
+
+    leaf_app_policy "$app" "$WORKSPACE_ROOT" mlp1
+    [ "$package_name" = "$expected_package" ] || {
+        echo "unexpected package for $app: $package_name" >&2
+        exit 1
+    }
+    [ "$distribution" = "$expected_distribution" ] || {
+        echo "unexpected distribution for $app: $distribution" >&2
+        exit 1
+    }
+}
+
+assert_policy Leaf-Itchio-Pak Itch-io.pak pakrat
+assert_policy DiscoBoy DiscoBoy.pak pakrat
+assert_policy Nimbus Nimbus.pak pakrat
+assert_policy PortMaster-mlp1 PortMaster.pak pakrat
+assert_policy ssh-server SSHServer.pak release
+
+if rg '^STAGE_APPS' "$LEAF_ROOT/stage/mlp1.mk" "$SCRIPT_DIR/make-sd-release-zip.sh" |
+    rg -i 'Leaf-Itchio|DiscoBoy|Nimbus|PortMaster'; then
+    echo "Pak Rat-owned optional app leaked into default STAGE_APPS" >&2
+    exit 1
+fi
+
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/leaf-pakrat-policy.XXXXXX")"
+trap 'rm -rf "$fixture"' EXIT HUP INT TERM
+mkdir -p "$fixture/platforms/mlp1" "$fixture/Apps/mlp1"
+printf '{"managed_apps": []}\n' >"$fixture/platforms/mlp1/manifest.json"
+: >"$fixture/managed-apps.txt"
+
+pakrat_packages=()
+while IFS= read -r package; do
+    [ -n "$package" ] && pakrat_packages+=("$package")
+done < <(leaf_pakrat_owned_package_names)
+python3 "$SCRIPT_DIR/audit-pakrat-owned-apps.py" "$fixture" "${pakrat_packages[@]}" >/dev/null
+
+for package in "${pakrat_packages[@]}"; do
+    printf 'mlp1/%s\n' "$package" >"$fixture/managed-apps.txt"
+    if python3 "$SCRIPT_DIR/audit-pakrat-owned-apps.py" \
+        "$fixture" "${pakrat_packages[@]}" >/dev/null 2>&1; then
+        echo "ownership audit accepted managed $package" >&2
+        exit 1
+    fi
+    : >"$fixture/managed-apps.txt"
+
+    printf '{"managed_apps": ["mlp1/%s"]}\n' "$package" \
+        >"$fixture/platforms/mlp1/manifest.json"
+    if python3 "$SCRIPT_DIR/audit-pakrat-owned-apps.py" \
+        "$fixture" "${pakrat_packages[@]}" >/dev/null 2>&1; then
+        echo "ownership audit accepted manifest-owned $package" >&2
+        exit 1
+    fi
+    printf '{"managed_apps": []}\n' >"$fixture/platforms/mlp1/manifest.json"
+
+    mkdir -p "$fixture/Apps/mlp1/$package"
+    if python3 "$SCRIPT_DIR/audit-pakrat-owned-apps.py" \
+        "$fixture" "${pakrat_packages[@]}" >/dev/null 2>&1; then
+        echo "ownership audit accepted staged $package" >&2
+        exit 1
+    fi
+    rmdir "$fixture/Apps/mlp1/$package"
+done
+
+echo "app-package-policy-smoke: PASS"

--- a/scripts/app-package-policy.sh
+++ b/scripts/app-package-policy.sh
@@ -9,12 +9,21 @@
 #   package_name
 #   destination_platform
 #   supported_devices
+#   distribution      release | pakrat
 
 leaf_known_platform() {
     case "${1:-}" in
         mlp1|tg5040|tg5050|my355|mac|shared) return 0 ;;
         *) return 1 ;;
     esac
+}
+
+leaf_pakrat_owned_package_names() {
+    printf '%s\n' \
+        "Itch-io.pak" \
+        "DiscoBoy.pak" \
+        "Nimbus.pak" \
+        "PortMaster.pak"
 }
 
 leaf_app_policy() {
@@ -28,6 +37,7 @@ leaf_app_policy() {
     package_name=
     destination_platform=
     supported_devices=
+    distribution=
 
     case "$app" in
         Leaf-Itchio-Pak)
@@ -37,6 +47,7 @@ leaf_app_policy() {
             package_name="Itch-io.pak"
             destination_platform="mlp1"
             supported_devices="mlp1"
+            distribution="pakrat"
             ;;
         DiscoBoy)
             package_target="package-platform"
@@ -45,6 +56,25 @@ leaf_app_policy() {
             package_name="DiscoBoy.pak"
             destination_platform="mlp1"
             supported_devices="mlp1"
+            distribution="pakrat"
+            ;;
+        Nimbus)
+            package_target="package-platform"
+            package_platform="mlp1"
+            package_dir="$workspace_dir/Nimbus/build/mlp1/package/Nimbus.pak"
+            package_name="Nimbus.pak"
+            destination_platform="mlp1"
+            supported_devices="mlp1"
+            distribution="pakrat"
+            ;;
+        PortMaster-mlp1)
+            package_target="package-platform"
+            package_platform="mlp1"
+            package_dir="$workspace_dir/PortMaster-mlp1/build/mlp1/package/PortMaster.pak"
+            package_name="PortMaster.pak"
+            destination_platform="mlp1"
+            supported_devices="mlp1"
+            distribution="pakrat"
             ;;
         ssh-server)
             package_target="package-platform"
@@ -53,6 +83,7 @@ leaf_app_policy() {
             package_name="SSHServer.pak"
             destination_platform="mlp1"
             supported_devices="mlp1"
+            distribution="release"
             ;;
         Thing-File)
             package_target="package-platform"
@@ -61,6 +92,7 @@ leaf_app_policy() {
             package_name="Thing-File.pak"
             destination_platform="mlp1"
             supported_devices="mlp1"
+            distribution="release"
             ;;
         CentralScrutinizer)
             package_target="package-platform"
@@ -69,6 +101,7 @@ leaf_app_policy() {
             package_name="CentralScrutinizer.pak"
             destination_platform="mlp1"
             supported_devices="mlp1"
+            distribution="release"
             ;;
         Fugazi)
             package_target="package-platform"
@@ -77,6 +110,7 @@ leaf_app_policy() {
             package_name="Fugazi.pak"
             destination_platform="mlp1"
             supported_devices="mlp1"
+            distribution="release"
             ;;
         joes-calibrage)
             package_target="package-platform"
@@ -85,6 +119,7 @@ leaf_app_policy() {
             package_name="Joe's Calibrage.pak"
             destination_platform="mlp1"
             supported_devices="mlp1"
+            distribution="release"
             ;;
         retroarch-builds)
             package_target="package-platform"
@@ -93,6 +128,7 @@ leaf_app_policy() {
             package_name="RetroArch.pak"
             destination_platform="shared"
             supported_devices="mlp1"
+            distribution="release"
             ;;
         *)
             return 1
@@ -103,6 +139,10 @@ leaf_app_policy() {
     if [ -n "$package_platform" ]; then
         leaf_known_platform "$package_platform" || return 1
     fi
+    case "$distribution" in
+        release|pakrat) ;;
+        *) return 1 ;;
+    esac
 
     if [ -n "$device" ]; then
         leaf_known_platform "$device" || return 2

--- a/scripts/app-package-policy.sh
+++ b/scripts/app-package-policy.sh
@@ -38,6 +38,14 @@ leaf_app_policy() {
             destination_platform="mlp1"
             supported_devices="mlp1"
             ;;
+        DiscoBoy)
+            package_target="package-platform"
+            package_platform="mlp1"
+            package_dir="$workspace_dir/DiscoBoy/build/mlp1/package/DiscoBoy.pak"
+            package_name="DiscoBoy.pak"
+            destination_platform="mlp1"
+            supported_devices="mlp1"
+            ;;
         ssh-server)
             package_target="package-platform"
             package_platform="mlp1"

--- a/scripts/app-package-policy.sh
+++ b/scripts/app-package-policy.sh
@@ -30,6 +30,14 @@ leaf_app_policy() {
     supported_devices=
 
     case "$app" in
+        Leaf-Itchio-Pak)
+            package_target="package-platform"
+            package_platform="mlp1"
+            package_dir="$workspace_dir/Leaf-Itchio-Pak/build/mlp1/package/Itch-io.pak"
+            package_name="Itch-io.pak"
+            destination_platform="mlp1"
+            supported_devices="mlp1"
+            ;;
         ssh-server)
             package_target="package-platform"
             package_platform="mlp1"

--- a/scripts/audit-pakrat-owned-apps.py
+++ b/scripts/audit-pakrat-owned-apps.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Reject Pak Rat-owned optional apps from a Leaf release payload."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+
+def read_managed_apps(path: pathlib.Path) -> list[str]:
+    if not path.is_file():
+        raise SystemExit(f"error: missing managed app list: {path}")
+    return [
+        line.strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def main() -> None:
+    if len(sys.argv) < 3:
+        raise SystemExit(
+            "usage: audit-pakrat-owned-apps.py RELEASE_ROOT PACKAGE.pak [...]"
+        )
+
+    release_root = pathlib.Path(sys.argv[1])
+    owned = {name.casefold(): name for name in sys.argv[2:]}
+    platform = release_root / "platforms" / "mlp1"
+    managed_file = release_root / "managed-apps.txt"
+    manifest_path = platform / "manifest.json"
+
+    managed_apps = read_managed_apps(managed_file)
+    if not manifest_path.is_file():
+        raise SystemExit(f"error: missing platform manifest: {manifest_path}")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest_apps = manifest.get("managed_apps", [])
+    if not isinstance(manifest_apps, list):
+        raise SystemExit("error: platform manifest managed_apps must be a list")
+
+    violations: list[str] = []
+    for source, entries in (
+        ("managed-apps.txt", managed_apps),
+        ("platform manifest", manifest_apps),
+    ):
+        for entry in entries:
+            package = pathlib.PurePosixPath(str(entry)).name.casefold()
+            if package in owned:
+                violations.append(
+                    f"{source} claims Pak Rat-owned {owned[package]}: {entry}"
+                )
+
+    apps_root = release_root / "Apps"
+    if apps_root.is_dir():
+        for path in apps_root.rglob("*"):
+            package = path.name.casefold()
+            if package in owned:
+                violations.append(
+                    f"release stages Pak Rat-owned {owned[package]}: {path}"
+                )
+
+    if violations:
+        raise SystemExit("error: " + "\nerror: ".join(violations))
+
+    names = ", ".join(owned.values())
+    print(f"Pak Rat ownership gate: optional apps absent from release ({names})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/make-sd-release-zip.sh
+++ b/scripts/make-sd-release-zip.sh
@@ -419,29 +419,23 @@ if not icon.is_file() or icon.stat().st_size == 0:
 if not license_path.is_file() or license_path.stat().st_size == 0:
     raise SystemExit(f"error: packaged Ports licence is missing or empty: {license_path}")
 
-managed_file = release_root / "managed-apps.txt"
-managed_apps = []
-if managed_file.is_file():
-    managed_apps = [line.strip() for line in managed_file.read_text(encoding="utf-8").splitlines()
-                    if line.strip() and not line.lstrip().startswith("#")]
-if any(pathlib.PurePosixPath(item).name.casefold() == "portmaster.pak" for item in managed_apps):
-    raise SystemExit("error: PortMaster.pak must remain Pak Rat-owned, not release-managed")
-
-manifest = json.load(open(platform / "manifest.json", encoding="utf-8"))
-manifest_apps = manifest.get("managed_apps", [])
-if any(pathlib.PurePosixPath(item).name.casefold() == "portmaster.pak" for item in manifest_apps):
-    raise SystemExit("error: platform manifest claims release ownership of PortMaster.pak")
-
-apps_root = release_root / "Apps"
-if apps_root.is_dir():
-    staged_portmaster = [path for path in apps_root.rglob("*")
-                         if path.name.casefold() == "portmaster.pak"]
-    if staged_portmaster:
-        raise SystemExit("error: release stages Pak Rat-owned PortMaster.pak: "
-                         + " ".join(str(path) for path in staged_portmaster))
-
-print("PortMaster OTA gate: packaged integration verified; pak remains Pak Rat-owned")
+print("PortMaster OTA gate: packaged Ports integration verified")
 EOF
+}
+
+validate_pakrat_owned_apps() {
+    local release_root="$1"
+    local package
+    local pakrat_packages=()
+
+    # shellcheck source=scripts/app-package-policy.sh
+    . "$LEAF_ROOT/scripts/app-package-policy.sh"
+    while IFS= read -r package; do
+        [ -n "$package" ] && pakrat_packages+=("$package")
+    done < <(leaf_pakrat_owned_package_names)
+    python3 "$LEAF_ROOT/scripts/audit-pakrat-owned-apps.py" \
+        "$release_root" "${pakrat_packages[@]}" || \
+        die "Pak Rat ownership validation failed"
 }
 
 audit_mlp1_build_tuning() {
@@ -470,11 +464,13 @@ build_missing_platform_bits() {
 
 package_app() {
     local app="$1"
-    local package_target package_platform package_dir package_name destination_platform supported_devices
+    local package_target package_platform package_dir package_name destination_platform supported_devices distribution
 
     # shellcheck source=scripts/app-package-policy.sh
     . "$LEAF_ROOT/scripts/app-package-policy.sh"
     leaf_app_policy "$app" "$WORKSPACE_DIR" "$DEVICE" || die "unsupported release app policy: $app for DEVICE=$DEVICE"
+    [ "$distribution" = "release" ] || \
+        die "Pak Rat-owned optional app cannot be packaged in a Leaf release: $app ($package_name)"
 
     [ -d "$WORKSPACE_DIR/$app" ] || die "missing app repo: $WORKSPACE_DIR/$app"
     local make_args=("$package_target")
@@ -690,6 +686,7 @@ build_install_zip() {
         package_app "$app"
     done
     sync_platform_managed_apps_manifest "$RELEASE_ROOT/platforms/mlp1/manifest.json" "$MANAGED_APPS_FILE"
+    validate_pakrat_owned_apps "$RELEASE_ROOT"
     validate_portmaster_integration "$RELEASE_ROOT"
     audit_mlp1_build_tuning "$RELEASE_ROOT"
 


### PR DESCRIPTION
## What changed

- registers Leaf-Itchio-Pak, Disco Boy, Nimbus, and PortMaster as explicit `stage-app` targets for MLP1 developer and acceptance work
- classifies app package policies as either release-managed or Pak Rat-owned
- leaves both default `STAGE_APPS` declarations unchanged
- blocks Pak Rat-owned policies from the release packaging path even when `STAGE_APPS` is overridden
- audits release payloads, `managed-apps.txt`, and the platform manifest for all four optional package names
- adds a host smoke test for policy resolution and positive/negative ownership cases

## Why

First-party optional apps need the same convenient direct device-staging path during development, without weakening their Pak Rat ownership or making them part of Leaf's default SD release.

## User and developer impact

Maintainers can explicitly stage any of the four optional apps when its sibling repository is present. Full staging, release ZIPs, managed app ownership, bootstrap requirements, and end-user distribution remain unchanged. Pak Rat is still required to test store ownership, updates, adoption, and uninstall behavior.

## Validation

- `bash -n scripts/app-package-policy.sh scripts/app-package-policy-smoke.sh scripts/make-sd-release-zip.sh`
- `python3 -m py_compile scripts/audit-pakrat-owned-apps.py`
- `./scripts/app-package-policy-smoke.sh`
- policy resolution checked against the owning Nimbus and PortMaster package targets and output paths
- verified all optional packages are absent from default `STAGE_APPS`
- verified managed-list, manifest, and staged-payload rejection for each optional package

This PR does not add an optional app to a default Leaf build or release ZIP.
