### PR TITLE
Generalize exact-artifact Pak Rat local feeds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ LARGE_LIBRARY_FIXTURE_ENV = \
 	REMOTE_SDCARD_PATH="$(REMOTE_SDCARD_PATH)"
 
 .DEFAULT_GOAL := help
-.PHONY: help bootstrap doctor status status-internal adb-enable-marker adb-disable-marker adb-tail-logs adb-large-library-create adb-large-library-clean adb-large-library-status adb-install-wrapper adb-uninstall-wrapper
+.PHONY: help bootstrap doctor status status-internal pakrat-local-feed-test adb-enable-marker adb-disable-marker adb-tail-logs adb-large-library-create adb-large-library-clean adb-large-library-status adb-install-wrapper adb-uninstall-wrapper
 
 help:
 	@echo "Leaf workspace commands (DEVICE=$(DEVICE), WORKSPACE_DIR=$(WORKSPACE_DIR)):"
@@ -47,6 +47,7 @@ help:
 	@echo "  make release-zips DEVICE=mlp1             build end-user install + recovery ZIPs"
 	@echo "  make release-sd-zip DEVICE=mlp1           build end-user install ZIP"
 	@echo "  make release-recovery-zip DEVICE=mlp1     build end-user recovery ZIP"
+	@echo "  make pakrat-local-feed-test               test multi-app and exact-artifact local feeds"
 	@echo "  make adb-enable-marker                    enable Leaf launcher marker"
 	@echo "  make adb-disable-marker                   disable Leaf launcher marker"
 	@echo "  make adb-tail-logs                        tail launcher logs"
@@ -87,6 +88,9 @@ status-internal:
 			printf "%-30s %s\n" "$$r" "(missing — run: make bootstrap)"; \
 		fi; \
 	done
+
+pakrat-local-feed-test:
+	python3 scripts/pakrat-local-feed-test.py
 
 adb-enable-marker:
 	scripts/adb-set-marker.sh on

--- a/README.md
+++ b/README.md
@@ -97,6 +97,29 @@ developer stage. They remain Pak Rat-owned and are excluded from default full
 staging, release ZIPs, `managed_apps`, and bootstrap requirements. Store
 install/update/uninstall testing must still use Pak Rat rather than `stage-app`.
 
+For a local Pak Rat catalog, pass one or more app repositories containing
+`pakrat.json`. The generator builds each selected package and writes only below
+`build/pakrat-local`:
+
+```sh
+python3 scripts/pakrat-local-feed.py \
+  --app-dir ../Leaf-Itchio-Pak \
+  --app-dir ../PortMaster-mlp1
+```
+
+To exercise the exact ZIP downloaded from a draft release without repackaging
+it, add an app-id-to-file override:
+
+```sh
+python3 scripts/pakrat-local-feed.py \
+  --app-dir ../Leaf-Itchio-Pak \
+  --skip-build \
+  --artifact org.umrk.itchio=/path/to/Itch-io.mlp1.pak.zip
+```
+
+The exact-artifact path is copied byte-for-byte into the local feed. Pak Rat
+lifecycle testing still uses the generated catalog and Jawaka ownership state.
+
 `make bootstrap` is idempotent. Existing sibling repos are reported as present
 and left untouched. Missing public repos are cloned into `Leaf/..`; optional
 private repos are cloned only when credentials are available.

--- a/scripts/pakrat-local-feed-test.py
+++ b/scripts/pakrat-local-feed-test.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Host tests for the multi-app Pak Rat local-feed generator."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+import uuid
+import warnings
+import zipfile
+
+
+LEAF_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = LEAF_ROOT / "scripts" / "pakrat-local-feed.py"
+OUTPUT_BASE = LEAF_ROOT / "build" / "pakrat-local"
+
+
+class LocalFeedTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory(prefix="leaf-pakrat-apps.")
+        self.apps_root = Path(self.temp.name)
+        self.output = OUTPUT_BASE / f"test-{uuid.uuid4().hex}"
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.output, ignore_errors=True)
+        self.temp.cleanup()
+
+    def write_app(
+        self,
+        directory: str,
+        app_id: str,
+        install_name: str,
+        artifact_name: str,
+        version: str = "1.0.0",
+    ) -> Path:
+        app_dir = self.apps_root / directory
+        package_dir = app_dir / "build" / "mlp1" / "package" / install_name
+        package_dir.mkdir(parents=True)
+        (package_dir / "pak.json").write_text(
+            json.dumps(
+                {
+                    "name": directory,
+                    "icon": "res/icon.png",
+                    "platform": "mlp1",
+                    "pak_version": version,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (package_dir / "payload.bin").write_bytes(f"payload-{app_id}".encode())
+        metadata = {
+            "schema": 1,
+            "id": app_id,
+            "name": directory,
+            "summary": f"{directory} summary",
+            "description": f"{directory} description",
+            "author": "Test",
+            "repo_url": f"https://example.invalid/{directory}",
+            "categories": ["test"],
+            "leaf": {
+                "packages": [
+                    {
+                        "platform": "mlp1",
+                        "version": version,
+                        "artifact_name": artifact_name,
+                        "install_name": install_name,
+                        "runtime_manifest_path": "pak.json",
+                        "package_dir": str(package_dir.relative_to(app_dir)),
+                        "build_command": ["false"],
+                    }
+                ]
+            },
+        }
+        (app_dir / "pakrat.json").write_text(
+            json.dumps(metadata, indent=2) + "\n", encoding="utf-8"
+        )
+        return app_dir
+
+    def run_feed(
+        self,
+        app_dirs: list[Path],
+        *extra: str,
+        expected_ok: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        command = [
+            sys.executable,
+            str(SCRIPT),
+            "--output",
+            str(self.output),
+            "--base-url",
+            "http://127.0.0.1:8765/pakrat/v1/",
+            "--skip-build",
+        ]
+        for app_dir in app_dirs:
+            command.extend(["--app-dir", str(app_dir)])
+        command.extend(extra)
+        result = subprocess.run(command, text=True, capture_output=True)
+        if expected_ok and result.returncode != 0:
+            self.fail(f"feed failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+        if not expected_ok and result.returncode == 0:
+            self.fail(f"feed unexpectedly passed:\n{result.stdout}")
+        return result
+
+    def catalog(self) -> dict:
+        return json.loads(
+            (self.output / "pakrat" / "v1" / "storefront.json").read_text(
+                encoding="utf-8"
+            )
+        )
+
+    def test_multiple_explicit_apps(self) -> None:
+        first = self.write_app(
+            "First", "org.example.first", "First.pak", "First.pak.zip"
+        )
+        second = self.write_app(
+            "Second", "org.example.second", "Second.pak", "Second.pak.zip"
+        )
+        self.run_feed([first, second])
+        catalog = self.catalog()
+        self.assertEqual(
+            [app["id"] for app in catalog["apps"]],
+            ["org.example.first", "org.example.second"],
+        )
+        for app in catalog["apps"]:
+            artifact = app["packages"][0]["artifact"]
+            artifact_path = (
+                self.output / "pakrat" / "v1" / "artifacts" / artifact["name"]
+            )
+            self.assertTrue(artifact_path.is_file())
+            self.assertEqual(artifact["size"], artifact_path.stat().st_size)
+            self.assertEqual(
+                artifact["sha256"],
+                hashlib.sha256(artifact_path.read_bytes()).hexdigest(),
+            )
+
+    def test_duplicate_id_and_install_name_are_rejected(self) -> None:
+        first = self.write_app(
+            "First", "org.example.same", "First.pak", "First.pak.zip"
+        )
+        duplicate_id = self.write_app(
+            "Second", "org.example.same", "Second.pak", "Second.pak.zip"
+        )
+        result = self.run_feed([first, duplicate_id], expected_ok=False)
+        self.assertIn("duplicate app id", result.stderr)
+
+        duplicate_install = self.write_app(
+            "Third", "org.example.third", "First.pak", "Third.pak.zip"
+        )
+        result = self.run_feed([first, duplicate_install], expected_ok=False)
+        self.assertIn("duplicate install name", result.stderr)
+
+    def test_exact_artifact_override_is_copied_byte_for_byte(self) -> None:
+        app = self.write_app(
+            "Exact", "org.example.exact", "Exact.pak", "Exact.pak.zip"
+        )
+        exact = self.apps_root / "Exact.pak.zip"
+        runtime = json.dumps(
+            {
+                "name": "Exact",
+                "icon": "res/icon.png",
+                "platform": "mlp1",
+                "pak_version": "1.0.0",
+            }
+        ).encode()
+        payload = b"exact-release-payload"
+        with zipfile.ZipFile(exact, "w") as archive:
+            archive.writestr("Exact.pak/pak.json", runtime)
+            archive.writestr("Exact.pak/exact.bin", payload)
+
+        self.run_feed(
+            [app],
+            "--artifact",
+            f"org.example.exact={exact}",
+        )
+        copied = self.output / "pakrat" / "v1" / "artifacts" / exact.name
+        self.assertEqual(copied.read_bytes(), exact.read_bytes())
+        package = self.catalog()["apps"][0]["packages"][0]
+        self.assertEqual(package["artifact"]["installed_size"], len(runtime) + len(payload))
+
+    def test_unsafe_exact_artifact_is_rejected(self) -> None:
+        app = self.write_app(
+            "Unsafe", "org.example.unsafe", "Unsafe.pak", "Unsafe.pak.zip"
+        )
+        unsafe = self.apps_root / "Unsafe.pak.zip"
+        with zipfile.ZipFile(unsafe, "w") as archive:
+            archive.writestr(
+                "Unsafe.pak/pak.json",
+                json.dumps({"pak_version": "1.0.0"}),
+            )
+            archive.writestr("../escape", b"no")
+        result = self.run_feed(
+            [app],
+            "--artifact",
+            f"org.example.unsafe={unsafe}",
+            expected_ok=False,
+        )
+        self.assertIn("unsafe or unexpected archive path", result.stderr)
+
+    def test_duplicate_exact_artifact_path_is_rejected(self) -> None:
+        app = self.write_app(
+            "Duplicate", "org.example.duplicate", "Duplicate.pak", "Duplicate.pak.zip"
+        )
+        duplicate = self.apps_root / "Duplicate.pak.zip"
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            with zipfile.ZipFile(duplicate, "w") as archive:
+                archive.writestr(
+                    "Duplicate.pak/pak.json",
+                    json.dumps({"pak_version": "1.0.0"}),
+                )
+                archive.writestr("Duplicate.pak/payload.bin", b"first")
+                archive.writestr("Duplicate.pak/payload.bin", b"second")
+        result = self.run_feed(
+            [app],
+            "--artifact",
+            f"org.example.duplicate={duplicate}",
+            expected_ok=False,
+        )
+        self.assertIn("duplicate archive path", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/pakrat-local-feed.py
+++ b/scripts/pakrat-local-feed.py
@@ -64,14 +64,6 @@ def run_command(argv: list[str], cwd: Path) -> None:
     subprocess.run(argv, cwd=str(cwd), check=True)
 
 
-def tree_size(path: Path) -> int:
-    total = 0
-    for item in path.rglob("*"):
-        if item.is_file() and not item.is_symlink():
-            total += item.stat().st_size
-    return total
-
-
 def file_sha256(path: Path) -> str:
     h = hashlib.sha256()
     with path.open("rb") as fp:
@@ -105,6 +97,114 @@ def zip_pak_dir(package_dir: Path, out_zip: Path) -> None:
     tmp_zip.replace(out_zip)
 
 
+def inspect_zip_artifact(
+    artifact_path: Path, install_name: str, runtime_manifest_path: str
+) -> tuple[dict, int]:
+    if not artifact_path.is_file():
+        die(f"missing artifact: {artifact_path}")
+    if artifact_path.suffix.casefold() != ".zip":
+        die(f"artifact must be a ZIP: {artifact_path}")
+    if not install_name.endswith(".pak") or "/" in install_name or "\\" in install_name:
+        die(f"unsafe install_name: {install_name!r}")
+    runtime_parts = Path(runtime_manifest_path).parts
+    if (
+        not runtime_parts
+        or Path(runtime_manifest_path).is_absolute()
+        or ".." in runtime_parts
+        or "\\" in runtime_manifest_path
+    ):
+        die(f"unsafe runtime_manifest_path: {runtime_manifest_path!r}")
+
+    expected_manifest = (
+        Path(install_name, *runtime_parts).as_posix()
+    )
+    installed_size = 0
+    runtime_bytes: bytes | None = None
+    try:
+        with zipfile.ZipFile(artifact_path) as archive:
+            seen_names: set[str] = set()
+            for info in archive.infolist():
+                name = info.filename
+                path = Path(name)
+                if (
+                    not name
+                    or name.startswith("/")
+                    or "\\" in name
+                    or ".." in path.parts
+                    or path.parts[0] != install_name
+                ):
+                    die(f"{artifact_path}: unsafe or unexpected archive path {name!r}")
+                if name in seen_names:
+                    die(f"{artifact_path}: duplicate archive path {name!r}")
+                seen_names.add(name)
+                mode = (info.external_attr >> 16) & 0o170000
+                if mode not in (0, 0o040000, 0o100000):
+                    die(f"{artifact_path}: non-regular archive entry {name!r}")
+                if info.is_dir():
+                    continue
+                installed_size += info.file_size
+                if name == expected_manifest:
+                    runtime_bytes = archive.read(info)
+    except zipfile.BadZipFile as exc:
+        die(f"invalid ZIP {artifact_path}: {exc}")
+
+    if runtime_bytes is None:
+        die(f"{artifact_path}: missing {expected_manifest}")
+    try:
+        runtime = json.loads(runtime_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        die(f"{artifact_path}: invalid runtime manifest: {exc}")
+    if not isinstance(runtime, dict):
+        die(f"{artifact_path}: runtime manifest must be an object")
+    return runtime, installed_size
+
+
+def parse_artifact_overrides(values: list[str]) -> dict[str, Path]:
+    overrides: dict[str, Path] = {}
+    for value in values:
+        app_id, separator, raw_path = value.partition("=")
+        if not separator or not app_id or not raw_path:
+            die(f"invalid --artifact {value!r}; expected APP_ID=/path/to/file.zip")
+        if app_id in overrides:
+            die(f"duplicate --artifact override for {app_id}")
+        overrides[app_id] = Path(raw_path).expanduser().resolve()
+    return overrides
+
+
+def require_metadata_string(meta: dict, key: str, source: Path) -> str:
+    value = meta.get(key)
+    if not isinstance(value, str) or not value.strip():
+        die(f"{source}: {key} must be a non-empty string")
+    return value
+
+
+def resolve_app_dirs(args: argparse.Namespace) -> list[Path]:
+    if args.app_dir:
+        app_dirs = [Path(value).expanduser().resolve() for value in args.app_dir]
+    else:
+        app_dirs = [find_sdlreader(args.sdlreader_dir).resolve()]
+    seen: set[Path] = set()
+    result: list[Path] = []
+    for app_dir in app_dirs:
+        if app_dir in seen:
+            die(f"duplicate --app-dir: {app_dir}")
+        if not (app_dir / "pakrat.json").is_file():
+            die(f"missing {app_dir / 'pakrat.json'}")
+        seen.add(app_dir)
+        result.append(app_dir)
+    return result
+
+
+def require_output_root(value: str) -> Path:
+    output_root = Path(value).expanduser().resolve()
+    allowed_root = DEFAULT_OUTPUT.resolve()
+    try:
+        output_root.relative_to(allowed_root)
+    except ValueError:
+        die(f"--output must be {allowed_root} or a child path")
+    return output_root
+
+
 def ensure_base_url(base_url: str) -> str:
     return base_url if base_url.endswith("/") else base_url + "/"
 
@@ -119,76 +219,154 @@ def default_lan_ip() -> str:
 
 
 def build_storefront(args: argparse.Namespace) -> Path:
-    output_root = Path(args.output).resolve()
+    output_root = require_output_root(args.output)
+    if output_root.exists():
+        shutil.rmtree(output_root)
     feed_root = output_root / FEED_PREFIX
     artifacts_root = feed_root / "artifacts"
     artifacts_root.mkdir(parents=True, exist_ok=True)
 
-    sdlreader = find_sdlreader(args.sdlreader_dir)
-    meta = load_json(sdlreader / "pakrat.json")
-    root_nextui = load_json(sdlreader / "pak.json")
-
-    compat = meta.get("compat", {})
-    if compat.get("nextui_pak_json") != "pak.json":
-        die("SDLReader pakrat.json must declare compat.nextui_pak_json = pak.json")
-    if root_nextui.get("release_filename") != "SDLReader.pakz":
-        die("SDLReader root pak.json no longer looks like the NextUI manifest")
-
-    packages = meta.get("leaf", {}).get("packages", [])
-    if not packages:
-        die("pakrat.json has no leaf.packages entries")
-
+    app_dirs = resolve_app_dirs(args)
+    artifact_overrides = parse_artifact_overrides(args.artifact)
     base_url = ensure_base_url(args.base_url)
-    apps_packages = []
-    app_version = ""
+    apps: list[dict] = []
+    seen_ids: set[str] = set()
+    seen_install_names: set[str] = set()
+    seen_artifact_names: set[str] = set()
 
-    for pkg in packages:
-        platform = pkg.get("platform")
-        if platform != "mlp1":
-            print(f"pakrat-local-feed: skipping non-MLP1 package {platform!r}")
-            continue
+    for app_dir in app_dirs:
+        metadata_path = app_dir / "pakrat.json"
+        meta = load_json(metadata_path)
+        if meta.get("schema") != 1:
+            die(f"{metadata_path}: schema must be 1")
+        app_id = require_metadata_string(meta, "id", metadata_path)
+        if app_id in seen_ids:
+            die(f"duplicate app id: {app_id}")
+        seen_ids.add(app_id)
 
-        build_command = pkg.get("build_command") or []
-        if build_command and not args.skip_build:
-            run_command([str(part) for part in build_command], sdlreader)
+        packages = meta.get("leaf", {}).get("packages", [])
+        if not isinstance(packages, list) or not packages:
+            die(f"{metadata_path}: leaf.packages must be a non-empty array")
+        selected = [pkg for pkg in packages if pkg.get("platform") == "mlp1"]
+        if not selected:
+            die(f"{metadata_path}: no MLP1 Leaf package")
+        if app_id in artifact_overrides and len(selected) != 1:
+            die(f"--artifact override for {app_id} requires exactly one MLP1 package")
 
-        package_dir = sdlreader / pkg.get("package_dir", "")
-        artifact_name = pkg.get("artifact_name")
-        if not artifact_name:
-            die("leaf package missing artifact_name")
-        artifact_path = artifacts_root / artifact_name
-        zip_pak_dir(package_dir, artifact_path)
+        app_packages: list[dict] = []
+        app_versions: set[str] = set()
+        for pkg in selected:
+            package_dir_raw = pkg.get("package_dir")
+            artifact_name = pkg.get("artifact_name")
+            install_name = pkg.get("install_name")
+            runtime_manifest_path = pkg.get("runtime_manifest_path", "pak.json")
+            if not isinstance(package_dir_raw, str) or not package_dir_raw:
+                die(f"{metadata_path}: package_dir must be a non-empty string")
+            if not isinstance(artifact_name, str) or not artifact_name.endswith(".zip"):
+                die(f"{metadata_path}: artifact_name must end with .zip")
+            if not isinstance(install_name, str) or not install_name.endswith(".pak"):
+                die(f"{metadata_path}: install_name must end with .pak")
+            if not isinstance(runtime_manifest_path, str) or not runtime_manifest_path:
+                die(f"{metadata_path}: runtime_manifest_path must be a non-empty string")
 
-        runtime_manifest = package_dir / pkg.get("runtime_manifest_path", "pak.json")
-        runtime = load_json(runtime_manifest)
-        version = pkg.get("version") or runtime.get("pak_version")
-        if version != runtime.get("pak_version"):
-            die(
-                f"{runtime_manifest} pak_version {runtime.get('pak_version')!r} "
-                f"does not match Pak Rat version {version!r}"
+            install_key = install_name.casefold()
+            if install_key in seen_install_names:
+                die(f"duplicate install name: {install_name}")
+            seen_install_names.add(install_key)
+            artifact_key = artifact_name.casefold()
+            if artifact_key in seen_artifact_names:
+                die(f"duplicate artifact name: {artifact_name}")
+            seen_artifact_names.add(artifact_key)
+
+            package_dir = (app_dir / package_dir_raw).resolve()
+            try:
+                package_dir.relative_to(app_dir)
+            except ValueError:
+                die(f"{metadata_path}: package_dir escapes app root")
+            if package_dir.name != install_name:
+                die(
+                    f"{metadata_path}: package_dir name {package_dir.name!r} "
+                    f"does not match install_name {install_name!r}"
+                )
+
+            build_command = pkg.get("build_command") or []
+            override = artifact_overrides.get(app_id)
+            if override is None and build_command and not args.skip_build:
+                if not isinstance(build_command, list) or not all(
+                    isinstance(part, str) and part for part in build_command
+                ):
+                    die(f"{metadata_path}: build_command must be a string array")
+                run_command(build_command, app_dir)
+
+            artifact_path = artifacts_root / artifact_name
+            if override is not None:
+                if override.name != artifact_name:
+                    die(
+                        f"--artifact for {app_id} must be named {artifact_name}, "
+                        f"got {override.name}"
+                    )
+                if not override.is_file():
+                    die(f"missing exact artifact override: {override}")
+                shutil.copy2(override, artifact_path)
+            else:
+                zip_pak_dir(package_dir, artifact_path)
+
+            runtime, installed_size = inspect_zip_artifact(
+                artifact_path, install_name, runtime_manifest_path
+            )
+            version = pkg.get("version") or runtime.get("pak_version")
+            if not isinstance(version, str) or not version:
+                die(f"{metadata_path}: package version must be a non-empty string")
+            if version != runtime.get("pak_version"):
+                die(
+                    f"{artifact_path}: runtime pak_version "
+                    f"{runtime.get('pak_version')!r} does not match Pak Rat "
+                    f"version {version!r}"
+                )
+            app_versions.add(version)
+            app_packages.append(
+                {
+                    "platform": "mlp1",
+                    "runtime": "leaf",
+                    "version": version,
+                    "install_name": install_name,
+                    "runtime_manifest_path": runtime_manifest_path,
+                    "artifact": {
+                        "url": base_url + f"artifacts/{artifact_name}",
+                        "name": artifact_name,
+                        "archive": "zip",
+                        "size": artifact_path.stat().st_size,
+                        "installed_size": installed_size,
+                        "sha256": file_sha256(artifact_path),
+                    },
+                }
             )
 
-        app_version = version
-        apps_packages.append(
+        if len(app_versions) != 1:
+            die(f"{metadata_path}: all MLP1 packages must use one app version")
+        app_version = next(iter(app_versions))
+        categories = meta.get("categories", [])
+        if not isinstance(categories, list) or not all(
+            isinstance(value, str) and value for value in categories
+        ):
+            die(f"{metadata_path}: categories must be a string array")
+        apps.append(
             {
-                "platform": platform,
-                "runtime": "leaf",
-                "version": version,
-                "install_name": pkg.get("install_name", package_dir.name),
-                "runtime_manifest_path": pkg.get("runtime_manifest_path", "pak.json"),
-                "artifact": {
-                    "url": base_url + f"artifacts/{artifact_name}",
-                    "name": artifact_name,
-                    "archive": "zip",
-                    "size": artifact_path.stat().st_size,
-                    "installed_size": tree_size(package_dir),
-                    "sha256": file_sha256(artifact_path),
-                },
+                "id": app_id,
+                "name": require_metadata_string(meta, "name", metadata_path),
+                "summary": require_metadata_string(meta, "summary", metadata_path),
+                "description": require_metadata_string(meta, "description", metadata_path),
+                "author": require_metadata_string(meta, "author", metadata_path),
+                "repo_url": require_metadata_string(meta, "repo_url", metadata_path),
+                "categories": categories,
+                "version": app_version,
+                "packages": app_packages,
             }
         )
 
-    if not apps_packages:
-        die("no local Pak Rat packages were generated")
+    unknown_overrides = sorted(set(artifact_overrides) - seen_ids)
+    if unknown_overrides:
+        die(f"--artifact references unknown app ids: {', '.join(unknown_overrides)}")
 
     generated_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
     storefront = {
@@ -196,27 +374,19 @@ def build_storefront(args: argparse.Namespace) -> Path:
         "product": "pak-rat",
         "catalog_revision": "local-" + generated_at.replace(":", "").replace("-", ""),
         "generated_at": generated_at,
-        "apps": [
-            {
-                "id": meta["id"],
-                "name": meta["name"],
-                "summary": meta["summary"],
-                "description": meta.get("description", ""),
-                "author": meta.get("author", ""),
-                "repo_url": meta.get("repo_url", ""),
-                "categories": meta.get("categories", []),
-                "version": app_version,
-                "packages": apps_packages,
-            }
-        ],
+        "apps": apps,
     }
 
     storefront_path = feed_root / "storefront.json"
     storefront_path.write_text(json.dumps(storefront, indent=2) + "\n", encoding="utf-8")
     print(f"Wrote {storefront_path}")
-    for pkg in apps_packages:
-        artifact = pkg["artifact"]
-        print(f"  {artifact['name']} size={artifact['size']} sha256={artifact['sha256']}")
+    for app in apps:
+        for pkg in app["packages"]:
+            artifact = pkg["artifact"]
+            print(
+                f"  {app['id']} {artifact['name']} "
+                f"size={artifact['size']} sha256={artifact['sha256']}"
+            )
     return storefront_path
 
 
@@ -279,7 +449,20 @@ def serve(args: argparse.Namespace) -> None:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output", default=str(DEFAULT_OUTPUT), help="output root")
+    parser.add_argument(
+        "--app-dir",
+        action="append",
+        default=[],
+        help="app repo containing pakrat.json; repeat for multiple apps",
+    )
     parser.add_argument("--sdlreader-dir", help="path to SDLReader-brick")
+    parser.add_argument(
+        "--artifact",
+        action="append",
+        default=[],
+        metavar="APP_ID=ZIP",
+        help="use an exact prebuilt artifact for one selected app",
+    )
     parser.add_argument("--host", default="127.0.0.1", help="serve host")
     parser.add_argument("--port", type=int, default=8765, help="serve port")
     parser.add_argument("--base-url", help="catalog artifact base URL")


### PR DESCRIPTION
## What changed

- generalizes the Pak Rat local-feed generator from SDLReader-only discovery to one or more explicit app repositories
- retains SDLReader as the no-argument compatibility/default source
- builds every selected MLP1 package and rejects duplicate app IDs, install names, and artifact names
- supports an explicit `APP_ID=ZIP` override that copies a downloaded draft artifact byte-for-byte instead of repackaging it
- derives size, installed size, runtime version, and SHA-256 from the actual ZIP
- rejects unsafe, escaping, non-regular, duplicate, or malformed archive entries
- constrains generated output to `Leaf/build/pakrat-local`
- adds host tests and usage documentation

## Why

Leaf-Itchio-Pak's production gate must test the exact draft release artifact through Jawaka Pak Rat. The prior helper always rebuilt and rezipped one SDLReader package, so it could not prove artifact identity or support coordinated first-party app feeds.

## User and developer impact

Maintainers can generate one local catalog for any selected first-party apps and can verify an immutable downloaded ZIP without altering production `leaf-docs` data. Existing no-argument SDLReader behavior remains available.

## Validation

- `python3 -m py_compile scripts/pakrat-local-feed.py scripts/pakrat-local-feed-test.py`
- `make pakrat-local-feed-test` — five tests pass
- generated a Leaf-Itchio-Pak-only feed from the exact local package
- verified byte-for-byte artifact SHA-256 `e061615608d86d67e145015fc6a7270df2eb7ff11aadc855dd519f9cd339875f`
- Jawaka local Pak Rat available/install/stale/restore/managed-ownership smoke passed against that feed
- `git diff --check`

This changes no default staging, release ZIP, managed-app, bootstrap, or production storefront data.
