### PR TITLE
Stage the MLP1 PPSSPP Vulkan runtime and benchmark lane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ LARGE_LIBRARY_FIXTURE_ENV = \
 	REMOTE_SDCARD_PATH="$(REMOTE_SDCARD_PATH)"
 
 .DEFAULT_GOAL := help
-.PHONY: help bootstrap doctor status status-internal pakrat-local-feed-test adb-enable-marker adb-disable-marker adb-tail-logs adb-large-library-create adb-large-library-clean adb-large-library-status adb-install-wrapper adb-uninstall-wrapper
+.PHONY: help bootstrap doctor status status-internal pakrat-local-feed-test adb-enable-marker adb-disable-marker adb-tail-logs adb-large-library-create adb-large-library-clean adb-large-library-status adb-install-wrapper adb-uninstall-wrapper benchmark-ppsspp
 
 help:
 	@echo "Leaf workspace commands (DEVICE=$(DEVICE), WORKSPACE_DIR=$(WORKSPACE_DIR)):"
@@ -56,6 +56,7 @@ help:
 	@echo "  make adb-large-library-clean              remove fake large-library fixture"
 	@echo "  make adb-install-wrapper                  install Leaf init hook (compat alias)"
 	@echo "  make adb-uninstall-wrapper                remove Leaf init hook (compat alias)"
+	@echo "  make benchmark-ppsspp ROM=/path CORE=vulkan PRESET=balanced"
 
 bootstrap:
 	@LEAF_WORKSPACE_DIR="$(WORKSPACE_DIR)" scripts/bootstrap.sh $(REQUIRED_REPOS) --optional $(OPTIONAL_PRIVATE_REPOS)
@@ -115,3 +116,11 @@ adb-install-wrapper:
 
 adb-uninstall-wrapper:
 	scripts/adb-uninstall-wrapper.sh
+
+benchmark-ppsspp:
+	@test -n "$(ROM)" || { echo "usage: make benchmark-ppsspp ROM=/device/path [CORE=vulkan|gles] [PRESET=balanced|performance] [BENCHMARK_ARGS='...']" >&2; exit 1; }
+	scripts/ppsspp-benchmark.py \
+		--rom "$(ROM)" \
+		--core "$(if $(CORE),$(CORE),vulkan)" \
+		--preset "$(if $(PRESET),$(PRESET),balanced)" \
+		$(BENCHMARK_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ help:
 	@echo "  make adb-large-library-clean              remove fake large-library fixture"
 	@echo "  make adb-install-wrapper                  install Leaf init hook (compat alias)"
 	@echo "  make adb-uninstall-wrapper                remove Leaf init hook (compat alias)"
-	@echo "  make benchmark-ppsspp ROM=/path CORE=vulkan PRESET=balanced"
+	@echo "  make benchmark-ppsspp ROM=/path CORE=vulkan PRESET=balanced TRACE=scripts/ppsspp-input-traces/example.json"
 
 bootstrap:
 	@LEAF_WORKSPACE_DIR="$(WORKSPACE_DIR)" scripts/bootstrap.sh $(REQUIRED_REPOS) --optional $(OPTIONAL_PRIVATE_REPOS)
@@ -118,9 +118,10 @@ adb-uninstall-wrapper:
 	scripts/adb-uninstall-wrapper.sh
 
 benchmark-ppsspp:
-	@test -n "$(ROM)" || { echo "usage: make benchmark-ppsspp ROM=/device/path [CORE=vulkan|gles] [PRESET=balanced|performance] [BENCHMARK_ARGS='...']" >&2; exit 1; }
+	@test -n "$(ROM)" || { echo "usage: make benchmark-ppsspp ROM=/device/path [CORE=vulkan|gles] [PRESET=balanced|performance] [TRACE=/local/trace.json] [BENCHMARK_ARGS='...']" >&2; exit 1; }
 	scripts/ppsspp-benchmark.py \
 		--rom "$(ROM)" \
 		--core "$(if $(CORE),$(CORE),vulkan)" \
 		--preset "$(if $(PRESET),$(PRESET),balanced)" \
+		$(if $(TRACE),--input-trace "$(TRACE)") \
 		$(BENCHMARK_ARGS)

--- a/scripts/build-mlp1-graphics-runtime.sh
+++ b/scripts/build-mlp1-graphics-runtime.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LEAF_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LOCK="${MLP1_MALI_LOCK:-$LEAF_ROOT/stage/mlp1-graphics/aarch64-mali.lock.json}"
+WORK_DIR="${MLP1_GRAPHICS_WORK_DIR:-$LEAF_ROOT/workdir/mlp1/graphics}"
+GRAPHICS_ROOT="${MLP1_GRAPHICS_RUNTIME_DIR:-$LEAF_ROOT/build/mlp1/runtime/graphics}"
+RUNTIME_ID="rk3566-g52-g29p1"
+RUNTIME_DIR="$GRAPHICS_ROOT/vulkan/$RUNTIME_ID"
+
+read_lock() {
+    python3 - "$LOCK" "$1" <<'PY'
+import json
+import sys
+
+path, key = sys.argv[1], sys.argv[2]
+with open(path, "r", encoding="utf-8") as handle:
+    value = json.load(handle)
+for part in key.split("."):
+    value = value[part]
+print(value)
+PY
+}
+
+download_checked() {
+    local url="$1"
+    local path="$2"
+    local expected_size="$3"
+    local expected_sha256="$4"
+
+    mkdir -p "$(dirname "$path")"
+    if [ ! -f "$path" ] ||
+       [ "$(wc -c <"$path" | tr -d ' ')" != "$expected_size" ]; then
+        local temporary="$path.tmp.$$"
+        curl -fL --retry 3 --connect-timeout 20 -o "$temporary" "$url"
+        mv "$temporary" "$path"
+    fi
+
+    local actual_sha256
+    actual_sha256="$(shasum -a 256 "$path" | awk '{print $1}')"
+    if [ "$actual_sha256" != "$expected_sha256" ]; then
+        echo "sha256 mismatch for $(basename "$path")" >&2
+        echo "expected: $expected_sha256" >&2
+        echo "actual:   $actual_sha256" >&2
+        exit 1
+    fi
+}
+
+repo="$(read_lock release.repo)"
+branch="$(read_lock release.branch)"
+commit="$(read_lock release.commit)"
+variant="$(read_lock name)"
+architecture="$(read_lock architecture)"
+asset_filename="$(read_lock asset.filename)"
+asset_path="$(read_lock asset.path)"
+asset_url="$(read_lock asset.url)"
+asset_size="$(read_lock asset.size)"
+asset_sha256="$(read_lock asset.sha256)"
+icd_filename="$(read_lock icd.filename)"
+icd_library_path="$(read_lock icd.library_path)"
+icd_api_version="$(read_lock icd.api_version)"
+license_filename="$(read_lock license.filename)"
+license_url="$(read_lock license.url)"
+license_size="$(read_lock license.size)"
+license_sha256="$(read_lock license.sha256)"
+packaging_reference="$(read_lock packaging_reference)"
+
+asset="$WORK_DIR/$asset_filename"
+license_source="$WORK_DIR/$license_filename"
+download_checked "$asset_url" "$asset" "$asset_size" "$asset_sha256"
+download_checked "$license_url" "$license_source" "$license_size" "$license_sha256"
+
+rm -rf "$RUNTIME_DIR"
+mkdir -p "$RUNTIME_DIR/lib" "$RUNTIME_DIR/share/vulkan/icd.d"
+cp -f "$asset" "$RUNTIME_DIR/lib/libmali.so.1"
+cp -f "$license_source" "$RUNTIME_DIR/LICENSE.txt"
+chmod 755 "$RUNTIME_DIR/lib/libmali.so.1"
+chmod 644 "$RUNTIME_DIR/LICENSE.txt"
+
+cat >"$RUNTIME_DIR/share/vulkan/icd.d/$icd_filename" <<EOF
+{
+  "file_format_version": "1.0.0",
+  "ICD": {
+    "library_path": "$icd_library_path",
+    "api_version": "$icd_api_version"
+  }
+}
+EOF
+chmod 644 "$RUNTIME_DIR/share/vulkan/icd.d/$icd_filename"
+
+installed_lib_sha256="$(shasum -a 256 "$RUNTIME_DIR/lib/libmali.so.1" | awk '{print $1}')"
+installed_icd_sha256="$(shasum -a 256 "$RUNTIME_DIR/share/vulkan/icd.d/$icd_filename" | awk '{print $1}')"
+installed_license_sha256="$(shasum -a 256 "$RUNTIME_DIR/LICENSE.txt" | awk '{print $1}')"
+
+cat >"$RUNTIME_DIR/manifest.json" <<EOF
+{
+  "schema": 1,
+  "id": "$RUNTIME_ID",
+  "kind": "platform-vulkan-runtime",
+  "platform": "mlp1",
+  "producer": "Leaf",
+  "packaging_reference": "$packaging_reference",
+  "source": "https://github.com/$repo",
+  "branch": "$branch",
+  "commit": "$commit",
+  "variant": "$variant",
+  "architecture": "$architecture",
+  "api_version": "$icd_api_version",
+  "asset": {
+    "filename": "$asset_filename",
+    "path": "$asset_path",
+    "url": "$asset_url",
+    "size": $asset_size,
+    "sha256": "$asset_sha256"
+  },
+  "files": [
+    {
+      "path": "lib/libmali.so.1",
+      "sha256": "$installed_lib_sha256"
+    },
+    {
+      "path": "share/vulkan/icd.d/$icd_filename",
+      "sha256": "$installed_icd_sha256"
+    },
+    {
+      "path": "LICENSE.txt",
+      "sha256": "$installed_license_sha256"
+    }
+  ]
+}
+EOF
+chmod 644 "$RUNTIME_DIR/manifest.json"
+
+echo "MLP1 Vulkan runtime ready: $RUNTIME_DIR"

--- a/scripts/make-sd-release-zip.sh
+++ b/scripts/make-sd-release-zip.sh
@@ -32,6 +32,8 @@ MLP1_RETROARCH_MANIFEST="${MLP1_RETROARCH_MANIFEST:-$RETROARCH_BUILDS_DIR/output
 MLP1_CORES_DIR="${MLP1_CORES_DIR:-$CORES_SPRUCE_DIR/output/mlp1/cores}"
 MLP1_CORES_REPORT="${MLP1_CORES_REPORT:-$CORES_SPRUCE_DIR/output/mlp1/build-report.json}"
 MLP1_PPSSPP_PACKAGE="${MLP1_PPSSPP_PACKAGE:-$PPSSPP_SPRUCE_DIR/output/mlp1/ppsspp}"
+MLP1_GRAPHICS_RUNTIME="${MLP1_GRAPHICS_RUNTIME:-$LEAF_ROOT/build/mlp1/runtime/graphics}"
+MLP1_VULKAN_RUNTIME="${MLP1_VULKAN_RUNTIME:-$MLP1_GRAPHICS_RUNTIME/vulkan/rk3566-g52-g29p1}"
 MLP1_DRASTIC_PACKAGE="${MLP1_DRASTIC_PACKAGE:-$LEAF_ROOT/build/drastic/mlp1/drastic}"
 MLP1_MUPEN64PLUS_PACKAGE="${MLP1_MUPEN64PLUS_PACKAGE:-$N64_STANDALONE_DIR/output/mlp1/mupen64plus}"
 MLP1_RETROARCH_PATCH_SET="${MLP1_RETROARCH_PATCH_SET:-portrait-rotation,command-menu,jawaka-load-content}"
@@ -328,7 +330,8 @@ for e in packaged:
         expected_sos.add(so)
         if not os.path.isfile(os.path.join(cores_dir, so)):
             missing_bin.append("%s (%s)" % (cid, so))
-    if not os.path.isfile(os.path.join(lic_dir, cid + ".txt")):
+    license_id = {"ppsspp_gles": "ppsspp"}.get(cid, cid)
+    if not os.path.isfile(os.path.join(lic_dir, license_id + ".txt")):
         missing_lic.append(cid)
 staged = sorted(f for f in os.listdir(cores_dir)
                 if f.endswith("_libretro.so")) if os.path.isdir(cores_dir) else []
@@ -393,6 +396,7 @@ expected_core = {
     "supports_savestate": False,
     "supports_disk_control": False,
     "needs_swap": False,
+    "requires_direct_drm": False,
     "platforms": ["mlp1"],
     "status": "packaged",
 }
@@ -559,6 +563,27 @@ package_emulator() {
     cp -R "$package_dir" "$RELEASE_ROOT/platforms/mlp1/emulators/$remote_name"
 }
 
+package_graphics_runtime() {
+    MLP1_GRAPHICS_RUNTIME_DIR="$MLP1_GRAPHICS_RUNTIME" \
+        "$LEAF_ROOT/scripts/build-mlp1-graphics-runtime.sh"
+
+    [ -d "$MLP1_VULKAN_RUNTIME" ] || \
+        die "missing shared Vulkan runtime: $MLP1_VULKAN_RUNTIME"
+
+    local graphics_root="$RELEASE_ROOT/platforms/mlp1/runtime/graphics"
+    rm -rf "$graphics_root/vulkan/rk3566-g52-g29p1"
+    mkdir -p "$graphics_root/vulkan"
+    cp -R "$MLP1_VULKAN_RUNTIME" \
+        "$graphics_root/vulkan/rk3566-g52-g29p1"
+    chmod 755 "$graphics_root/vulkan/rk3566-g52-g29p1/lib/libmali.so.1"
+}
+
+validate_ppsspp_vulkan_release() {
+    local platform_dir="$RELEASE_ROOT/platforms/mlp1"
+    python3 "$LEAF_ROOT/scripts/validate-ppsspp-vulkan-release.py" "$platform_dir" ||
+        die "PPSSPP Vulkan release validation failed"
+}
+
 validate_standalone_n64_release() {
     local platform_dir="$RELEASE_ROOT/platforms/mlp1"
 
@@ -713,10 +738,12 @@ build_install_zip() {
 
     cp -R "$PAYLOAD_ROOT/.system/leaf/platforms/mlp1" "$RELEASE_ROOT/platforms/mlp1"
 
+    package_graphics_runtime
     for emulator in $STAGE_EMULATORS; do
         package_emulator "$emulator"
     done
     validate_standalone_n64_release
+    validate_ppsspp_vulkan_release
 
     cp -R "$LEAF_ROOT/stage/licenses" "$RELEASE_ROOT/licenses"
     validate_packaged_cores "$RELEASE_ROOT"

--- a/scripts/ppsspp-benchmark-report.py
+++ b/scripts/ppsspp-benchmark-report.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Validate and aggregate repeated PPSSPP benchmark summaries."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+class ReportError(RuntimeError):
+    pass
+
+
+CONTRACT_FIELDS = {
+    "device_serial": ("device_serial",),
+    "rom_path": ("rom_path",),
+    "core": ("core",),
+    "core_id": ("core_id",),
+    "preset": ("preset",),
+    "warmup_seconds": ("warmup_seconds",),
+    "measurement_seconds": ("measurement_seconds",),
+    "sample_interval_seconds": ("sample_interval_seconds",),
+    "scene_sha256": ("scene_state", "sha256"),
+    "scene_game_id": ("scene_state", "game_id"),
+    "scene_game_version": ("scene_state", "game_version"),
+    "input_trace_sha256": ("input_trace", "sha256"),
+    "input_trace_game_id": ("input_trace", "game_id"),
+}
+
+METRICS = {
+    "emulation_speed_median_percent": (
+        "ppsspp",
+        "emulation_speed_percent",
+        "median",
+    ),
+    "emulation_speed_p05_percent": (
+        "ppsspp",
+        "emulation_speed_percent",
+        "p05",
+    ),
+    "emulation_speed_min_percent": (
+        "ppsspp",
+        "emulation_speed_percent",
+        "min",
+    ),
+    "vblank_median_per_second": (
+        "ppsspp",
+        "vblanks_per_second",
+        "median",
+    ),
+    "vblank_p05_per_second": (
+        "ppsspp",
+        "vblanks_per_second",
+        "p05",
+    ),
+    "rendered_fps_median": ("ppsspp", "rendered_fps", "median"),
+    "process_cpu_median_percent": ("device", "process_cpu_percent", "median"),
+    "gpu_load_median_percent": ("device", "gpu_load_percent", "median"),
+    "soc_peak_c": ("device", "temperatures", "temp_soc_thermal", "max_c"),
+    "gpu_peak_c": ("device", "temperatures", "temp_gpu_thermal", "max_c"),
+}
+
+
+def nested(document: dict[str, Any], path: tuple[str, ...]) -> Any:
+    value: Any = document
+    for key in path:
+        if not isinstance(value, dict) or key not in value:
+            raise ReportError(f"Missing summary field: {'.'.join(path)}")
+        value = value[key]
+    return value
+
+
+def finite_number(document: dict[str, Any], path: tuple[str, ...]) -> float:
+    value = nested(document, path)
+    if (
+        not isinstance(value, (int, float))
+        or isinstance(value, bool)
+        or not math.isfinite(float(value))
+    ):
+        raise ReportError(
+            f"Expected finite number at {'.'.join(path)}, observed {value!r}"
+        )
+    return float(value)
+
+
+def rounded(value: float, places: int = 6) -> float:
+    return round(value, places)
+
+
+def distribution(values: list[float]) -> dict[str, float]:
+    mean = statistics.mean(values)
+    deviation = statistics.stdev(values) if len(values) > 1 else 0.0
+    return {
+        "median": rounded(statistics.median(values)),
+        "mean": rounded(mean),
+        "min": rounded(min(values)),
+        "max": rounded(max(values)),
+        "range": rounded(max(values) - min(values)),
+        "sample_stddev": rounded(deviation),
+        "coefficient_of_variation_percent": rounded(
+            deviation / mean * 100.0 if mean else 0.0
+        ),
+    }
+
+
+def validate_summary(path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    try:
+        raw = path.read_bytes()
+        summary = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as error:
+        raise ReportError(f"Could not read {path}: {error}") from error
+    if not isinstance(summary, dict):
+        raise ReportError(f"Summary must be a JSON object: {path}")
+    if summary.get("schema_version") != 1:
+        raise ReportError(f"Unsupported summary schema in {path}")
+    if summary.get("status") != "completed" or summary.get("error") is not None:
+        raise ReportError(f"Benchmark did not complete successfully: {path}")
+
+    scene = summary.get("scene_state")
+    if not isinstance(scene, dict) or scene.get("action") != "load":
+        raise ReportError(f"Benchmark did not load a deterministic scene: {path}")
+    if not scene.get("completed"):
+        raise ReportError(f"Scene load did not complete: {path}")
+
+    trace = summary.get("input_trace")
+    if not isinstance(trace, dict):
+        raise ReportError(f"Benchmark has no input trace: {path}")
+    expanded = trace.get("expanded_event_count")
+    dispatched = trace.get("dispatched_event_count")
+    late = trace.get("skipped_late_event_count")
+    if (
+        not isinstance(expanded, int)
+        or expanded <= 0
+        or dispatched != expanded
+        or late != 0
+    ):
+        raise ReportError(
+            f"Incomplete input trace in {path}: "
+            f"expanded={expanded} dispatched={dispatched} late={late}"
+        )
+
+    backend = summary.get("backend_evidence", {})
+    for key in (
+        "argument_observed",
+        "backend_runtime_observed",
+        "stats_backend_observed",
+    ):
+        if backend.get(key) is not True:
+            raise ReportError(f"Backend evidence {key} did not pass: {path}")
+
+    lifecycle = summary.get("lifecycle", {})
+    for key in ("display_lifecycle_observed", "frontend_restored"):
+        if lifecycle.get(key) is not True:
+            raise ReportError(f"Lifecycle evidence {key} did not pass: {path}")
+
+    sample_count = summary.get("sample_count")
+    if not isinstance(sample_count, int) or sample_count <= 0:
+        raise ReportError(f"Invalid sample count in {path}: {sample_count!r}")
+
+    contract = {
+        name: nested(summary, field_path)
+        for name, field_path in CONTRACT_FIELDS.items()
+    }
+    metrics = {
+        name: finite_number(summary, field_path)
+        for name, field_path in METRICS.items()
+    }
+    transport = summary.get("transport_recovery", {})
+    adb_recoveries = transport.get("adb_recoveries", [])
+    debugger_reconnects = transport.get("debugger_reconnects", 0)
+    if not isinstance(adb_recoveries, list) or not isinstance(
+        debugger_reconnects, int
+    ):
+        raise ReportError(f"Invalid transport recovery evidence in {path}")
+
+    run = {
+        "name": path.parent.name,
+        "summary_path": str(path.resolve()),
+        "summary_sha256": hashlib.sha256(raw).hexdigest(),
+        "started_unix": summary.get("started_unix"),
+        "finished_unix": summary.get("finished_unix"),
+        "sample_count": sample_count,
+        "trace_events": {
+            "expanded": expanded,
+            "dispatched": dispatched,
+            "late": late,
+        },
+        "transport_recovery": {
+            "adb_recovery_count": len(adb_recoveries),
+            "debugger_reconnects": debugger_reconnects,
+        },
+        "metrics": {
+            name: rounded(value) for name, value in metrics.items()
+        },
+    }
+    return contract, run
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    contract = report["contract"]
+    lines = [
+        "# PPSSPP benchmark repeat report",
+        "",
+        f"- Core/preset: `{contract['core']}` / `{contract['preset']}`",
+        f"- Game: `{contract['scene_game_id']}` version "
+        f"`{contract['scene_game_version']}`",
+        f"- Scene SHA-256: `{contract['scene_sha256']}`",
+        f"- Trace SHA-256: `{contract['input_trace_sha256']}`",
+        f"- Warm-up/measurement: {contract['warmup_seconds']:.0f}s / "
+        f"{contract['measurement_seconds']:.0f}s",
+        f"- Runs/samples: {report['run_count']} / {report['total_sample_count']}",
+        "",
+        "| Run | Median speed | p05 speed | Median vblank/s | Median FPS | "
+        "Median CPU | Median GPU | Peak SoC |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for run in report["runs"]:
+        metric = run["metrics"]
+        lines.append(
+            f"| {run['name']} "
+            f"| {metric['emulation_speed_median_percent']:.3f}% "
+            f"| {metric['emulation_speed_p05_percent']:.3f}% "
+            f"| {metric['vblank_median_per_second']:.3f} "
+            f"| {metric['rendered_fps_median']:.3f} "
+            f"| {metric['process_cpu_median_percent']:.3f}% "
+            f"| {metric['gpu_load_median_percent']:.3f}% "
+            f"| {metric['soc_peak_c']:.3f} °C |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Run-level aggregate",
+            "",
+            "| Run-median metric | Median | Mean | Min | Max | Range | "
+            "Sample stddev | CV |",
+            "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for name in (
+        "emulation_speed_median_percent",
+        "vblank_median_per_second",
+        "rendered_fps_median",
+        "process_cpu_median_percent",
+        "gpu_load_median_percent",
+    ):
+        item = report["aggregate"][name]
+        lines.append(
+            f"| `{name}` "
+            f"| {item['median']:.3f} "
+            f"| {item['mean']:.3f} "
+            f"| {item['min']:.3f} "
+            f"| {item['max']:.3f} "
+            f"| {item['range']:.3f} "
+            f"| {item['sample_stddev']:.3f} "
+            f"| {item['coefficient_of_variation_percent']:.3f}% |"
+        )
+    lines.extend(
+        [
+            "",
+            f"Transport recovery: {report['transport_recovery']['adb_recovery_count']} "
+            "ADB recoveries, "
+            f"{report['transport_recovery']['debugger_reconnects']} debugger "
+            "reconnects.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate repeated PPSSPP benchmark summaries and report run-level "
+            "variance."
+        )
+    )
+    parser.add_argument("summaries", nargs="+", help="Benchmark summary.json files")
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="New aggregate JSON path; a Markdown report is written beside it",
+    )
+    parser.add_argument(
+        "--minimum-runs",
+        type=int,
+        default=3,
+        help="Minimum compatible completed runs required (default: 3)",
+    )
+    args = parser.parse_args()
+    if args.minimum_runs < 1:
+        parser.error("minimum runs must be >= 1")
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    output = Path(args.output).resolve()
+    markdown = output.with_suffix(".md")
+    if output.suffix.lower() != ".json":
+        print("ppsspp-benchmark-report: output must end in .json", file=sys.stderr)
+        return 1
+    if output.exists() or markdown.exists():
+        print(
+            f"ppsspp-benchmark-report: output already exists: {output} or {markdown}",
+            file=sys.stderr,
+        )
+        return 1
+    if len(args.summaries) < args.minimum_runs:
+        print(
+            "ppsspp-benchmark-report: "
+            f"need at least {args.minimum_runs} summaries",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        loaded = [
+            validate_summary(Path(summary).resolve())
+            for summary in args.summaries
+        ]
+        contract = loaded[0][0]
+        for index, (candidate, _) in enumerate(loaded[1:], start=2):
+            if candidate != contract:
+                raise ReportError(
+                    f"Summary {index} benchmark contract does not match run 1"
+                )
+        runs = [run for _, run in loaded]
+        summary_hashes = [run["summary_sha256"] for run in runs]
+        if len(set(summary_hashes)) != len(summary_hashes):
+            raise ReportError("Duplicate benchmark summaries are not repeats")
+        aggregate = {
+            name: distribution(
+                [float(run["metrics"][name]) for run in runs]
+            )
+            for name in METRICS
+        }
+        canonical_contract = json.dumps(
+            contract, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")
+        report = {
+            "schema_version": 1,
+            "generated_unix": time.time(),
+            "contract": contract,
+            "contract_sha256": hashlib.sha256(canonical_contract).hexdigest(),
+            "run_count": len(runs),
+            "total_sample_count": sum(run["sample_count"] for run in runs),
+            "trace_events": {
+                "expanded": sum(
+                    run["trace_events"]["expanded"] for run in runs
+                ),
+                "dispatched": sum(
+                    run["trace_events"]["dispatched"] for run in runs
+                ),
+                "late": sum(run["trace_events"]["late"] for run in runs),
+            },
+            "transport_recovery": {
+                "adb_recovery_count": sum(
+                    run["transport_recovery"]["adb_recovery_count"]
+                    for run in runs
+                ),
+                "debugger_reconnects": sum(
+                    run["transport_recovery"]["debugger_reconnects"]
+                    for run in runs
+                ),
+            },
+            "runs": runs,
+            "aggregate": aggregate,
+        }
+    except ReportError as error:
+        print(f"ppsspp-benchmark-report: {error}", file=sys.stderr)
+        return 1
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    markdown.write_text(markdown_report(report), encoding="utf-8")
+    print(f"JSON report: {output}")
+    print(f"Markdown report: {markdown}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ppsspp-benchmark.py
+++ b/scripts/ppsspp-benchmark.py
@@ -695,6 +695,7 @@ class BenchmarkSession:
         self.backend_evidence: dict[str, Any] = {}
         self.game_status: dict[str, Any] = {}
         self.debugger_reconnects = 0
+        self.daemon_recovery: dict[str, Any] | None = None
         self.trace_started_at: float | None = None
         self.input_trace = (
             InputTrace(Path(args.input_trace), args.warmup + args.duration)
@@ -934,6 +935,9 @@ sync
             "umrk-launcher.log": (
                 f"{self.sdcard}/.userdata/mlp1/logs/umrk-launcher.log"
             ),
+            "umrk-leaf-session.log": (
+                f"{self.sdcard}/.userdata/mlp1/logs/umrk-leaf-session.log"
+            ),
         }
         self.log_offsets = {
             remote: self.remote_file_size(remote) for remote in paths.values()
@@ -946,6 +950,9 @@ sync
             "ppsspp.log": f"{self.sdcard}/.userdata/mlp1/logs/ppsspp.log",
             "umrk-launcher.log": (
                 f"{self.sdcard}/.userdata/mlp1/logs/umrk-launcher.log"
+            ),
+            "umrk-leaf-session.log": (
+                f"{self.sdcard}/.userdata/mlp1/logs/umrk-leaf-session.log"
             ),
         }
         for local_name, remote in paths.items():
@@ -1361,6 +1368,92 @@ done
             )
             self.wait_process_gone(5.0)
 
+    def trigger_daemon_exit(self) -> None:
+        signal = self.args.daemon_exit_signal
+        if not signal:
+            return
+        daemon_pids = self.adb.process_ids("loong_pangu")
+        if len(daemon_pids) != 1:
+            raise BenchmarkError(
+                f"Expected one loong_pangu daemon before lifecycle action, found {daemon_pids}"
+            )
+        old_pid = daemon_pids[0]
+        started = time.monotonic()
+        self.daemon_recovery = {
+            "signal": f"SIG{signal}",
+            "old_pid": old_pid,
+            "new_pid": None,
+            "completed": False,
+            "elapsed_seconds": None,
+            "ppsspp_gone": False,
+            "socket_ready": False,
+            "frontend_ready": False,
+        }
+        self.log(f"Terminating loong_pangu with SIG{signal}: [{old_pid}]")
+        shell_signal = "-KILL" if signal == "KILL" else "-TERM"
+        self.adb.shell(f"kill {shell_signal} {old_pid}")
+
+        required = [
+            name
+            for name in ("jawaka-launcher", "jawaka-osd", "weston")
+            if self.frontend_before.get(name)
+        ]
+        deadline = started + self.args.daemon_recovery_timeout
+        while time.monotonic() < deadline:
+            current_daemons = self.adb.process_ids("loong_pangu")
+            new_pids = [pid for pid in current_daemons if pid != old_pid]
+            ppsspp_gone = not self.adb.process_ids("PPSSPPSDL")
+            socket_ready = (
+                self.adb.shell(
+                    f"[ -S {quote(REMOTE_SOCKET)} ] && echo yes",
+                    check=False,
+                )
+                == "yes"
+            )
+            snapshot = self.adb.process_snapshot()
+            frontend_ready = all(snapshot[name] for name in required)
+            if new_pids and ppsspp_gone and socket_ready and frontend_ready:
+                elapsed = time.monotonic() - started
+                self.daemon_recovery.update(
+                    {
+                        "new_pid": new_pids[0],
+                        "completed": True,
+                        "elapsed_seconds": elapsed,
+                        "ppsspp_gone": True,
+                        "socket_ready": True,
+                        "frontend_ready": True,
+                    }
+                )
+                self.log(
+                    "Daemon recovery passed "
+                    f"old={old_pid} new={new_pids[0]} elapsed={elapsed:.2f}s"
+                )
+                return
+            time.sleep(0.5)
+
+        current_daemons = self.adb.process_ids("loong_pangu")
+        new_pids = [pid for pid in current_daemons if pid != old_pid]
+        snapshot = self.adb.process_snapshot()
+        self.daemon_recovery.update(
+            {
+                "new_pid": new_pids[0] if new_pids else None,
+                "elapsed_seconds": time.monotonic() - started,
+                "ppsspp_gone": not snapshot["PPSSPPSDL"],
+                "socket_ready": (
+                    self.adb.shell(
+                        f"[ -S {quote(REMOTE_SOCKET)} ] && echo yes",
+                        check=False,
+                    )
+                    == "yes"
+                ),
+                "frontend_ready": all(snapshot[name] for name in required),
+            }
+        )
+        raise BenchmarkError(
+            "Daemon recovery timed out: "
+            + json.dumps(self.daemon_recovery, sort_keys=True)
+        )
+
     def wait_frontend(self, timeout: float = 30.0) -> bool:
         required = [
             name
@@ -1507,7 +1600,17 @@ done
             "measurement_seconds": self.args.duration,
             "sample_interval_seconds": self.args.interval,
             "sample_count": len(self.samples),
-            "exit_signal": f"SIG{self.args.exit_signal}",
+            "exit_signal": (
+                f"SIG{self.args.daemon_exit_signal}"
+                if self.args.daemon_exit_signal
+                else f"SIG{self.args.exit_signal}"
+            ),
+            "exit_target": (
+                "loong_pangu"
+                if self.args.daemon_exit_signal
+                else "PPSSPPSDL"
+            ),
+            "daemon_recovery": self.daemon_recovery,
             "transport_recovery": {
                 "adb_recoveries": self.adb.recoveries,
                 "debugger_reconnects": self.debugger_reconnects,
@@ -1645,6 +1748,10 @@ done
             self.connect_debugger()
             self.warm_up()
             self.sample()
+            if self.args.daemon_exit_signal:
+                self.release_input_trace()
+                self.close_debugger()
+                self.trigger_daemon_exit()
         except (BenchmarkError, OSError, ValueError, json.JSONDecodeError) as error:
             self.error = str(error)
             self.log(f"ERROR: {self.error}")
@@ -1683,6 +1790,12 @@ done
             self.error = "PPSSPP GPU stats did not confirm the requested backend"
         if not self.error and not summary["lifecycle"]["display_lifecycle_observed"]:
             self.error = "expected display-server lifecycle was not observed"
+        if (
+            not self.error
+            and self.args.daemon_exit_signal
+            and not (self.daemon_recovery or {}).get("completed")
+        ):
+            self.error = "daemon recovery did not complete"
         if self.error and summary["error"] != self.error:
             self.log(f"ERROR: {self.error}")
             summary = self.make_summary(frontend_restored)
@@ -1750,7 +1863,24 @@ def parse_args() -> argparse.Namespace:
         "--exit-signal",
         choices=("TERM", "KILL"),
         default="TERM",
-        help="Signal used after measurement; KILL exercises crash recovery",
+        help=(
+            "Signal used to stop PPSSPP after measurement when "
+            "--daemon-exit-signal is not set (default: TERM)"
+        ),
+    )
+    parser.add_argument(
+        "--daemon-exit-signal",
+        choices=("TERM", "KILL"),
+        help=(
+            "Stop loong_pangu after measurement and require the session "
+            "supervisor to remove PPSSPP and restore the frontend"
+        ),
+    )
+    parser.add_argument(
+        "--daemon-recovery-timeout",
+        type=float,
+        default=30.0,
+        help="Seconds allowed for supervised daemon recovery (default: 30)",
     )
     parser.add_argument(
         "--replace-running",
@@ -1779,6 +1909,8 @@ def parse_args() -> argparse.Namespace:
         parser.error("max debugger reconnects must be >= 0")
     if args.adb_retry_timeout < 0:
         parser.error("ADB retry timeout must be >= 0")
+    if args.daemon_recovery_timeout <= 0:
+        parser.error("daemon recovery timeout must be > 0")
     return args
 
 

--- a/scripts/ppsspp-benchmark.py
+++ b/scripts/ppsspp-benchmark.py
@@ -36,6 +36,52 @@ DEFAULT_PRESET_ROOT = PPSSPP_ROOT / "output/mlp1/ppsspp/defaults"
 DEFAULT_OUTPUT_ROOT = LEAF_ROOT / "build/benchmarks/ppsspp"
 REMOTE_SOCKET = "/tmp/jawaka-runtime/jawakad.sock"
 CORE_IDS = {"vulkan": "ppsspp", "gles": "ppsspp_gles"}
+TRANSIENT_ADB_ERRORS = (
+    "device not found",
+    "device offline",
+    "no devices/emulators found",
+    "closed",
+    "connection reset",
+    "protocol fault",
+    "transport error",
+    "transport is closing",
+)
+TRACE_EVENTS = {
+    "input.buttons.press",
+    "input.buttons.send",
+    "input.analog.send",
+}
+TRACE_BUTTONS = {
+    "back",
+    "circle",
+    "cross",
+    "disc",
+    "down",
+    "forward",
+    "hold",
+    "home",
+    "l2",
+    "l3",
+    "left",
+    "ltrigger",
+    "memstick",
+    "note",
+    "playpause",
+    "r2",
+    "r3",
+    "remote_hold",
+    "right",
+    "rtrigger",
+    "screen",
+    "select",
+    "square",
+    "start",
+    "triangle",
+    "up",
+    "vol_down",
+    "vol_up",
+    "wlan",
+}
 
 
 class BenchmarkError(RuntimeError):
@@ -71,7 +117,7 @@ def run(
 
 
 class Adb:
-    def __init__(self, serial: str | None) -> None:
+    def __init__(self, serial: str | None, retry_timeout: float = 15.0) -> None:
         if serial:
             self.serial = serial
         else:
@@ -85,7 +131,27 @@ class Adb:
             if not self.serial:
                 raise BenchmarkError("No online adb device found")
         self.prefix = ["adb", "-s", self.serial]
-        run(self.prefix + ["get-state"])
+        self.retry_timeout = retry_timeout
+        self.recoveries: list[dict[str, Any]] = []
+        self.command(["get-state"])
+
+    @staticmethod
+    def _detail(result: subprocess.CompletedProcess[Any], text: bool) -> str:
+        if text:
+            stderr = result.stderr.strip()
+            stdout = result.stdout.strip()
+        else:
+            stderr = result.stderr.decode(errors="replace").strip()
+            stdout = result.stdout.decode(errors="replace").strip()
+        return stderr or stdout or f"exit {result.returncode}"
+
+    @staticmethod
+    def _transient(detail: str) -> bool:
+        lowered = detail.lower()
+        return (
+            any(pattern in lowered for pattern in TRANSIENT_ADB_ERRORS)
+            or bool(re.search(r"(?:adb|error): device .+ not found", lowered))
+        )
 
     def command(
         self,
@@ -95,12 +161,36 @@ class Adb:
         text: bool = True,
         timeout: float | None = None,
     ) -> subprocess.CompletedProcess[Any]:
-        return run(
-            self.prefix + arguments,
-            check=check,
-            text=text,
-            timeout=timeout,
-        )
+        command = self.prefix + arguments
+        deadline = time.monotonic() + self.retry_timeout
+        attempts = 0
+        first_error = ""
+        while True:
+            result = run(command, check=False, text=text, timeout=timeout)
+            if result.returncode == 0:
+                if attempts:
+                    self.recoveries.append(
+                        {
+                            "host_time": time.time(),
+                            "command": shlex.join(command),
+                            "attempts": attempts + 1,
+                            "first_error": first_error,
+                        }
+                    )
+                return result
+            detail = self._detail(result, text)
+            if (
+                not self._transient(detail)
+                or time.monotonic() >= deadline
+                or self.retry_timeout <= 0
+            ):
+                if check:
+                    raise BenchmarkError(f"{shlex.join(command)}: {detail}")
+                return result
+            if not first_error:
+                first_error = detail
+            attempts += 1
+            time.sleep(0.5)
 
     def shell(
         self,
@@ -222,6 +312,199 @@ def numeric(value: str) -> int | float | str:
             return float(value)
         except ValueError:
             return value
+
+
+class InputTrace:
+    """Validated, time-based PPSSPP debugger input sequence."""
+
+    def __init__(self, path: Path, horizon: float) -> None:
+        self.path = path.resolve()
+        try:
+            raw = self.path.read_bytes()
+        except OSError as error:
+            raise BenchmarkError(
+                f"Could not read PPSSPP input trace {self.path}: {error}"
+            ) from error
+        try:
+            document = json.loads(raw)
+        except json.JSONDecodeError as error:
+            raise BenchmarkError(f"Invalid PPSSPP input trace JSON: {error}") from error
+        if not isinstance(document, dict) or document.get("schema") != 1:
+            raise BenchmarkError("PPSSPP input trace must be a schema 1 object")
+        name = document.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise BenchmarkError("PPSSPP input trace requires a non-empty name")
+        game_id = document.get("game_id")
+        if game_id is not None and (
+            not isinstance(game_id, str) or not game_id.strip()
+        ):
+            raise BenchmarkError("PPSSPP input trace game_id must be a string")
+        source_events = document.get("events")
+        if not isinstance(source_events, list) or not source_events:
+            raise BenchmarkError("PPSSPP input trace requires at least one event")
+
+        self.name = name
+        self.game_id = game_id
+        self.description = str(document.get("description", ""))
+        self.sha256 = hashlib.sha256(raw).hexdigest()
+        self.events: list[tuple[float, str, dict[str, Any]]] = []
+        self.used_buttons: set[str] = set()
+        self.next_index = 0
+        self.dispatched = 0
+        self.skipped_late = 0
+
+        for index, item in enumerate(source_events):
+            self._append_source_event(item, index, horizon)
+        self.events.sort(key=lambda event: event[0])
+
+    def _append_source_event(
+        self,
+        item: Any,
+        index: int,
+        horizon: float,
+    ) -> None:
+        label = f"input trace event {index}"
+        if not isinstance(item, dict):
+            raise BenchmarkError(f"{label} must be an object")
+        at = item.get("at")
+        event = item.get("event")
+        if (
+            not isinstance(at, (int, float))
+            or isinstance(at, bool)
+            or not math.isfinite(float(at))
+            or at < 0
+        ):
+            raise BenchmarkError(f"{label} requires a finite, non-negative at value")
+        if event not in TRACE_EVENTS:
+            raise BenchmarkError(f"{label} uses unsupported event: {event!r}")
+        repeat_every = item.get("repeat_every")
+        if repeat_every is not None and (
+            not isinstance(repeat_every, (int, float))
+            or isinstance(repeat_every, bool)
+            or not math.isfinite(float(repeat_every))
+            or repeat_every <= 0
+        ):
+            raise BenchmarkError(f"{label} repeat_every must be positive")
+        repeat_until = item.get("repeat_until", horizon)
+        if (
+            not isinstance(repeat_until, (int, float))
+            or isinstance(repeat_until, bool)
+            or not math.isfinite(float(repeat_until))
+        ):
+            raise BenchmarkError(f"{label} repeat_until must be finite")
+
+        parameters = {
+            key: value
+            for key, value in item.items()
+            if key not in {"at", "event", "repeat_every", "repeat_until"}
+        }
+        self._validate_parameters(str(event), parameters, label)
+
+        current = float(at)
+        limit = min(float(repeat_until), horizon)
+        while current <= limit + 1e-9:
+            self.events.append((current, str(event), parameters.copy()))
+            if repeat_every is None:
+                break
+            current += float(repeat_every)
+
+    def _validate_parameters(
+        self,
+        event: str,
+        parameters: dict[str, Any],
+        label: str,
+    ) -> None:
+        if event == "input.buttons.press":
+            button = parameters.get("button")
+            duration = parameters.get("duration", 1)
+            if button not in TRACE_BUTTONS:
+                raise BenchmarkError(f"{label} has unsupported button: {button!r}")
+            if not isinstance(duration, int) or isinstance(duration, bool) or duration < 0:
+                raise BenchmarkError(f"{label} duration must be a non-negative integer")
+            if set(parameters) - {"button", "duration"}:
+                raise BenchmarkError(f"{label} has unsupported button-press parameters")
+            self.used_buttons.add(str(button))
+            return
+        if event == "input.buttons.send":
+            buttons = parameters.get("buttons")
+            if not isinstance(buttons, dict) or not buttons:
+                raise BenchmarkError(f"{label} buttons must be a non-empty object")
+            if set(parameters) != {"buttons"}:
+                raise BenchmarkError(f"{label} has unsupported button-state parameters")
+            for button, state in buttons.items():
+                if button not in TRACE_BUTTONS:
+                    raise BenchmarkError(f"{label} has unsupported button: {button!r}")
+                if state is not None and not isinstance(state, bool):
+                    raise BenchmarkError(f"{label} button states must be boolean or null")
+                self.used_buttons.add(button)
+            return
+
+        stick = parameters.get("stick", "left")
+        x = parameters.get("x")
+        y = parameters.get("y")
+        if set(parameters) - {"stick", "x", "y"}:
+            raise BenchmarkError(f"{label} has unsupported analog parameters")
+        if stick not in {"left", "right"}:
+            raise BenchmarkError(f"{label} stick must be left or right")
+        for axis, value in (("x", x), ("y", y)):
+            if (
+                not isinstance(value, (int, float))
+                or isinstance(value, bool)
+                or not math.isfinite(float(value))
+                or not -1.0 <= float(value) <= 1.0
+            ):
+                raise BenchmarkError(f"{label} {axis} must be between -1.0 and 1.0")
+
+    def dispatch_due(
+        self,
+        websocket: "WebSocketClient",
+        elapsed: float,
+        *,
+        late_tolerance: float = 1.0,
+    ) -> None:
+        while (
+            self.next_index < len(self.events)
+            and self.events[self.next_index][0] <= elapsed
+        ):
+            scheduled, event, parameters = self.events[self.next_index]
+            self.next_index += 1
+            if elapsed - scheduled > late_tolerance:
+                self.skipped_late += 1
+                continue
+            websocket.notify(event, parameters)
+            self.dispatched += 1
+
+    def next_at(self) -> float | None:
+        if self.next_index >= len(self.events):
+            return None
+        return self.events[self.next_index][0]
+
+    def release(self, websocket: "WebSocketClient") -> None:
+        websocket.notify(
+            "input.analog.send",
+            {"stick": "left", "x": 0.0, "y": 0.0},
+        )
+        websocket.notify(
+            "input.analog.send",
+            {"stick": "right", "x": 0.0, "y": 0.0},
+        )
+        if self.used_buttons:
+            websocket.notify(
+                "input.buttons.send",
+                {"buttons": {button: False for button in sorted(self.used_buttons)}},
+            )
+
+    def metadata(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "game_id": self.game_id,
+            "description": self.description,
+            "source_path": str(self.path),
+            "sha256": self.sha256,
+            "expanded_event_count": len(self.events),
+            "dispatched_event_count": self.dispatched,
+            "skipped_late_event_count": self.skipped_late,
+        }
 
 
 class WebSocketClient:
@@ -359,6 +642,19 @@ class WebSocketClient:
     def request_gpu_stats(self, ticket: str) -> dict[str, Any]:
         return self.request("gpu.stats.get", ticket)
 
+    def notify(
+        self,
+        event: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> None:
+        message = {"event": event}
+        if parameters:
+            message.update(parameters)
+        self._send_frame(
+            0x1,
+            json.dumps(message, separators=(",", ":")).encode("utf-8"),
+        )
+
     def close(self) -> None:
         try:
             self._send_frame(0x8, struct.pack("!H", 1000))
@@ -370,7 +666,10 @@ class WebSocketClient:
 class BenchmarkSession:
     def __init__(self, args: argparse.Namespace) -> None:
         self.args = args
-        self.adb = Adb(args.serial or os.environ.get("ADB_SERIAL"))
+        self.adb = Adb(
+            args.serial or os.environ.get("ADB_SERIAL"),
+            retry_timeout=args.adb_retry_timeout,
+        )
         timestamp = time.strftime("%Y%m%d-%H%M%S")
         output = Path(args.output) if args.output else (
             DEFAULT_OUTPUT_ROOT / f"{timestamp}-{args.core}-{args.preset}"
@@ -394,6 +693,18 @@ class BenchmarkSession:
         self.error: str | None = None
         self.effective_config = ""
         self.backend_evidence: dict[str, Any] = {}
+        self.game_status: dict[str, Any] = {}
+        self.debugger_reconnects = 0
+        self.trace_started_at: float | None = None
+        self.input_trace = (
+            InputTrace(Path(args.input_trace), args.warmup + args.duration)
+            if args.input_trace
+            else None
+        )
+        if self.input_trace:
+            (self.output / "input-trace.json").write_bytes(
+                self.input_trace.path.read_bytes()
+            )
         self.started_at = time.time()
 
     def resolve_sdcard(self) -> str:
@@ -512,6 +823,9 @@ fi
                     "preset_path": str(preset_path),
                     "effective_config_sha256": config_sha,
                     "backend_command_line": self.args.core,
+                    "input_trace": (
+                        self.input_trace.metadata() if self.input_trace else None
+                    ),
                     "debugger": {
                         "port": self.args.debug_port,
                         "on_startup": True,
@@ -771,7 +1085,13 @@ done
             encoding="utf-8",
         )
 
-    def connect_debugger(self) -> None:
+    def connect_debugger(self, *, reconnecting: bool = False) -> None:
+        if self.websocket:
+            try:
+                self.websocket.close()
+            except OSError:
+                pass
+            self.websocket = None
         self.adb.command(
             ["forward", "--remove", f"tcp:{self.args.debug_port}"],
             check=False,
@@ -806,8 +1126,25 @@ done
                     candidate.close()
                     time.sleep(0.5)
                     continue
+                expected_game_id = (
+                    self.input_trace.game_id if self.input_trace else None
+                )
+                actual_game_id = game_status.get("game", {}).get("id")
+                if expected_game_id and actual_game_id != expected_game_id:
+                    candidate.close()
+                    raise ValueError(
+                        "PPSSPP input trace expects game "
+                        f"{expected_game_id}, observed {actual_game_id or 'unknown'}"
+                    )
+                self.game_status = game_status
                 self.websocket = candidate
-                self.log("Connected to PPSSPP GPU statistics debugger")
+                if self.trace_started_at is None:
+                    self.trace_started_at = time.monotonic()
+                self.log(
+                    "Reconnected to PPSSPP GPU statistics debugger"
+                    if reconnecting
+                    else "Connected to PPSSPP GPU statistics debugger"
+                )
                 return
             except (OSError, BenchmarkError) as error:
                 last_error = error
@@ -815,6 +1152,80 @@ done
                     candidate.close()
                 time.sleep(0.5)
         raise BenchmarkError(f"Timed out connecting to PPSSPP debugger: {last_error}")
+
+    @staticmethod
+    def _debugger_transport_error(error: Exception) -> bool:
+        if isinstance(error, (OSError, json.JSONDecodeError)):
+            return True
+        detail = str(error).lower()
+        return any(
+            marker in detail
+            for marker in (
+                "websocket closed",
+                "websocket accept",
+                "closed during websocket",
+                "timed out",
+            )
+        )
+
+    def request_gpu_stats(self, ticket: str) -> dict[str, Any]:
+        if not self.websocket:
+            raise BenchmarkError("PPSSPP debugger is not connected")
+        while True:
+            try:
+                return self.websocket.request_gpu_stats(ticket)
+            except (BenchmarkError, OSError, json.JSONDecodeError) as error:
+                if (
+                    not self._debugger_transport_error(error)
+                    or self.debugger_reconnects >= self.args.max_debugger_reconnects
+                ):
+                    raise
+                self.debugger_reconnects += 1
+                self.log(
+                    "Debugger transport interrupted; reconnecting "
+                    f"({self.debugger_reconnects}/"
+                    f"{self.args.max_debugger_reconnects}): {error}"
+                )
+                self.connect_debugger(reconnecting=True)
+
+    def trace_elapsed(self) -> float:
+        if self.trace_started_at is None:
+            return 0.0
+        return time.monotonic() - self.trace_started_at
+
+    def dispatch_input_trace(self) -> None:
+        if not self.input_trace or not self.websocket:
+            return
+        try:
+            self.input_trace.dispatch_due(self.websocket, self.trace_elapsed())
+        except OSError as error:
+            if self.debugger_reconnects >= self.args.max_debugger_reconnects:
+                raise
+            self.debugger_reconnects += 1
+            self.log(
+                "Input-trace debugger transport interrupted; reconnecting "
+                f"({self.debugger_reconnects}/"
+                f"{self.args.max_debugger_reconnects}): {error}"
+            )
+            self.connect_debugger(reconnecting=True)
+            self.input_trace.dispatch_due(self.websocket, self.trace_elapsed())
+
+    def wait_with_trace(self, deadline: float) -> None:
+        while time.monotonic() < deadline:
+            self.dispatch_input_trace()
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            sleep_for = min(0.1 if self.input_trace else 0.5, remaining)
+            if self.input_trace:
+                next_at = self.input_trace.next_at()
+                if next_at is not None:
+                    sleep_for = min(
+                        sleep_for,
+                        max(0.0, next_at - self.trace_elapsed()),
+                    )
+            if sleep_for > 0:
+                time.sleep(sleep_for)
 
     def telemetry(self) -> dict[str, Any]:
         if not self.pid:
@@ -874,7 +1285,7 @@ done
         while time.monotonic() < deadline:
             if not self.process_alive():
                 raise BenchmarkError("PPSSPP exited during warm-up")
-            time.sleep(min(0.5, max(0.0, deadline - time.monotonic())))
+            self.wait_with_trace(min(deadline, time.monotonic() + 0.5))
 
     def sample(self) -> None:
         if not self.websocket:
@@ -892,11 +1303,12 @@ done
                     raise BenchmarkError("PPSSPP exited during measurement")
                 now = time.monotonic()
                 if now < next_sample:
-                    time.sleep(next_sample - now)
+                    self.wait_with_trace(next_sample)
                 if index > 0 and time.monotonic() >= deadline:
                     break
+                self.dispatch_input_trace()
                 requested_at = time.monotonic()
-                stats = self.websocket.request_gpu_stats(f"sample-{index}")
+                stats = self.request_gpu_stats(f"sample-{index}")
                 telemetry = self.telemetry()
                 current_ticks = int(telemetry.get("proc_ticks", 0))
                 if previous_ticks is not None and previous_time is not None:
@@ -967,6 +1379,14 @@ done
             time.sleep(0.5)
         self.frontend_after = self.adb.process_snapshot()
         return False
+
+    def release_input_trace(self) -> None:
+        if not self.input_trace or not self.websocket:
+            return
+        try:
+            self.input_trace.release(self.websocket)
+        except OSError as error:
+            self.log(f"Could not release input-trace state: {error}")
 
     def close_debugger(self) -> None:
         if self.websocket:
@@ -1078,12 +1498,20 @@ done
             "rom_path": self.args.rom,
             "core": self.args.core,
             "core_id": CORE_IDS[self.args.core],
+            "game_status": self.game_status,
             "preset": self.args.preset,
+            "input_trace": (
+                self.input_trace.metadata() if self.input_trace else None
+            ),
             "warmup_seconds": self.args.warmup,
             "measurement_seconds": self.args.duration,
             "sample_interval_seconds": self.args.interval,
             "sample_count": len(self.samples),
             "exit_signal": f"SIG{self.args.exit_signal}",
+            "transport_recovery": {
+                "adb_recoveries": self.adb.recoveries,
+                "debugger_reconnects": self.debugger_reconnects,
+            },
             "started_unix": self.started_at,
             "finished_unix": time.time(),
             "ppsspp": {
@@ -1224,6 +1652,7 @@ done
             self.error = "interrupted"
             self.log("Interrupted; restoring PPSSPP and frontend state")
         finally:
+            self.release_input_trace()
             self.close_debugger()
             self.terminate_ppsspp()
             if self.frontend_before:
@@ -1295,9 +1724,28 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--warmup", type=float, default=15.0)
     parser.add_argument("--duration", type=float, default=60.0)
     parser.add_argument("--interval", type=float, default=1.0)
+    parser.add_argument(
+        "--input-trace",
+        help=(
+            "Schema 1 JSON input trace driven through PPSSPP's debugger from "
+            "debugger connection through warm-up and measurement"
+        ),
+    )
     parser.add_argument("--startup-timeout", type=float, default=30.0)
     parser.add_argument("--debugger-timeout", type=float, default=30.0)
     parser.add_argument("--debug-port", type=int, default=28000)
+    parser.add_argument(
+        "--max-debugger-reconnects",
+        type=int,
+        default=3,
+        help="Debugger transport recoveries allowed during one run (default: 3)",
+    )
+    parser.add_argument(
+        "--adb-retry-timeout",
+        type=float,
+        default=15.0,
+        help="Seconds to retry a transient ADB transport failure (default: 15)",
+    )
     parser.add_argument(
         "--exit-signal",
         choices=("TERM", "KILL"),
@@ -1327,6 +1775,10 @@ def parse_args() -> argparse.Namespace:
         parser.error("warmup must be >= 0; duration and interval must be > 0")
     if not 1 <= args.debug_port <= 65535:
         parser.error("debug port must be in 1..65535")
+    if args.max_debugger_reconnects < 0:
+        parser.error("max debugger reconnects must be >= 0")
+    if args.adb_retry_timeout < 0:
+        parser.error("ADB retry timeout must be >= 0")
     return args
 
 

--- a/scripts/ppsspp-benchmark.py
+++ b/scripts/ppsspp-benchmark.py
@@ -1,0 +1,1342 @@
+#!/usr/bin/env python3
+"""Run a controlled PPSSPP Vulkan/GLES benchmark on an attached MLP1.
+
+The harness launches PPSSPP through Jawaka so direct-DRM lifecycle and
+performance-profile behavior are part of the measurement.  It temporarily
+installs a known PPSSPP preset with the local debugger enabled, then restores
+the exact pre-run configuration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import re
+import secrets
+import shlex
+import socket
+import statistics
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any
+
+
+LEAF_ROOT = Path(__file__).resolve().parent.parent
+WORKSPACE_ROOT = LEAF_ROOT.parent
+PPSSPP_ROOT = WORKSPACE_ROOT / "PPSSPP-spruce"
+DEFAULT_PRESET_ROOT = PPSSPP_ROOT / "output/mlp1/ppsspp/defaults"
+DEFAULT_OUTPUT_ROOT = LEAF_ROOT / "build/benchmarks/ppsspp"
+REMOTE_SOCKET = "/tmp/jawaka-runtime/jawakad.sock"
+CORE_IDS = {"vulkan": "ppsspp", "gles": "ppsspp_gles"}
+
+
+class BenchmarkError(RuntimeError):
+    pass
+
+
+def quote(value: str | Path) -> str:
+    return shlex.quote(str(value))
+
+
+def run(
+    command: list[str],
+    *,
+    check: bool = True,
+    text: bool = True,
+    env: dict[str, str] | None = None,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[Any]:
+    result = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=text,
+        env=env,
+        timeout=timeout,
+    )
+    if check and result.returncode != 0:
+        stderr = result.stderr.strip() if text else result.stderr.decode(errors="replace").strip()
+        stdout = result.stdout.strip() if text else result.stdout.decode(errors="replace").strip()
+        detail = stderr or stdout or f"exit {result.returncode}"
+        raise BenchmarkError(f"{shlex.join(command)}: {detail}")
+    return result
+
+
+class Adb:
+    def __init__(self, serial: str | None) -> None:
+        if serial:
+            self.serial = serial
+        else:
+            result = run(["adb", "devices"])
+            self.serial = ""
+            for line in result.stdout.splitlines()[1:]:
+                fields = line.split()
+                if len(fields) >= 2 and fields[1] == "device":
+                    self.serial = fields[0]
+                    break
+            if not self.serial:
+                raise BenchmarkError("No online adb device found")
+        self.prefix = ["adb", "-s", self.serial]
+        run(self.prefix + ["get-state"])
+
+    def command(
+        self,
+        arguments: list[str],
+        *,
+        check: bool = True,
+        text: bool = True,
+        timeout: float | None = None,
+    ) -> subprocess.CompletedProcess[Any]:
+        return run(
+            self.prefix + arguments,
+            check=check,
+            text=text,
+            timeout=timeout,
+        )
+
+    def shell(
+        self,
+        script: str,
+        *,
+        check: bool = True,
+        timeout: float | None = None,
+    ) -> str:
+        result = self.command(["shell", script], check=check, timeout=timeout)
+        return result.stdout.replace("\r\n", "\n").rstrip("\r\n")
+
+    def exec_out(self, arguments: list[str], *, check: bool = True) -> bytes:
+        return self.command(["exec-out"] + arguments, check=check, text=False).stdout
+
+    def push(self, local_path: Path, remote_path: str) -> None:
+        self.command(["push", str(local_path), remote_path])
+
+    def process_ids(self, name: str) -> list[int]:
+        output = self.shell(f"pidof {quote(name)} 2>/dev/null || true")
+        return [int(value) for value in output.split() if value.isdigit()]
+
+    def process_snapshot(self) -> dict[str, list[int]]:
+        return {
+            name: self.process_ids(name)
+            for name in (
+                "loong_pangu",
+                "jawaka-launcher",
+                "jawaka-osd",
+                "weston",
+                "PPSSPPSDL",
+            )
+        }
+
+
+class Logger:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def __call__(self, message: str) -> None:
+        line = f"[{time.strftime('%H:%M:%S')}] {message}"
+        print(line, flush=True)
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+
+
+def replace_ini_values(text: str, section: str, values: dict[str, str]) -> str:
+    """Replace or add keys in one INI section without rewriting other sections."""
+    lines = text.splitlines()
+    section_pattern = re.compile(r"^\s*\[\s*" + re.escape(section) + r"\s*\]\s*$", re.I)
+    any_section_pattern = re.compile(r"^\s*\[[^]]+\]\s*$")
+    start = next((i for i, line in enumerate(lines) if section_pattern.match(line)), None)
+
+    if start is None:
+        if lines and lines[-1].strip():
+            lines.append("")
+        lines.append(f"[{section}]")
+        lines.extend(f"{key} = {value}" for key, value in values.items())
+        return "\n".join(lines) + "\n"
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if any_section_pattern.match(lines[index]):
+            end = index
+            break
+
+    remaining = {key.lower(): (key, value) for key, value in values.items()}
+    output = lines[: start + 1]
+    key_pattern = re.compile(r"^\s*([^#;][^=]*?)\s*=")
+    for line in lines[start + 1 : end]:
+        match = key_pattern.match(line)
+        lowered = match.group(1).strip().lower() if match else ""
+        if lowered in remaining:
+            key, value = remaining.pop(lowered)
+            output.append(f"{key} = {value}")
+        else:
+            output.append(line)
+    output.extend(f"{key} = {value}" for key, value in remaining.values())
+    output.extend(lines[end:])
+    return "\n".join(output) + "\n"
+
+
+def ini_value(text: str, section: str, key: str) -> str | None:
+    current = ""
+    for line in text.splitlines():
+        section_match = re.match(r"^\s*\[\s*([^]]+?)\s*\]\s*$", line)
+        if section_match:
+            current = section_match.group(1)
+            continue
+        if current.lower() != section.lower():
+            continue
+        key_match = re.match(r"^\s*([^#;][^=]*?)\s*=\s*(.*?)\s*$", line)
+        if key_match and key_match.group(1).strip().lower() == key.lower():
+            return key_match.group(2)
+    return None
+
+
+def percentile(values: list[float], percent: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * percent / 100.0
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * (position - lower)
+
+
+def rounded(value: float | None, places: int = 3) -> float | None:
+    return round(value, places) if value is not None else None
+
+
+def numeric(value: str) -> int | float | str:
+    try:
+        return int(value)
+    except ValueError:
+        try:
+            return float(value)
+        except ValueError:
+            return value
+
+
+class WebSocketClient:
+    """Small RFC 6455 client sufficient for PPSSPP's JSON debugger."""
+
+    def __init__(self, host: str, port: int, timeout: float = 5.0) -> None:
+        self.socket = socket.create_connection((host, port), timeout=timeout)
+        self.socket.settimeout(timeout)
+        self.buffer = bytearray()
+        key = base64.b64encode(secrets.token_bytes(16)).decode("ascii")
+        request = (
+            "GET /debugger HTTP/1.1\r\n"
+            f"Host: {host}:{port}\r\n"
+            "Upgrade: websocket\r\n"
+            "Connection: Upgrade\r\n"
+            f"Sec-WebSocket-Key: {key}\r\n"
+            "Sec-WebSocket-Version: 13\r\n"
+            "Sec-WebSocket-Protocol: debugger.ppsspp.org\r\n"
+            "\r\n"
+        )
+        self.socket.sendall(request.encode("ascii"))
+        response = self._read_until(b"\r\n\r\n").decode("iso-8859-1")
+        if not response.startswith("HTTP/1.1 101") and not response.startswith("HTTP/1.0 101"):
+            raise BenchmarkError(f"PPSSPP debugger WebSocket rejected upgrade: {response.splitlines()[0]}")
+        accept = base64.b64encode(
+            hashlib.sha1(
+                (key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").encode("ascii")
+            ).digest()
+        ).decode("ascii")
+        headers = {}
+        for line in response.split("\r\n")[1:]:
+            if ":" in line:
+                name, value = line.split(":", 1)
+                headers[name.lower()] = value.strip()
+        if headers.get("sec-websocket-accept") != accept:
+            raise BenchmarkError("PPSSPP debugger returned an invalid WebSocket accept key")
+
+    def _receive(self, count: int) -> bytes:
+        while len(self.buffer) < count:
+            chunk = self.socket.recv(65536)
+            if not chunk:
+                raise BenchmarkError("PPSSPP debugger WebSocket closed unexpectedly")
+            self.buffer.extend(chunk)
+        data = bytes(self.buffer[:count])
+        del self.buffer[:count]
+        return data
+
+    def _read_until(self, marker: bytes) -> bytes:
+        while marker not in self.buffer:
+            chunk = self.socket.recv(65536)
+            if not chunk:
+                raise BenchmarkError("PPSSPP debugger closed during WebSocket handshake")
+            self.buffer.extend(chunk)
+        end = self.buffer.index(marker) + len(marker)
+        data = bytes(self.buffer[:end])
+        del self.buffer[:end]
+        return data
+
+    def _send_frame(self, opcode: int, payload: bytes) -> None:
+        mask = secrets.token_bytes(4)
+        length = len(payload)
+        header = bytearray([0x80 | opcode])
+        if length < 126:
+            header.append(0x80 | length)
+        elif length < 65536:
+            header.append(0x80 | 126)
+            header.extend(struct.pack("!H", length))
+        else:
+            header.append(0x80 | 127)
+            header.extend(struct.pack("!Q", length))
+        header.extend(mask)
+        masked = bytes(value ^ mask[index % 4] for index, value in enumerate(payload))
+        self.socket.sendall(header + masked)
+
+    def _read_frame(self) -> tuple[bool, int, bytes]:
+        first, second = self._receive(2)
+        final = bool(first & 0x80)
+        opcode = first & 0x0F
+        length = second & 0x7F
+        if length == 126:
+            length = struct.unpack("!H", self._receive(2))[0]
+        elif length == 127:
+            length = struct.unpack("!Q", self._receive(8))[0]
+        mask = self._receive(4) if second & 0x80 else b""
+        payload = self._receive(length)
+        if mask:
+            payload = bytes(value ^ mask[index % 4] for index, value in enumerate(payload))
+        return final, opcode, payload
+
+    def receive_text(self) -> str:
+        fragments = bytearray()
+        text_started = False
+        while True:
+            final, opcode, payload = self._read_frame()
+            if opcode == 0x8:
+                raise BenchmarkError("PPSSPP debugger WebSocket closed")
+            if opcode == 0x9:
+                self._send_frame(0xA, payload)
+                continue
+            if opcode == 0xA:
+                continue
+            if opcode == 0x1:
+                fragments = bytearray(payload)
+                text_started = True
+            elif opcode == 0x0 and text_started:
+                fragments.extend(payload)
+            else:
+                continue
+            if final:
+                return fragments.decode("utf-8")
+
+    def request(
+        self,
+        event: str,
+        ticket: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        request_object = {"event": event, "ticket": ticket}
+        if parameters:
+            request_object.update(parameters)
+        self._send_frame(
+            0x1,
+            json.dumps(request_object, separators=(",", ":")).encode("utf-8"),
+        )
+        while True:
+            response = json.loads(self.receive_text())
+            if response.get("ticket") == ticket:
+                if response.get("event") == "error":
+                    raise BenchmarkError(
+                        f"PPSSPP debugger error: {response.get('message', response)}"
+                    )
+                if response.get("event") == event:
+                    return response
+
+    def request_gpu_stats(self, ticket: str) -> dict[str, Any]:
+        return self.request("gpu.stats.get", ticket)
+
+    def close(self) -> None:
+        try:
+            self._send_frame(0x8, struct.pack("!H", 1000))
+        except OSError:
+            pass
+        self.socket.close()
+
+
+class BenchmarkSession:
+    def __init__(self, args: argparse.Namespace) -> None:
+        self.args = args
+        self.adb = Adb(args.serial or os.environ.get("ADB_SERIAL"))
+        timestamp = time.strftime("%Y%m%d-%H%M%S")
+        output = Path(args.output) if args.output else (
+            DEFAULT_OUTPUT_ROOT / f"{timestamp}-{args.core}-{args.preset}"
+        )
+        self.output = output.resolve()
+        self.output.mkdir(parents=True, exist_ok=False)
+        self.log = Logger(self.output / "session.log")
+        self.sdcard = ""
+        self.remote_config = ""
+        self.remote_backup = ""
+        self.remote_state = ""
+        self.config_prepared = False
+        self.forward_active = False
+        self.websocket: WebSocketClient | None = None
+        self.pid: int | None = None
+        self.samples: list[dict[str, Any]] = []
+        self.frontend_before: dict[str, list[int]] = {}
+        self.frontend_during: dict[str, list[int]] = {}
+        self.frontend_after: dict[str, list[int]] = {}
+        self.log_offsets: dict[str, int] = {}
+        self.error: str | None = None
+        self.effective_config = ""
+        self.backend_evidence: dict[str, Any] = {}
+        self.started_at = time.time()
+
+    def resolve_sdcard(self) -> str:
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "PLATFORM_ID": "mlp1",
+                "REMOTE_SDCARD_PATH": self.args.remote_sd,
+                "ADB_SERIAL": self.adb.serial,
+            }
+        )
+        result = run(
+            [str(LEAF_ROOT / "scripts/adb-resolve-umrk-sd.sh")],
+            env=environment,
+        )
+        return result.stdout.strip()
+
+    def ensure_preflight(self) -> None:
+        self.sdcard = self.resolve_sdcard()
+        self.log(f"Using adb device {self.adb.serial}; active SD is {self.sdcard}")
+        if "'" in self.sdcard or "\n" in self.sdcard:
+            raise BenchmarkError(f"Unsupported resolved SD path: {self.sdcard!r}")
+        if not self.adb.shell(f"[ -f {quote(self.args.rom)} ] && echo yes") == "yes":
+            raise BenchmarkError(f"ROM not found on device: {self.args.rom}")
+        controller = (
+            f"{self.sdcard}/.system/leaf/platforms/mlp1/launcher/bin/"
+            "jawaka-platformctl"
+        )
+        checks = (
+            f"[ -x {quote(controller)} ] && "
+            f"[ -S {quote(REMOTE_SOCKET)} ] && echo yes"
+        )
+        if self.adb.shell(checks) != "yes":
+            raise BenchmarkError("Jawaka controller or daemon socket is unavailable")
+        running = self.adb.process_ids("PPSSPPSDL")
+        if running and not self.args.replace_running:
+            raise BenchmarkError(
+                f"PPSSPP is already running (pid {running}); pass --replace-running to terminate it"
+            )
+        if running:
+            self.log(f"Terminating pre-existing PPSSPP process(es): {running}")
+            self.adb.shell("killall PPSSPPSDL 2>/dev/null || true")
+            self.wait_process_gone(10.0)
+            if self.adb.process_ids("PPSSPPSDL"):
+                self.adb.shell("killall -KILL PPSSPPSDL 2>/dev/null || true")
+                self.wait_process_gone(5.0)
+        self.frontend_before = self.adb.process_snapshot()
+        if not self.frontend_before["jawaka-launcher"]:
+            raise BenchmarkError("Jawaka launcher is not active before benchmark")
+
+    def recover_stale_config(self) -> None:
+        command = f"""
+set -eu
+state={quote(self.remote_state)}
+config={quote(self.remote_config)}
+backup={quote(self.remote_backup)}
+if [ -f "$state" ]; then
+    previous="$(cat "$state" 2>/dev/null || true)"
+    case "$previous" in
+        existed=1)
+            [ -f "$backup" ] || {{
+                echo "stale PPSSPP benchmark backup is missing" >&2
+                exit 1
+            }}
+            cp -p "$backup" "$config"
+            ;;
+        existed=0)
+            rm -f "$config"
+            ;;
+        *)
+            echo "invalid stale PPSSPP benchmark state" >&2
+            exit 1
+            ;;
+    esac
+    rm -f "$state" "$backup"
+    sync
+    echo recovered
+fi
+"""
+        result = self.adb.shell(command)
+        if result:
+            self.log("Recovered PPSSPP configuration left by an interrupted benchmark")
+
+    def prepare_config(self) -> None:
+        config_dir = (
+            f"{self.sdcard}/.userdata/mlp1/ppsspp/config/ppsspp/PSP/SYSTEM"
+        )
+        self.remote_config = f"{config_dir}/ppsspp.ini"
+        self.remote_backup = f"{self.remote_config}.umrk-benchmark-backup"
+        self.remote_state = f"{self.remote_config}.umrk-benchmark-state"
+        self.adb.shell(f"mkdir -p {quote(config_dir)}")
+        self.recover_stale_config()
+
+        preset_path = Path(self.args.preset_root) / f"ppsspp-{self.args.preset}.ini"
+        if not preset_path.is_file():
+            raise BenchmarkError(f"PPSSPP preset not found: {preset_path}")
+        preset = preset_path.read_text(encoding="utf-8")
+        self.effective_config = replace_ini_values(
+            preset,
+            "General",
+            {
+                "RemoteISOPort": str(self.args.debug_port),
+                "RemoteDebuggerOnStartup": "True",
+                "RemoteDebuggerLocal": "True",
+            },
+        )
+        (self.output / "effective.ini").write_text(
+            self.effective_config,
+            encoding="utf-8",
+        )
+        config_sha = hashlib.sha256(self.effective_config.encode("utf-8")).hexdigest()
+        (self.output / "benchmark-overrides.json").write_text(
+            json.dumps(
+                {
+                    "preset": self.args.preset,
+                    "preset_path": str(preset_path),
+                    "effective_config_sha256": config_sha,
+                    "backend_command_line": self.args.core,
+                    "debugger": {
+                        "port": self.args.debug_port,
+                        "on_startup": True,
+                        "local": True,
+                    },
+                    "graphics": {
+                        key: ini_value(self.effective_config, "Graphics", key)
+                        for key in (
+                            "GraphicsBackend",
+                            "InternalResolution",
+                            "FrameSkip",
+                            "AutoFrameSkip",
+                            "InflightFrames",
+                            "RenderDuplicateFrames",
+                        )
+                    },
+                    "cpu": {
+                        key: ini_value(self.effective_config, "CPU", key)
+                        for key in (
+                            "CPUCore",
+                            "FastMemoryAccess",
+                            "CPUSpeed",
+                        )
+                    },
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        self.adb.shell(
+            f"""
+set -eu
+config={quote(self.remote_config)}
+backup={quote(self.remote_backup)}
+state={quote(self.remote_state)}
+if [ -e "$config" ]; then
+    cp -p "$config" "$backup"
+    printf 'existed=1\\n' >"$state"
+else
+    rm -f "$backup"
+    printf 'existed=0\\n' >"$state"
+fi
+"""
+        )
+        self.config_prepared = True
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+            handle.write(self.effective_config)
+            temporary = Path(handle.name)
+        try:
+            remote_temporary = f"{self.remote_config}.tmp"
+            self.adb.push(temporary, remote_temporary)
+            self.adb.shell(
+                f"mv {quote(remote_temporary)} {quote(self.remote_config)} && sync"
+            )
+        finally:
+            temporary.unlink(missing_ok=True)
+        self.log(
+            f"Installed controlled {self.args.preset} preset; original config is recoverable"
+        )
+
+    def restore_config(self) -> None:
+        if not self.config_prepared:
+            return
+        self.adb.shell(
+            f"""
+set -eu
+config={quote(self.remote_config)}
+backup={quote(self.remote_backup)}
+state={quote(self.remote_state)}
+previous="$(cat "$state" 2>/dev/null || true)"
+case "$previous" in
+    existed=1)
+        [ -f "$backup" ] || {{
+            echo "PPSSPP benchmark backup is missing" >&2
+            exit 1
+        }}
+        cp -p "$backup" "$config"
+        ;;
+    existed=0)
+        rm -f "$config"
+        ;;
+    *)
+        echo "PPSSPP benchmark state is missing or invalid" >&2
+        exit 1
+        ;;
+esac
+rm -f "$state" "$backup"
+sync
+"""
+        )
+        self.config_prepared = False
+        self.log("Restored the pre-benchmark PPSSPP configuration")
+
+    def remote_file_size(self, path: str) -> int:
+        output = self.adb.shell(
+            f"if [ -f {quote(path)} ]; then wc -c <{quote(path)}; else echo 0; fi"
+        )
+        return int(output.strip() or "0")
+
+    def mark_log_offsets(self) -> None:
+        paths = {
+            "ppsspp.log": f"{self.sdcard}/.userdata/mlp1/logs/ppsspp.log",
+            "umrk-launcher.log": (
+                f"{self.sdcard}/.userdata/mlp1/logs/umrk-launcher.log"
+            ),
+        }
+        self.log_offsets = {
+            remote: self.remote_file_size(remote) for remote in paths.values()
+        }
+
+    def capture_log_slices(self) -> None:
+        if not self.log_offsets:
+            return
+        paths = {
+            "ppsspp.log": f"{self.sdcard}/.userdata/mlp1/logs/ppsspp.log",
+            "umrk-launcher.log": (
+                f"{self.sdcard}/.userdata/mlp1/logs/umrk-launcher.log"
+            ),
+        }
+        for local_name, remote in paths.items():
+            offset = self.log_offsets.get(remote, 0)
+            content = self.adb.shell(
+                f"if [ -f {quote(remote)} ]; then "
+                f"tail -c +{offset + 1} {quote(remote)} 2>/dev/null || true; fi",
+                check=False,
+            )
+            (self.output / local_name).write_text(content + ("\n" if content else ""), encoding="utf-8")
+
+    def capture_device_identity(self) -> None:
+        script = r"""
+echo "serial=$(cat /sys/class/android_usb/android0/iSerial 2>/dev/null || true)"
+echo "uname=$(uname -a)"
+echo "buildroot=$(cat /etc/os-release 2>/dev/null | tr '\n' ' ')"
+echo "meminfo:"
+sed -n '1,24p' /proc/meminfo
+echo "swap:"
+cat /proc/swaps
+echo "display:"
+for connector in /sys/class/drm/card*-*; do
+    [ -f "$connector/status" ] || continue
+    printf '%s status=%s modes=' "$(basename "$connector")" "$(cat "$connector/status")"
+    tr '\n' ',' <"$connector/modes" 2>/dev/null || true
+    echo
+done
+echo "cpu:"
+for policy in /sys/devices/system/cpu/cpufreq/policy*; do
+    [ -d "$policy" ] || continue
+    printf '%s governor=%s min=%s max=%s available=%s\n' \
+        "$(basename "$policy")" \
+        "$(cat "$policy/scaling_governor" 2>/dev/null)" \
+        "$(cat "$policy/cpuinfo_min_freq" 2>/dev/null)" \
+        "$(cat "$policy/cpuinfo_max_freq" 2>/dev/null)" \
+        "$(cat "$policy/scaling_available_frequencies" 2>/dev/null)"
+done
+echo "devfreq:"
+for node in /sys/class/devfreq/*; do
+    [ -d "$node" ] || continue
+    printf '%s governor=%s min=%s max=%s available=%s\n' \
+        "$(basename "$node")" \
+        "$(cat "$node/governor" 2>/dev/null)" \
+        "$(cat "$node/min_freq" 2>/dev/null)" \
+        "$(cat "$node/max_freq" 2>/dev/null)" \
+        "$(cat "$node/available_frequencies" 2>/dev/null)"
+done
+echo "thermal:"
+for zone in /sys/class/thermal/thermal_zone*; do
+    [ -d "$zone" ] || continue
+    printf '%s type=%s temp=%s\n' \
+        "$(basename "$zone")" \
+        "$(cat "$zone/type" 2>/dev/null)" \
+        "$(cat "$zone/temp" 2>/dev/null)"
+done
+"""
+        (self.output / "device.txt").write_text(
+            self.adb.shell(script) + "\n",
+            encoding="utf-8",
+        )
+
+    def launch(self) -> None:
+        controller = (
+            f"{self.sdcard}/.system/leaf/platforms/mlp1/launcher/bin/"
+            "jawaka-platformctl"
+        )
+        request = json.dumps(
+            {
+                "type": "launch-game",
+                "system": "PSP",
+                "rom_path": self.args.rom,
+                "core_id": CORE_IDS[self.args.core],
+            },
+            separators=(",", ":"),
+        )
+        response = self.adb.shell(
+            f"{quote(controller)} --socket {quote(REMOTE_SOCKET)} "
+            f"request {quote(request)}"
+        )
+        try:
+            response_object = json.loads(response)
+        except json.JSONDecodeError as error:
+            raise BenchmarkError(f"Jawaka returned invalid launch response: {response}") from error
+        if response_object.get("type") != "ok":
+            raise BenchmarkError(
+                f"Jawaka rejected {self.args.core} launch: "
+                f"{response_object.get('message', response)}"
+            )
+        self.log(f"Jawaka accepted {self.args.core} launch: {response}")
+        launcher_pids = self.adb.process_ids("jawaka-launcher")
+        if launcher_pids:
+            self.adb.shell(
+                "kill -KILL " + " ".join(str(pid) for pid in launcher_pids)
+            )
+            self.log(
+                "Closed the launcher process so jawakad can enter the requested game"
+            )
+
+        deadline = time.monotonic() + self.args.startup_timeout
+        while time.monotonic() < deadline:
+            pids = self.adb.process_ids("PPSSPPSDL")
+            if pids:
+                self.pid = pids[0]
+                self.log(f"PPSSPP started as pid {self.pid}")
+                return
+            time.sleep(0.5)
+        raise BenchmarkError("Timed out waiting for PPSSPP to start")
+
+    def wait_process_gone(self, timeout: float) -> bool:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if not self.adb.process_ids("PPSSPPSDL"):
+                return True
+            time.sleep(0.25)
+        return not self.adb.process_ids("PPSSPPSDL")
+
+    def process_alive(self) -> bool:
+        return bool(self.pid and self.pid in self.adb.process_ids("PPSSPPSDL"))
+
+    def capture_backend_evidence(self) -> None:
+        if not self.pid:
+            return
+        command_line = self.adb.shell(
+            f"tr '\\000' ' ' </proc/{self.pid}/cmdline 2>/dev/null || true"
+        )
+        mappings = self.adb.shell(
+            f"grep -E 'lib(vulkan|mali|GLES|EGL|SDL)' "
+            f"/proc/{self.pid}/maps 2>/dev/null | "
+            "awk '{print $NF}' | sort -u || true"
+        ).splitlines()
+        self.backend_evidence = {
+            "command_line": command_line,
+            "graphics_mappings": mappings,
+        }
+        (self.output / "backend.json").write_text(
+            json.dumps(self.backend_evidence, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    def connect_debugger(self) -> None:
+        self.adb.command(
+            ["forward", "--remove", f"tcp:{self.args.debug_port}"],
+            check=False,
+        )
+        self.adb.command(
+            [
+                "forward",
+                f"tcp:{self.args.debug_port}",
+                f"tcp:{self.args.debug_port}",
+            ]
+        )
+        self.forward_active = True
+        deadline = time.monotonic() + self.args.debugger_timeout
+        last_error: Exception | None = None
+        while time.monotonic() < deadline:
+            if not self.process_alive():
+                raise BenchmarkError("PPSSPP exited before debugger connected")
+            candidate: WebSocketClient | None = None
+            try:
+                candidate = WebSocketClient(
+                    "127.0.0.1",
+                    self.args.debug_port,
+                    timeout=min(5.0, self.args.debugger_timeout),
+                )
+                candidate.request(
+                    "version",
+                    "harness-version",
+                    {"name": "UMRK PPSSPP benchmark", "version": "1"},
+                )
+                game_status = candidate.request("game.status", "harness-game-status")
+                if not game_status.get("game"):
+                    candidate.close()
+                    time.sleep(0.5)
+                    continue
+                self.websocket = candidate
+                self.log("Connected to PPSSPP GPU statistics debugger")
+                return
+            except (OSError, BenchmarkError) as error:
+                last_error = error
+                if candidate:
+                    candidate.close()
+                time.sleep(0.5)
+        raise BenchmarkError(f"Timed out connecting to PPSSPP debugger: {last_error}")
+
+    def telemetry(self) -> dict[str, Any]:
+        if not self.pid:
+            raise BenchmarkError("Cannot sample telemetry without a PPSSPP pid")
+        script = f"""
+pid={self.pid}
+[ -d "/proc/$pid" ] || exit 44
+cpu_cur=0
+for node in /sys/devices/system/cpu/cpufreq/policy*/scaling_cur_freq; do
+    [ -f "$node" ] || continue
+    value="$(cat "$node" 2>/dev/null || echo 0)"
+    [ "$value" -gt "$cpu_cur" ] 2>/dev/null && cpu_cur="$value"
+done
+echo "cpu_cur_khz=$cpu_cur"
+echo "gpu_cur_hz=$(cat /sys/class/devfreq/fde60000.gpu/cur_freq 2>/dev/null || echo 0)"
+echo "gpu_load=$(cat /sys/class/devfreq/fde60000.gpu/load 2>/dev/null || echo unknown)"
+echo "gpu_governor=$(cat /sys/class/devfreq/fde60000.gpu/governor 2>/dev/null || echo unknown)"
+echo "dmc_cur_hz=$(cat /sys/class/devfreq/dmc/cur_freq 2>/dev/null || echo 0)"
+echo "dmc_load=$(cat /sys/class/devfreq/dmc/load 2>/dev/null || echo unknown)"
+echo "dmc_governor=$(cat /sys/class/devfreq/dmc/governor 2>/dev/null || echo unknown)"
+echo "proc_ticks=$(awk '{{print $14 + $15}}' /proc/$pid/stat)"
+sed -n \
+    -e 's/^VmRSS:[[:space:]]*/proc_rss_kb=/p' \
+    -e 's/^VmSize:[[:space:]]*/proc_vmsize_kb=/p' \
+    -e 's/^VmSwap:[[:space:]]*/proc_swap_kb=/p' \
+    /proc/$pid/status | sed 's/[[:space:]]*kB$//'
+sed -n \
+    -e 's/^MemAvailable:[[:space:]]*/mem_available_kb=/p' \
+    -e 's/^SwapFree:[[:space:]]*/swap_free_kb=/p' \
+    /proc/meminfo | sed 's/[[:space:]]*kB$//'
+for zone in /sys/class/thermal/thermal_zone*; do
+    [ -d "$zone" ] || continue
+    name="$(tr -d '\n' <"$zone/type" 2>/dev/null | tr -c 'A-Za-z0-9_' '_')"
+    echo "temp_${{name}}_millic=$(cat "$zone/temp" 2>/dev/null || echo 0)"
+done
+"""
+        output = self.adb.shell(script)
+        result: dict[str, Any] = {}
+        for line in output.splitlines():
+            if "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            result[key] = numeric(value)
+        load_match = re.match(r"(\d+)@(\d+)", str(result.get("gpu_load", "")))
+        if load_match:
+            result["gpu_load_percent"] = int(load_match.group(1))
+            result["gpu_load_reported_hz"] = int(load_match.group(2))
+        dmc_match = re.match(r"(\d+)@(\d+)", str(result.get("dmc_load", "")))
+        if dmc_match:
+            result["dmc_load_percent"] = int(dmc_match.group(1))
+            result["dmc_load_reported_hz"] = int(dmc_match.group(2))
+        return result
+
+    def warm_up(self) -> None:
+        self.log(f"Warming up for {self.args.warmup:.1f} seconds")
+        deadline = time.monotonic() + self.args.warmup
+        while time.monotonic() < deadline:
+            if not self.process_alive():
+                raise BenchmarkError("PPSSPP exited during warm-up")
+            time.sleep(min(0.5, max(0.0, deadline - time.monotonic())))
+
+    def sample(self) -> None:
+        if not self.websocket:
+            raise BenchmarkError("PPSSPP debugger is not connected")
+        sample_file = self.output / "samples.jsonl"
+        measurement_started = time.monotonic()
+        deadline = measurement_started + self.args.duration
+        next_sample = measurement_started
+        previous_ticks: int | None = None
+        previous_time: float | None = None
+        index = 0
+        with sample_file.open("w", encoding="utf-8") as handle:
+            while time.monotonic() < deadline:
+                if not self.process_alive():
+                    raise BenchmarkError("PPSSPP exited during measurement")
+                now = time.monotonic()
+                if now < next_sample:
+                    time.sleep(next_sample - now)
+                if index > 0 and time.monotonic() >= deadline:
+                    break
+                requested_at = time.monotonic()
+                stats = self.websocket.request_gpu_stats(f"sample-{index}")
+                telemetry = self.telemetry()
+                current_ticks = int(telemetry.get("proc_ticks", 0))
+                if previous_ticks is not None and previous_time is not None:
+                    elapsed = requested_at - previous_time
+                    if elapsed > 0:
+                        telemetry["proc_cpu_percent"] = (
+                            (current_ticks - previous_ticks)
+                            / self.args.clock_ticks
+                            / elapsed
+                            * 100.0
+                        )
+                previous_ticks = current_ticks
+                previous_time = requested_at
+                record = {
+                    "index": index,
+                    "elapsed_seconds": requested_at - measurement_started,
+                    "host_time": time.time(),
+                    "gpu_stats": stats,
+                    "telemetry": telemetry,
+                }
+                self.samples.append(record)
+                handle.write(json.dumps(record, separators=(",", ":")) + "\n")
+                handle.flush()
+                fps = stats.get("fps", {}).get("actual")
+                vps = stats.get("vblanksPerSecond", {}).get("actual")
+                self.log(
+                    f"sample {index + 1}: rendered={fps} fps, emulation={vps} vblank/s, "
+                    f"GPU={telemetry.get('gpu_load', '?')}"
+                )
+                index += 1
+                next_sample += self.args.interval
+                if next_sample < time.monotonic() - self.args.interval:
+                    next_sample = time.monotonic()
+        if not self.samples:
+            raise BenchmarkError("Measurement window produced no samples")
+
+    def terminate_ppsspp(self) -> None:
+        pids = self.adb.process_ids("PPSSPPSDL")
+        if not pids:
+            return
+        signal = "-KILL" if self.args.exit_signal == "KILL" else "-TERM"
+        self.log(f"Terminating PPSSPP with SIG{self.args.exit_signal}: {pids}")
+        self.adb.shell(f"kill {signal} " + " ".join(str(pid) for pid in pids), check=False)
+        if not self.wait_process_gone(10.0):
+            remaining = self.adb.process_ids("PPSSPPSDL")
+            self.log(f"PPSSPP did not exit promptly; forcing SIGKILL: {remaining}")
+            self.adb.shell(
+                "kill -KILL " + " ".join(str(pid) for pid in remaining),
+                check=False,
+            )
+            self.wait_process_gone(5.0)
+
+    def wait_frontend(self, timeout: float = 30.0) -> bool:
+        required = [
+            name
+            for name in ("jawaka-launcher", "jawaka-osd", "weston")
+            if self.frontend_before.get(name)
+        ]
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            snapshot = self.adb.process_snapshot()
+            socket_ready = (
+                self.adb.shell(f"[ -S {quote(REMOTE_SOCKET)} ] && echo yes") == "yes"
+            )
+            if socket_ready and all(snapshot[name] for name in required):
+                self.frontend_after = snapshot
+                return True
+            time.sleep(0.5)
+        self.frontend_after = self.adb.process_snapshot()
+        return False
+
+    def close_debugger(self) -> None:
+        if self.websocket:
+            self.websocket.close()
+            self.websocket = None
+        if self.forward_active:
+            self.adb.command(
+                ["forward", "--remove", f"tcp:{self.args.debug_port}"],
+                check=False,
+            )
+            self.forward_active = False
+
+    def make_summary(self, frontend_restored: bool) -> dict[str, Any]:
+        fps_values = [
+            float(item["gpu_stats"]["fps"]["actual"])
+            for item in self.samples
+            if item.get("gpu_stats", {}).get("fps", {}).get("actual") is not None
+        ]
+        vps_values = [
+            float(item["gpu_stats"]["vblanksPerSecond"]["actual"])
+            for item in self.samples
+            if item.get("gpu_stats", {})
+            .get("vblanksPerSecond", {})
+            .get("actual")
+            is not None
+        ]
+        target_values = [
+            float(item["gpu_stats"]["vblanksPerSecond"]["target"])
+            for item in self.samples
+            if item.get("gpu_stats", {})
+            .get("vblanksPerSecond", {})
+            .get("target")
+        ]
+        target_vps = statistics.median(target_values) if target_values else 60.0 / 1.001
+        speed_values = [value / target_vps * 100.0 for value in vps_values]
+        final_frames = []
+        if self.samples:
+            final_frames = self.samples[-1]["gpu_stats"].get("timing", {}).get("frames", [])
+        frame_ms = [
+            float(value) * 1000.0
+            for value in final_frames
+            if isinstance(value, (int, float)) and 0.0 < float(value) < 2.0
+        ]
+        telemetry = [item.get("telemetry", {}) for item in self.samples]
+
+        def values_for(key: str) -> list[float]:
+            return [
+                float(item[key])
+                for item in telemetry
+                if isinstance(item.get(key), (int, float))
+            ]
+
+        temperatures: dict[str, dict[str, float | None]] = {}
+        temperature_keys = sorted(
+            {
+                key
+                for item in telemetry
+                for key in item
+                if key.startswith("temp_") and key.endswith("_millic")
+            }
+        )
+        for key in temperature_keys:
+            values = [value / 1000.0 for value in values_for(key)]
+            temperatures[key.removesuffix("_millic")] = {
+                "median_c": rounded(statistics.median(values) if values else None),
+                "max_c": rounded(max(values) if values else None),
+            }
+
+        expected_backend_argument = f"--graphics={self.args.core}"
+        command_line = str(self.backend_evidence.get("command_line", ""))
+        mappings = self.backend_evidence.get("graphics_mappings", [])
+        gpu_info = [
+            str(item.get("gpu_stats", {}).get("info", "")) for item in self.samples
+        ]
+        staged_vulkan_driver_observed = any(
+            "/runtime/graphics/vulkan/rk3566-g52-g29p1/lib/libmali.so.1"
+            in mapping
+            for mapping in mappings
+        )
+        system_gles_runtime_observed = (
+            any("/usr/lib/libSDL2-" in mapping for mapping in mappings)
+            and any("/usr/lib/libmali.so" in mapping for mapping in mappings)
+        )
+        stats_backend_observed = (
+            any("Pipelines loaded:" in info for info in gpu_info)
+            if self.args.core == "vulkan"
+            else any("Programs loaded:" in info for info in gpu_info)
+        )
+        backend_runtime_observed = (
+            staged_vulkan_driver_observed
+            if self.args.core == "vulkan"
+            else system_gles_runtime_observed
+        )
+        direct_drm_expected = self.args.core == "vulkan"
+        weston_before = bool(self.frontend_before.get("weston"))
+        weston_during = bool(self.frontend_during.get("weston"))
+        direct_drm_observed = (
+            weston_before and not weston_during
+            if direct_drm_expected
+            else weston_before and weston_during
+        )
+
+        return {
+            "schema_version": 1,
+            "status": "failed" if self.error else "completed",
+            "error": self.error,
+            "device_serial": self.adb.serial,
+            "sdcard_path": self.sdcard,
+            "rom_path": self.args.rom,
+            "core": self.args.core,
+            "core_id": CORE_IDS[self.args.core],
+            "preset": self.args.preset,
+            "warmup_seconds": self.args.warmup,
+            "measurement_seconds": self.args.duration,
+            "sample_interval_seconds": self.args.interval,
+            "sample_count": len(self.samples),
+            "exit_signal": f"SIG{self.args.exit_signal}",
+            "started_unix": self.started_at,
+            "finished_unix": time.time(),
+            "ppsspp": {
+                "rendered_fps": {
+                    "median": rounded(statistics.median(fps_values) if fps_values else None),
+                    "min": rounded(min(fps_values) if fps_values else None),
+                    "p05": rounded(percentile(fps_values, 5)),
+                },
+                "vblanks_per_second": {
+                    "target": rounded(target_vps),
+                    "median": rounded(statistics.median(vps_values) if vps_values else None),
+                    "min": rounded(min(vps_values) if vps_values else None),
+                    "p05": rounded(percentile(vps_values, 5)),
+                },
+                "emulation_speed_percent": {
+                    "median": rounded(statistics.median(speed_values) if speed_values else None),
+                    "min": rounded(min(speed_values) if speed_values else None),
+                    "p05": rounded(percentile(speed_values, 5)),
+                },
+                "final_sample_frame_history_ms": {
+                    "count": len(frame_ms),
+                    "median": rounded(statistics.median(frame_ms) if frame_ms else None),
+                    "p95": rounded(percentile(frame_ms, 95)),
+                    "p99": rounded(percentile(frame_ms, 99)),
+                    "max": rounded(max(frame_ms) if frame_ms else None),
+                },
+            },
+            "device": {
+                "cpu_frequency_khz": {
+                    "median": rounded(
+                        statistics.median(values_for("cpu_cur_khz"))
+                        if values_for("cpu_cur_khz")
+                        else None
+                    ),
+                    "min": rounded(
+                        min(values_for("cpu_cur_khz"))
+                        if values_for("cpu_cur_khz")
+                        else None
+                    ),
+                },
+                "gpu_frequency_hz": {
+                    "median": rounded(
+                        statistics.median(values_for("gpu_cur_hz"))
+                        if values_for("gpu_cur_hz")
+                        else None
+                    ),
+                    "min": rounded(
+                        min(values_for("gpu_cur_hz"))
+                        if values_for("gpu_cur_hz")
+                        else None
+                    ),
+                },
+                "gpu_load_percent": {
+                    "median": rounded(
+                        statistics.median(values_for("gpu_load_percent"))
+                        if values_for("gpu_load_percent")
+                        else None
+                    ),
+                    "max": rounded(
+                        max(values_for("gpu_load_percent"))
+                        if values_for("gpu_load_percent")
+                        else None
+                    ),
+                },
+                "dmc_frequency_hz": {
+                    "median": rounded(
+                        statistics.median(values_for("dmc_cur_hz"))
+                        if values_for("dmc_cur_hz")
+                        else None
+                    ),
+                },
+                "process_cpu_percent": {
+                    "median": rounded(
+                        statistics.median(values_for("proc_cpu_percent"))
+                        if values_for("proc_cpu_percent")
+                        else None
+                    ),
+                    "max": rounded(
+                        max(values_for("proc_cpu_percent"))
+                        if values_for("proc_cpu_percent")
+                        else None
+                    ),
+                },
+                "process_rss_kb": {
+                    "median": rounded(
+                        statistics.median(values_for("proc_rss_kb"))
+                        if values_for("proc_rss_kb")
+                        else None
+                    ),
+                    "max": rounded(
+                        max(values_for("proc_rss_kb"))
+                        if values_for("proc_rss_kb")
+                        else None
+                    ),
+                },
+                "temperatures": temperatures,
+            },
+            "backend_evidence": {
+                **self.backend_evidence,
+                "expected_argument": expected_backend_argument,
+                "argument_observed": expected_backend_argument in command_line,
+                "vulkan_loader_observed": any(
+                    "libvulkan" in mapping for mapping in mappings
+                ),
+                "mali_driver_observed": any("libmali" in mapping for mapping in mappings),
+                "staged_vulkan_driver_observed": staged_vulkan_driver_observed,
+                "system_gles_runtime_observed": system_gles_runtime_observed,
+                "stats_backend_observed": stats_backend_observed,
+                "backend_runtime_observed": backend_runtime_observed,
+            },
+            "lifecycle": {
+                "direct_drm_expected": direct_drm_expected,
+                "display_lifecycle_observed": direct_drm_observed,
+                "frontend_restored": frontend_restored,
+                "before": self.frontend_before,
+                "during": self.frontend_during,
+                "after": self.frontend_after,
+            },
+        }
+
+    def run(self) -> int:
+        frontend_restored = False
+        try:
+            self.ensure_preflight()
+            self.capture_device_identity()
+            self.prepare_config()
+            self.mark_log_offsets()
+            self.launch()
+            self.frontend_during = self.adb.process_snapshot()
+            self.capture_backend_evidence()
+            self.connect_debugger()
+            self.warm_up()
+            self.sample()
+        except (BenchmarkError, OSError, ValueError, json.JSONDecodeError) as error:
+            self.error = str(error)
+            self.log(f"ERROR: {self.error}")
+        except KeyboardInterrupt:
+            self.error = "interrupted"
+            self.log("Interrupted; restoring PPSSPP and frontend state")
+        finally:
+            self.close_debugger()
+            self.terminate_ppsspp()
+            if self.frontend_before:
+                frontend_restored = self.wait_frontend()
+                self.log(
+                    "Frontend restoration passed"
+                    if frontend_restored
+                    else "Frontend restoration timed out"
+                )
+            try:
+                self.capture_log_slices()
+            except (BenchmarkError, OSError) as error:
+                self.log(f"Could not capture log slices: {error}")
+            try:
+                self.restore_config()
+            except (BenchmarkError, OSError) as error:
+                self.error = self.error or f"config restoration failed: {error}"
+                self.log(f"ERROR: config restoration failed: {error}")
+
+        summary = self.make_summary(frontend_restored)
+        if not self.error and not frontend_restored:
+            self.error = "frontend restoration timed out"
+        if not self.error and not summary["backend_evidence"]["argument_observed"]:
+            self.error = "requested graphics backend was not observed on the command line"
+        if not self.error and not summary["backend_evidence"]["backend_runtime_observed"]:
+            self.error = "requested graphics runtime was not observed in the process"
+        if not self.error and not summary["backend_evidence"]["stats_backend_observed"]:
+            self.error = "PPSSPP GPU stats did not confirm the requested backend"
+        if not self.error and not summary["lifecycle"]["display_lifecycle_observed"]:
+            self.error = "expected display-server lifecycle was not observed"
+        if self.error and summary["error"] != self.error:
+            self.log(f"ERROR: {self.error}")
+            summary = self.make_summary(frontend_restored)
+        (self.output / "summary.json").write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        self.log(f"Evidence written to {self.output}")
+        if self.error:
+            return 1
+        return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Benchmark PPSSPP through Jawaka on an attached MLP1 and preserve "
+            "GPU, thermal, memory, and lifecycle evidence."
+        )
+    )
+    parser.add_argument("--rom", required=True, help="Absolute ROM path on the device")
+    parser.add_argument(
+        "--core",
+        choices=tuple(CORE_IDS),
+        default="vulkan",
+        help="PPSSPP graphics backend to request (default: vulkan)",
+    )
+    parser.add_argument(
+        "--preset",
+        choices=("balanced", "performance"),
+        default="balanced",
+        help="Controlled PPSSPP preset (default: balanced)",
+    )
+    parser.add_argument(
+        "--preset-root",
+        default=str(DEFAULT_PRESET_ROOT),
+        help="Directory containing ppsspp-balanced.ini and ppsspp-performance.ini",
+    )
+    parser.add_argument("--warmup", type=float, default=15.0)
+    parser.add_argument("--duration", type=float, default=60.0)
+    parser.add_argument("--interval", type=float, default=1.0)
+    parser.add_argument("--startup-timeout", type=float, default=30.0)
+    parser.add_argument("--debugger-timeout", type=float, default=30.0)
+    parser.add_argument("--debug-port", type=int, default=28000)
+    parser.add_argument(
+        "--exit-signal",
+        choices=("TERM", "KILL"),
+        default="TERM",
+        help="Signal used after measurement; KILL exercises crash recovery",
+    )
+    parser.add_argument(
+        "--replace-running",
+        action="store_true",
+        help="Terminate an already-running PPSSPP before starting",
+    )
+    parser.add_argument(
+        "--remote-sd",
+        default=os.environ.get("REMOTE_SDCARD_PATH", "auto"),
+        help="Device SD mount or auto (default: auto)",
+    )
+    parser.add_argument("--serial", help="ADB device serial (defaults to ADB_SERIAL)")
+    parser.add_argument("--output", help="New evidence directory")
+    parser.add_argument(
+        "--clock-ticks",
+        type=float,
+        default=100.0,
+        help="Device USER_HZ for process CPU calculation (default: 100)",
+    )
+    args = parser.parse_args()
+    if args.warmup < 0 or args.duration <= 0 or args.interval <= 0:
+        parser.error("warmup must be >= 0; duration and interval must be > 0")
+    if not 1 <= args.debug_port <= 65535:
+        parser.error("debug port must be in 1..65535")
+    return args
+
+
+def main() -> int:
+    try:
+        return BenchmarkSession(parse_args()).run()
+    except (BenchmarkError, FileExistsError) as error:
+        print(f"ppsspp-benchmark: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ppsspp-benchmark.py
+++ b/scripts/ppsspp-benchmark.py
@@ -696,6 +696,7 @@ class BenchmarkSession:
         self.game_status: dict[str, Any] = {}
         self.debugger_reconnects = 0
         self.daemon_recovery: dict[str, Any] | None = None
+        self.scene_state: dict[str, Any] | None = None
         self.trace_started_at: float | None = None
         self.input_trace = (
             InputTrace(Path(args.input_trace), args.warmup + args.duration)
@@ -827,6 +828,11 @@ fi
                     "input_trace": (
                         self.input_trace.metadata() if self.input_trace else None
                     ),
+                    "scene_state": {
+                        "action": self.args.scene_state_action,
+                        "expected_sha256": self.args.scene_expected_sha256,
+                        "settle_seconds": self.args.scene_settle,
+                    },
                     "debugger": {
                         "port": self.args.debug_port,
                         "on_startup": True,
@@ -1194,6 +1200,128 @@ done
                     f"{self.args.max_debugger_reconnects}): {error}"
                 )
                 self.connect_debugger(reconnecting=True)
+
+    def scene_state_file_evidence(self, path: str) -> dict[str, Any]:
+        lowered = path.lower()
+        userdata_root = f"{self.sdcard}/.userdata/mlp1/".lower()
+        if (
+            "\n" in path
+            or not lowered.startswith(userdata_root)
+            or "/psp/ppsspp_state/umrk-benchmark-" not in lowered
+            or not lowered.endswith(".ppst")
+        ):
+            raise BenchmarkError(
+                f"PPSSPP debugger returned an unsafe benchmark savestate path: {path!r}"
+            )
+        output = self.adb.shell(
+            f"""
+set -eu
+file={quote(path)}
+[ -f "$file" ]
+printf 'size='
+wc -c <"$file"
+printf 'sha256='
+sha256sum "$file" | awk '{{print $1}}'
+"""
+        )
+        values = dict(
+            line.split("=", 1)
+            for line in output.splitlines()
+            if "=" in line
+        )
+        try:
+            size = int(values["size"])
+            sha256 = values["sha256"].lower()
+        except (KeyError, ValueError) as error:
+            raise BenchmarkError(
+                f"Could not read benchmark savestate evidence: {output!r}"
+            ) from error
+        if size <= 0 or not re.fullmatch(r"[0-9a-f]{64}", sha256):
+            raise BenchmarkError(
+                f"Invalid benchmark savestate evidence: size={size} sha256={sha256!r}"
+            )
+        expected = self.args.scene_expected_sha256
+        if expected and sha256 != expected:
+            raise BenchmarkError(
+                "Benchmark savestate hash mismatch: "
+                f"expected {expected}, observed {sha256}"
+            )
+        return {
+            "path": path,
+            "size_bytes": size,
+            "sha256": sha256,
+        }
+
+    def apply_scene_state(self, action: str) -> None:
+        if not self.websocket:
+            raise BenchmarkError("PPSSPP debugger is not connected")
+        event = (
+            "game.savestate.save"
+            if action == "capture"
+            else "game.savestate.load"
+        )
+        started = time.monotonic()
+        self.log(
+            "Capturing deterministic benchmark savestate"
+            if action == "capture"
+            else "Loading deterministic benchmark savestate"
+        )
+        response = self.websocket.request(event, f"harness-scene-{action}")
+        if response.get("status") != "success":
+            raise BenchmarkError(
+                f"PPSSPP benchmark savestate {action} returned "
+                f"{response.get('status', 'unknown')}: {response.get('message', '')}"
+            )
+        path = response.get("path")
+        if not isinstance(path, str) or not path:
+            raise BenchmarkError(
+                f"PPSSPP benchmark savestate {action} returned no path"
+            )
+        evidence = self.scene_state_file_evidence(path)
+        status = self.websocket.request(
+            "game.status",
+            f"harness-scene-{action}-game-status",
+        )
+        expected_game = self.game_status.get("game", {}).get("id")
+        observed_game = status.get("game", {}).get("id")
+        if not expected_game or observed_game != expected_game:
+            raise BenchmarkError(
+                "Benchmark savestate changed the running game: "
+                f"expected {expected_game or 'unknown'}, "
+                f"observed {observed_game or 'unknown'}"
+            )
+        self.game_status = status
+        self.scene_state = {
+            "action": action,
+            "completed": True,
+            "elapsed_seconds": time.monotonic() - started,
+            "game_id": observed_game,
+            "game_version": status.get("game", {}).get("version"),
+            "response": response,
+            **evidence,
+        }
+        (self.output / "scene-state.json").write_text(
+            json.dumps(self.scene_state, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        self.log(
+            f"Benchmark savestate {action} passed: "
+            f"{evidence['size_bytes']} bytes sha256={evidence['sha256']}"
+        )
+
+    def settle_after_scene_load(self) -> None:
+        if self.args.scene_settle <= 0:
+            self.trace_started_at = time.monotonic()
+            return
+        self.log(
+            f"Settling loaded benchmark scene for {self.args.scene_settle:.1f} seconds"
+        )
+        deadline = time.monotonic() + self.args.scene_settle
+        while time.monotonic() < deadline:
+            if not self.process_alive():
+                raise BenchmarkError("PPSSPP exited while settling loaded scene")
+            time.sleep(min(0.5, max(0.0, deadline - time.monotonic())))
+        self.trace_started_at = time.monotonic()
 
     def trace_elapsed(self) -> float:
         if self.trace_started_at is None:
@@ -1593,6 +1721,7 @@ done
             "core_id": CORE_IDS[self.args.core],
             "game_status": self.game_status,
             "preset": self.args.preset,
+            "scene_state": self.scene_state,
             "input_trace": (
                 self.input_trace.metadata() if self.input_trace else None
             ),
@@ -1746,7 +1875,12 @@ done
             self.frontend_during = self.adb.process_snapshot()
             self.capture_backend_evidence()
             self.connect_debugger()
+            if self.args.scene_state_action == "load":
+                self.apply_scene_state("load")
+                self.settle_after_scene_load()
             self.warm_up()
+            if self.args.scene_state_action == "capture":
+                self.apply_scene_state("capture")
             self.sample()
             if self.args.daemon_exit_signal:
                 self.release_input_trace()
@@ -1796,6 +1930,12 @@ done
             and not (self.daemon_recovery or {}).get("completed")
         ):
             self.error = "daemon recovery did not complete"
+        if (
+            not self.error
+            and self.args.scene_state_action
+            and not (self.scene_state or {}).get("completed")
+        ):
+            self.error = "benchmark savestate action did not complete"
         if self.error and summary["error"] != self.error:
             self.log(f"ERROR: {self.error}")
             summary = self.make_summary(frontend_restored)
@@ -1843,6 +1983,24 @@ def parse_args() -> argparse.Namespace:
             "Schema 1 JSON input trace driven through PPSSPP's debugger from "
             "debugger connection through warm-up and measurement"
         ),
+    )
+    parser.add_argument(
+        "--scene-state-action",
+        choices=("capture", "load"),
+        help=(
+            "Capture the game-scoped benchmark savestate after warm-up or "
+            "load it before warm-up"
+        ),
+    )
+    parser.add_argument(
+        "--scene-expected-sha256",
+        help="Require the captured or loaded benchmark savestate to match this SHA-256",
+    )
+    parser.add_argument(
+        "--scene-settle",
+        type=float,
+        default=3.0,
+        help="Seconds to settle after loading a benchmark savestate (default: 3)",
     )
     parser.add_argument("--startup-timeout", type=float, default=30.0)
     parser.add_argument("--debugger-timeout", type=float, default=30.0)
@@ -1911,6 +2069,14 @@ def parse_args() -> argparse.Namespace:
         parser.error("ADB retry timeout must be >= 0")
     if args.daemon_recovery_timeout <= 0:
         parser.error("daemon recovery timeout must be > 0")
+    if args.scene_settle < 0:
+        parser.error("scene settle must be >= 0")
+    if args.scene_expected_sha256:
+        args.scene_expected_sha256 = args.scene_expected_sha256.lower()
+        if not re.fullmatch(r"[0-9a-f]{64}", args.scene_expected_sha256):
+            parser.error("scene expected SHA-256 must contain exactly 64 hex digits")
+        if not args.scene_state_action:
+            parser.error("scene expected SHA-256 requires --scene-state-action")
     return args
 
 

--- a/scripts/ppsspp-input-traces/README.md
+++ b/scripts/ppsspp-input-traces/README.md
@@ -1,0 +1,31 @@
+# PPSSPP benchmark input traces
+
+Input traces drive repeatable PSP controls through PPSSPP's debugger during
+benchmark warm-up and measurement. They never contain or install game data.
+
+Pass a trace directly:
+
+```sh
+make benchmark-ppsspp \
+  ROM="/device/path/game.iso" \
+  CORE=vulkan \
+  PRESET=performance \
+  TRACE=scripts/ppsspp-input-traces/god-of-war-chains-opening.json
+```
+
+Schema 1 fields:
+
+- `name`: human-readable trace name.
+- `game_id`: optional PPSSPP game ID. A mismatch fails before input is sent.
+- `description`: optional evidence description.
+- `events`: non-empty array sorted by the harness using `at`, in seconds from
+  debugger connection.
+- `event`: `input.buttons.press`, `input.buttons.send`, or
+  `input.analog.send`.
+- `repeat_every`: optional positive repetition period in seconds.
+- `repeat_until`: optional final repetition time. The benchmark horizon is
+  always an upper bound.
+
+Late input is skipped rather than replayed in a burst after a debugger
+reconnection. At cleanup, the harness centers both analog sticks and releases
+every button named by the trace before terminating PPSSPP.

--- a/scripts/ppsspp-input-traces/god-of-war-chains-opening.json
+++ b/scripts/ppsspp-input-traces/god-of-war-chains-opening.json
@@ -1,0 +1,131 @@
+{
+  "schema": 1,
+  "name": "God of War: Chains of Olympus opening workload",
+  "game_id": "NPEG00023",
+  "description": "Skips the opening flow, accepts the default new-game path, then repeats movement and combat input.",
+  "events": [
+    {
+      "at": 0.0,
+      "event": "input.buttons.press",
+      "button": "start",
+      "duration": 8
+    },
+    {
+      "at": 1.7,
+      "event": "input.buttons.press",
+      "button": "cross",
+      "duration": 8
+    },
+    {
+      "at": 3.4,
+      "event": "input.buttons.press",
+      "button": "start",
+      "duration": 8
+    },
+    {
+      "at": 5.1,
+      "event": "input.buttons.press",
+      "button": "cross",
+      "duration": 8
+    },
+    {
+      "at": 6.8,
+      "event": "input.buttons.press",
+      "button": "cross",
+      "duration": 8
+    },
+    {
+      "at": 9.0,
+      "event": "input.buttons.press",
+      "button": "start",
+      "duration": 8
+    },
+    {
+      "at": 10.2,
+      "event": "input.buttons.press",
+      "button": "cross",
+      "duration": 8
+    },
+    {
+      "at": 12.4,
+      "event": "input.buttons.press",
+      "button": "cross",
+      "duration": 8
+    },
+    {
+      "at": 15.6,
+      "event": "input.buttons.press",
+      "button": "start",
+      "duration": 8
+    },
+    {
+      "at": 16.8,
+      "event": "input.buttons.press",
+      "button": "cross",
+      "duration": 8
+    },
+    {
+      "at": 20.0,
+      "event": "input.buttons.press",
+      "button": "start",
+      "duration": 8
+    },
+    {
+      "at": 21.2,
+      "event": "input.buttons.press",
+      "button": "cross",
+      "duration": 8
+    },
+    {
+      "at": 24.0,
+      "event": "input.analog.send",
+      "stick": "left",
+      "x": 0.3,
+      "y": -0.9,
+      "repeat_every": 8.0
+    },
+    {
+      "at": 28.0,
+      "event": "input.analog.send",
+      "stick": "left",
+      "x": -0.3,
+      "y": -0.9,
+      "repeat_every": 8.0
+    },
+    {
+      "at": 24.0,
+      "event": "input.buttons.press",
+      "button": "square",
+      "duration": 6,
+      "repeat_every": 0.65
+    },
+    {
+      "at": 24.25,
+      "event": "input.buttons.press",
+      "button": "triangle",
+      "duration": 7,
+      "repeat_every": 1.3
+    },
+    {
+      "at": 24.5,
+      "event": "input.buttons.press",
+      "button": "cross",
+      "duration": 7,
+      "repeat_every": 2.6
+    },
+    {
+      "at": 25.0,
+      "event": "input.buttons.press",
+      "button": "circle",
+      "duration": 7,
+      "repeat_every": 4.5
+    },
+    {
+      "at": 25.5,
+      "event": "input.buttons.press",
+      "button": "rtrigger",
+      "duration": 7,
+      "repeat_every": 7.0
+    }
+  ]
+}

--- a/scripts/ppsspp-input-traces/god-of-war-chains-scene.json
+++ b/scripts/ppsspp-input-traces/god-of-war-chains-scene.json
@@ -1,0 +1,59 @@
+{
+  "schema": 1,
+  "name": "God of War: Chains of Olympus deterministic scene workload",
+  "game_id": "NPEG00023",
+  "description": "Drives alternating forward movement and repeated combat input after loading the dedicated benchmark scene.",
+  "events": [
+    {
+      "at": 0.0,
+      "event": "input.analog.send",
+      "stick": "left",
+      "x": 0.3,
+      "y": -0.9,
+      "repeat_every": 8.0
+    },
+    {
+      "at": 4.0,
+      "event": "input.analog.send",
+      "stick": "left",
+      "x": -0.3,
+      "y": -0.9,
+      "repeat_every": 8.0
+    },
+    {
+      "at": 0.0,
+      "event": "input.buttons.press",
+      "button": "square",
+      "duration": 6,
+      "repeat_every": 0.65
+    },
+    {
+      "at": 0.25,
+      "event": "input.buttons.press",
+      "button": "triangle",
+      "duration": 7,
+      "repeat_every": 1.3
+    },
+    {
+      "at": 0.5,
+      "event": "input.buttons.press",
+      "button": "cross",
+      "duration": 7,
+      "repeat_every": 2.6
+    },
+    {
+      "at": 1.0,
+      "event": "input.buttons.press",
+      "button": "circle",
+      "duration": 7,
+      "repeat_every": 4.5
+    },
+    {
+      "at": 1.5,
+      "event": "input.buttons.press",
+      "button": "rtrigger",
+      "duration": 7,
+      "repeat_every": 7.0
+    }
+  ]
+}

--- a/scripts/validate-ppsspp-vulkan-release.py
+++ b/scripts/validate-ppsspp-vulkan-release.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Validate the MLP1 PPSSPP Vulkan runtime/package/metadata contract."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+
+
+VULKAN_RUNTIME_ID = "rk3566-g52-g29p1"
+
+
+def load_json(path: Path) -> dict:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"error: cannot read JSON {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise SystemExit(f"error: expected JSON object: {path}")
+    return value
+
+
+def validate(platform: Path) -> None:
+    runtime = platform / f"runtime/graphics/vulkan/{VULKAN_RUNTIME_ID}"
+    runtime_manifest = load_json(runtime / "manifest.json")
+    if runtime_manifest.get("id") != VULKAN_RUNTIME_ID:
+        raise SystemExit("error: unexpected Vulkan runtime id")
+    if runtime_manifest.get("kind") != "platform-vulkan-runtime":
+        raise SystemExit("error: unexpected Vulkan runtime kind")
+
+    files = runtime_manifest.get("files")
+    if not isinstance(files, list) or not files:
+        raise SystemExit("error: Vulkan runtime manifest has no file inventory")
+    for row in files:
+        if not isinstance(row, dict) or not row.get("path") or not row.get("sha256"):
+            raise SystemExit("error: malformed Vulkan runtime file inventory")
+        path = runtime / row["path"]
+        if not path.is_file():
+            raise SystemExit(f"error: Vulkan runtime file missing: {path}")
+        actual = hashlib.sha256(path.read_bytes()).hexdigest()
+        if actual != row["sha256"]:
+            raise SystemExit(f"error: Vulkan runtime checksum mismatch: {path}")
+
+    package = platform / "emulators/ppsspp"
+    manifest = load_json(package / "manifest.json")
+    if manifest.get("default_graphics_backend") != "vulkan-display":
+        raise SystemExit("error: PPSSPP package does not default to Vulkan display")
+    if manifest.get("vulkan_runtime") != runtime_manifest.get("id"):
+        raise SystemExit("error: PPSSPP and Vulkan runtime manifests disagree")
+    if manifest.get("fallback_entrypoint") != "launch-gles.sh":
+        raise SystemExit("error: PPSSPP package does not declare the GLES fallback")
+    for rel in ("launch.sh", "launch-gles.sh", "bin/PPSSPPSDL"):
+        path = package / rel
+        if not path.is_file() or not os.access(path, os.X_OK):
+            raise SystemExit(f"error: PPSSPP executable missing: {path}")
+
+    launch_text = (package / "launch.sh").read_text(encoding="utf-8")
+    if "USERDATA_PATH" not in launch_text:
+        raise SystemExit("error: PPSSPP launcher does not use USERDATA_PATH")
+    launch_lines = launch_text.splitlines()
+    if not any(
+        line.strip() == 'ROTATION_MODE="${ROTATION_MODE:-native}"'
+        for line in launch_lines
+    ):
+        raise SystemExit("error: native rotation is not the Vulkan default")
+    native_rotation = launch_text.split("            native)", 1)[-1].split(
+        "                ;;", 1
+    )[0]
+    if "portmaster" in native_rotation.lower():
+        raise SystemExit("error: native PPSSPP rotation depends on PortMaster")
+    if 'STATE_ROOT="$PLATFORM_ROOT/state/ppsspp"' in launch_lines:
+        raise SystemExit("error: PPSSPP launcher still writes release-managed state")
+    if 'OLD_STATE_ROOT="$PLATFORM_ROOT/state/ppsspp"' not in launch_lines:
+        raise SystemExit("error: PPSSPP launcher lost the one-time legacy state migration")
+
+    cores = load_json(platform / "defaults/cores.json").get("cores")
+    systems = load_json(platform / "defaults/systems.json").get("systems")
+    if not isinstance(cores, list) or not isinstance(systems, list):
+        raise SystemExit("error: malformed PPSSPP metadata catalog")
+    by_core = {row.get("id"): row for row in cores if isinstance(row, dict)}
+    by_system = {row.get("id"): row for row in systems if isinstance(row, dict)}
+    if not by_core.get("ppsspp", {}).get("requires_direct_drm"):
+        raise SystemExit("error: Vulkan PPSSPP core must request direct DRM")
+    if by_core.get("ppsspp_gles", {}).get("requires_direct_drm"):
+        raise SystemExit("error: GLES PPSSPP core must not request direct DRM")
+    if by_core.get("ppsspp_gles", {}).get("path") != "emulators/ppsspp/launch-gles.sh":
+        raise SystemExit("error: GLES PPSSPP core points at the wrong launcher")
+    if by_system.get("PSP", {}).get("default_core") != "ppsspp":
+        raise SystemExit("error: PSP does not default to Vulkan PPSSPP")
+    if "ppsspp_gles" not in by_system.get("PSP", {}).get("alternate_cores", []):
+        raise SystemExit("error: PSP has no GLES fallback core")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("platform_dir", type=Path)
+    args = parser.parse_args()
+    validate(args.platform_dir)
+    print("PPSSPP Vulkan gate: runtime, package, metadata, and fallback verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate-ppsspp-vulkan-release.py
+++ b/scripts/validate-ppsspp-vulkan-release.py
@@ -52,6 +52,10 @@ def validate(platform: Path) -> None:
         raise SystemExit("error: PPSSPP and Vulkan runtime manifests disagree")
     if manifest.get("fallback_entrypoint") != "launch-gles.sh":
         raise SystemExit("error: PPSSPP package does not declare the GLES fallback")
+    if manifest.get("fallback_sdl_video_driver") != "wayland":
+        raise SystemExit("error: PPSSPP GLES fallback is not compositor-safe")
+    if manifest.get("fallback_display_rotation") != 0:
+        raise SystemExit("error: PPSSPP GLES fallback must use compositor rotation")
     for rel in ("launch.sh", "launch-gles.sh", "bin/PPSSPPSDL"):
         path = package / rel
         if not path.is_file() or not os.access(path, os.X_OK):
@@ -75,6 +79,11 @@ def validate(platform: Path) -> None:
         raise SystemExit("error: PPSSPP launcher still writes release-managed state")
     if 'OLD_STATE_ROOT="$PLATFORM_ROOT/state/ppsspp"' not in launch_lines:
         raise SystemExit("error: PPSSPP launcher lost the one-time legacy state migration")
+    fallback_text = (package / "launch-gles.sh").read_text(encoding="utf-8")
+    if 'PPSSPP_GLES_SDL_VIDEODRIVER:-wayland' not in fallback_text:
+        raise SystemExit("error: PPSSPP GLES fallback does not select Wayland")
+    if 'PPSSPP_GLES_DISPLAY_ROTATION:-0' not in fallback_text:
+        raise SystemExit("error: PPSSPP GLES fallback still forces panel rotation")
 
     cores = load_json(platform / "defaults/cores.json").get("cores")
     systems = load_json(platform / "defaults/systems.json").get("systems")

--- a/stage/mlp1-graphics/aarch64-mali.lock.json
+++ b/stage/mlp1-graphics/aarch64-mali.lock.json
@@ -1,0 +1,30 @@
+{
+  "schema": 1,
+  "kind": "jeffycn-libmali-raw",
+  "name": "libmali-bifrost-g52-g29p1",
+  "architecture": "arm64",
+  "release": {
+    "repo": "JeffyCN/mirrors",
+    "branch": "libmali-next",
+    "commit": "4233031d818e97a19e8a9cdbbd5c15795ededd93"
+  },
+  "asset": {
+    "filename": "libmali-bifrost-g52-g29p1.so",
+    "path": "lib/aarch64-linux-gnu/libmali-bifrost-g52-g29p1.so",
+    "url": "https://raw.githubusercontent.com/JeffyCN/mirrors/4233031d818e97a19e8a9cdbbd5c15795ededd93/lib/aarch64-linux-gnu/libmali-bifrost-g52-g29p1.so",
+    "size": 59855128,
+    "sha256": "605e3a5caf1be62bb48d97b1168434257355d56db5e3be9b515cfa742c173118"
+  },
+  "icd": {
+    "filename": "rk_vk_g29.json",
+    "library_path": "libmali.so.1",
+    "api_version": "1.3.276"
+  },
+  "license": {
+    "filename": "END_USER_LICENCE_AGREEMENT.txt",
+    "url": "https://raw.githubusercontent.com/JeffyCN/mirrors/4233031d818e97a19e8a9cdbbd5c15795ededd93/END_USER_LICENCE_AGREEMENT.txt",
+    "size": 10040,
+    "sha256": "a78acc73de9909efb879800d4daa4640c4aaa55cd751238a133954aba15e4285"
+  },
+  "packaging_reference": "Utility-Muffin-Research-Kitchen/PortMaster-mlp1"
+}

--- a/stage/mlp1.mk
+++ b/stage/mlp1.mk
@@ -19,6 +19,8 @@ MLP1_METADATA_DIR  ?= $(UMRK_WORKSPACE_DIR)/plans/retroarch/generated/mlp1
 MLP1_CORE_REPORT_TOOL ?= $(CORES_SPRUCE_DIR)/scripts/mlp1-core-report.py
 MLP1_CORE_PROBE_RUNNER ?= $(CORES_SPRUCE_DIR)/probe-mlp1-cores-adb.sh
 MLP1_PPSSPP_PACKAGE ?= $(PPSSPP_SPRUCE_DIR)/output/mlp1/ppsspp
+MLP1_GRAPHICS_RUNTIME ?= $(LEAF_ROOT)/build/mlp1/runtime/graphics
+MLP1_VULKAN_RUNTIME ?= $(MLP1_GRAPHICS_RUNTIME)/vulkan/rk3566-g52-g29p1
 MLP1_DRASTIC_PACKAGE ?= $(LEAF_ROOT)/build/drastic/mlp1/drastic
 MLP1_MUPEN64PLUS_PACKAGE ?= $(N64_STANDALONE_DIR)/output/mlp1/mupen64plus
 MLP1_RETROARCH_PATCH_SET ?= portrait-rotation,command-menu,jawaka-load-content,controller-bindings
@@ -215,9 +217,12 @@ stage-emulator:
 	case "$(EMULATOR)" in \
 		ppsspp) \
 			test -d "$(PPSSPP_SPRUCE_DIR)" || { echo "missing repo: $(PPSSPP_SPRUCE_DIR) (run: make bootstrap)" >&2; exit 1; }; \
+			MLP1_GRAPHICS_RUNTIME_DIR="$(MLP1_GRAPHICS_RUNTIME)" \
+				"$(LEAF_ROOT)/scripts/build-mlp1-graphics-runtime.sh"; \
 			$(MAKE) -C "$(PPSSPP_SPRUCE_DIR)" package-mlp1; \
 			package_dir="$(MLP1_PPSSPP_PACKAGE)"; \
 			remote_name="ppsspp"; \
+			vulkan_runtime="$(MLP1_VULKAN_RUNTIME)"; \
 			;; \
 		drastic) \
 			test -d "$(STEWARD_NDS_DIR)" || { echo "missing repo: $(STEWARD_NDS_DIR) (run: make bootstrap)" >&2; exit 1; }; \
@@ -256,11 +261,18 @@ stage-emulator:
 	if [ -z "$$remote_system" ]; then remote_system="$$remote_sd/.system/leaf"; fi; \
 	remote_platform="$(REMOTE_PLATFORM_PATH)"; \
 	if [ -z "$$remote_platform" ]; then remote_platform="$$remote_system/platforms/mlp1"; fi; \
+	if [ -n "$${vulkan_runtime:-}" ]; then \
+		test -d "$$vulkan_runtime" || { echo "missing Vulkan runtime: $$vulkan_runtime" >&2; exit 1; }; \
+		remote_vulkan="$$remote_platform/runtime/graphics/vulkan/rk3566-g52-g29p1"; \
+		echo "Deploying shared Vulkan runtime to $$remote_vulkan"; \
+		"$${ADB[@]}" shell "rm -rf \"$$remote_vulkan\" && mkdir -p \"$$remote_vulkan\""; \
+		"$${ADB[@]}" push "$$vulkan_runtime/." "$$remote_vulkan/" >/dev/null; \
+	fi; \
 	remote_dir="$$remote_platform/emulators/$$remote_name"; \
 	echo "Deploying $(EMULATOR) emulator to $$remote_dir"; \
 	"$${ADB[@]}" shell "rm -rf \"$$remote_dir\" && mkdir -p \"$$remote_dir\""; \
 	"$${ADB[@]}" push "$$package_dir/." "$$remote_dir/" >/dev/null; \
-	"$${ADB[@]}" shell "chmod 755 \"$$remote_dir/launch.sh\" \"$$remote_dir/bin/\"* \"$$remote_dir/lib/\"* 2>/dev/null || true"; \
+	"$${ADB[@]}" shell "chmod 755 \"$$remote_dir\"/launch*.sh \"$$remote_dir/bin/\"* \"$$remote_dir/lib/\"* 2>/dev/null || true"; \
 	if [ -d "$(DEVICE_OVERLAY)/defaults" ]; then \
 		echo "Refreshing platform defaults at $$remote_platform/defaults"; \
 		"$${ADB[@]}" shell "rm -rf '$$remote_platform/defaults' && mkdir -p '$$remote_platform/defaults'"; \
@@ -353,6 +365,8 @@ release-zips:
 	MLP1_CORES_DIR="$(MLP1_CORES_DIR)" \
 	MLP1_CORES_REPORT="$(MLP1_CORES_REPORT)" \
 	MLP1_PPSSPP_PACKAGE="$(MLP1_PPSSPP_PACKAGE)" \
+	MLP1_GRAPHICS_RUNTIME="$(MLP1_GRAPHICS_RUNTIME)" \
+	MLP1_VULKAN_RUNTIME="$(MLP1_VULKAN_RUNTIME)" \
 	MLP1_DRASTIC_PACKAGE="$(MLP1_DRASTIC_PACKAGE)" \
 	MLP1_MUPEN64PLUS_PACKAGE="$(MLP1_MUPEN64PLUS_PACKAGE)" \
 	MLP1_RETROARCH_PATCH_SET="$(MLP1_RETROARCH_PATCH_SET)" \
@@ -379,6 +393,8 @@ release-sd-zip:
 	MLP1_CORES_DIR="$(MLP1_CORES_DIR)" \
 	MLP1_CORES_REPORT="$(MLP1_CORES_REPORT)" \
 	MLP1_PPSSPP_PACKAGE="$(MLP1_PPSSPP_PACKAGE)" \
+	MLP1_GRAPHICS_RUNTIME="$(MLP1_GRAPHICS_RUNTIME)" \
+	MLP1_VULKAN_RUNTIME="$(MLP1_VULKAN_RUNTIME)" \
 	MLP1_DRASTIC_PACKAGE="$(MLP1_DRASTIC_PACKAGE)" \
 	MLP1_MUPEN64PLUS_PACKAGE="$(MLP1_MUPEN64PLUS_PACKAGE)" \
 	MLP1_RETROARCH_PATCH_SET="$(MLP1_RETROARCH_PATCH_SET)" \


### PR DESCRIPTION
## What changed

- add a Leaf-owned, hash-pinned g29p1 Mali runtime assembly for MLP1
- stage that shared runtime with PPSSPP and validate its manifest, hashes, package contract, metadata, and licenses
- add a device benchmark harness with backend evidence, lifecycle recovery, deterministic input traces, and saved-scene capture/load
- add strict repeat aggregation with contract fingerprinting and variance reporting
- harden daemon-loss recovery evidence and release assembly

## Why

PPSSPP needs a current Vulkan driver that is available independently of the
optional PortMaster Pak. Reproducible performance claims also need evidence
that validates the exact backend, scene, trace, clocks, transport, and frontend
lifecycle.

## User and developer impact

Leaf now owns the required graphics runtime and release gates. PortMaster
remains optional and is neither bootstrapped nor required at runtime. Benchmark
reports reject failed, mismatched, duplicated, incomplete, or overwritten
evidence.

## Validation

- shell scripts and Python modules compiled/validated locally
- trace and runtime lock JSON validated
- shared runtime and PPSSPP package staged on the connected MLP1
- three 180-second God of War Vulkan/Performance runs completed
- 270 samples and 2,091/2,091 events recorded with zero late events or reconnects
- mismatch, failed-run, duplicate-run, and overwrite rejection paths verified


## Companion PRs

- [PPSSPP-spruce #1](https://github.com/Utility-Muffin-Research-Kitchen/PPSSPP-spruce/pull/1)
- [Jawaka #4](https://github.com/Utility-Muffin-Research-Kitchen/Jawaka/pull/4)
- [Leaf #13](https://github.com/Utility-Muffin-Research-Kitchen/Leaf/pull/13)
- [miniloong-launcher-switcher #4](https://github.com/Utility-Muffin-Research-Kitchen/miniloong-launcher-switcher/pull/4)
- [umrk-workspace #6](https://github.com/Utility-Muffin-Research-Kitchen/umrk-workspace/pull/6)
