### PR TITLE
Integrate standalone Flycast staging and release policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ LARGE_LIBRARY_FIXTURE_ENV = \
 	REMOTE_SDCARD_PATH="$(REMOTE_SDCARD_PATH)"
 
 .DEFAULT_GOAL := help
-.PHONY: help bootstrap doctor status status-internal pakrat-local-feed-test adb-enable-marker adb-disable-marker adb-tail-logs adb-large-library-create adb-large-library-clean adb-large-library-status adb-install-wrapper adb-uninstall-wrapper benchmark-ppsspp
+.PHONY: help bootstrap doctor status status-internal pakrat-local-feed-test flycast-release-policy-smoke adb-enable-marker adb-disable-marker adb-tail-logs adb-large-library-create adb-large-library-clean adb-large-library-status adb-install-wrapper adb-uninstall-wrapper benchmark-ppsspp
 
 help:
 	@echo "Leaf workspace commands (DEVICE=$(DEVICE), WORKSPACE_DIR=$(WORKSPACE_DIR)):"
@@ -38,6 +38,7 @@ help:
 	@echo "  make stage-emulator EMULATOR=ppsspp DEVICE=mlp1 stage a standalone emulator"
 	@echo "  make stage-emulator EMULATOR=drastic DEVICE=mlp1 stage DraStic"
 	@echo "  make stage-emulator EMULATOR=mupen64plus DEVICE=mlp1 stage standalone N64"
+	@echo "  make stage-emulator EMULATOR=flycast DEVICE=mlp1 stage standalone Dreamcast"
 	@echo "  make stage-emulators DEVICE=mlp1          stage standalone emulators"
 	@echo "  make stage-app APP=CentralScrutinizer DEVICE=mlp1 stage a single app repo"
 	@echo "  make stage-app APP=Leaf-Itchio-Pak DEVICE=mlp1 explicitly stage the optional Itch.io app"
@@ -48,6 +49,7 @@ help:
 	@echo "  make release-sd-zip DEVICE=mlp1           build end-user install ZIP"
 	@echo "  make release-recovery-zip DEVICE=mlp1     build end-user recovery ZIP"
 	@echo "  make pakrat-local-feed-test               test multi-app and exact-artifact local feeds"
+	@echo "  make flycast-release-policy-smoke         test standalone Flycast release gates"
 	@echo "  make adb-enable-marker                    enable Leaf launcher marker"
 	@echo "  make adb-disable-marker                   disable Leaf launcher marker"
 	@echo "  make adb-tail-logs                        tail launcher logs"
@@ -60,6 +62,9 @@ help:
 
 bootstrap:
 	@LEAF_WORKSPACE_DIR="$(WORKSPACE_DIR)" scripts/bootstrap.sh $(REQUIRED_REPOS) --optional $(OPTIONAL_PRIVATE_REPOS)
+
+flycast-release-policy-smoke:
+	@python3 scripts/validate-flycast-standalone-release-test.py
 
 doctor:
 	@LEAF_WORKSPACE_DIR="$(WORKSPACE_DIR)" TOOLCHAIN_IMAGE="$(TOOLCHAIN_IMAGE)" scripts/doctor.sh

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ By default Leaf treats its parent directory as the workspace root:
   PPSSPP-spruce/
   steward-fu-nds/
   N64-standalone/
+  Flycast-standalone/
   retroarch-builds/
   Cores-spruce/
   mlp1-toolchain/
@@ -77,7 +78,8 @@ make stage-jawaka DEVICE=mlp1               # launcher payload only
 make stage-retroarch DEVICE=mlp1            # RetroArch binary + cores + info
 make stage-emulator EMULATOR=drastic DEVICE=mlp1
 make stage-emulator EMULATOR=mupen64plus DEVICE=mlp1
-make stage-emulators DEVICE=mlp1            # PPSSPP + DraStic + standalone N64
+make stage-emulator EMULATOR=flycast DEVICE=mlp1
+make stage-emulators DEVICE=mlp1            # PPSSPP + DraStic + N64 + Dreamcast
 make stage-app APP=ssh-server DEVICE=mlp1   # stage one app
 make stage-app APP=Thing-File DEVICE=mlp1
 make stage-app APP=CentralScrutinizer DEVICE=mlp1
@@ -269,7 +271,10 @@ Standalone game emulator payloads are staged under
 `.system/leaf/platforms/mlp1/emulators/`. PPSSPP is built from the UMRK
 `PPSSPP-spruce` sibling repo. Mupen64Plus standalone is built from the
 `N64-standalone` sibling repo and launched as a selectable path core for the
-canonical `Roms/N64` library. DraStic is packaged from the local
+canonical `Roms/N64` library. Flycast standalone is built from the
+`Flycast-standalone` sibling repo and initially offered as a selectable
+alternate for the canonical `Roms/DC` library; RetroArch Flycast remains the
+default during compatibility soak. DraStic is packaged from the local
 `steward-fu-nds` sibling repo: Leaf bundles the cross-built steward SDL2 custom
 menu stack with the prebuilt `drastic64` binary, keeps runtime state under
 `state/drastic/`, and runs it through `SDL_VIDEODRIVER=NDS`. Single-emulator ADB

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -20,6 +20,7 @@ url_for() {
         PPSSPP-spruce)               echo "https://github.com/Utility-Muffin-Research-Kitchen/PPSSPP-spruce.git" ;;
         steward-fu-nds)              echo "https://github.com/Helaas/nds.git" ;;
         N64-standalone)              echo "https://github.com/Utility-Muffin-Research-Kitchen/leaf-n64-standalone.git" ;;
+        Flycast-standalone)          echo "https://github.com/Utility-Muffin-Research-Kitchen/Flycast-standalone.git" ;;
         retroarch-builds)            echo "https://github.com/Utility-Muffin-Research-Kitchen/retroarch-builds.git" ;;
         Cores-spruce)                echo "https://github.com/Utility-Muffin-Research-Kitchen/Cores-spruce.git" ;;
         mlp1-toolchain)              echo "https://github.com/Utility-Muffin-Research-Kitchen/mlp1-toolchain.git" ;;

--- a/scripts/make-sd-release-zip.sh
+++ b/scripts/make-sd-release-zip.sh
@@ -9,7 +9,7 @@ WORKSPACE_DIR="${LEAF_WORKSPACE_DIR:-$(cd "$LEAF_ROOT/.." && pwd)}"
 
 DEVICE="${DEVICE:-mlp1}"
 STAGE_APPS="${STAGE_APPS-ssh-server Thing-File CentralScrutinizer Fugazi joes-calibrage retroarch-builds}"
-STAGE_EMULATORS="${STAGE_EMULATORS-ppsspp drastic mupen64plus}"
+STAGE_EMULATORS="${STAGE_EMULATORS-ppsspp drastic mupen64plus flycast}"
 PUBLIC_ROOT_DIRS="${PUBLIC_ROOT_DIRS-Roms Images Apps BIOS Saves States Cheats}"
 RELEASE_BUILD="${RELEASE_BUILD:-$LEAF_ROOT/build/release}"
 STAGE_BUILD="${STAGE_BUILD:-$LEAF_ROOT/build/stage/mlp1}"
@@ -20,6 +20,7 @@ JAWAKA_DIR="${JAWAKA_DIR:-$WORKSPACE_DIR/Jawaka}"
 PPSSPP_SPRUCE_DIR="${PPSSPP_SPRUCE_DIR:-$WORKSPACE_DIR/PPSSPP-spruce}"
 STEWARD_NDS_DIR="${STEWARD_NDS_DIR:-$WORKSPACE_DIR/steward-fu-nds}"
 N64_STANDALONE_DIR="${N64_STANDALONE_DIR:-$WORKSPACE_DIR/N64-standalone}"
+FLYCAST_STANDALONE_DIR="${FLYCAST_STANDALONE_DIR:-$WORKSPACE_DIR/Flycast-standalone}"
 RETROARCH_BUILDS_DIR="${RETROARCH_BUILDS_DIR:-$WORKSPACE_DIR/retroarch-builds}"
 CORES_SPRUCE_DIR="${CORES_SPRUCE_DIR:-$WORKSPACE_DIR/Cores-spruce}"
 LAUNCHER_SWITCHER_DIR="${LAUNCHER_SWITCHER_DIR:-$WORKSPACE_DIR/miniloong-launcher-switcher}"
@@ -36,6 +37,7 @@ MLP1_GRAPHICS_RUNTIME="${MLP1_GRAPHICS_RUNTIME:-$LEAF_ROOT/build/mlp1/runtime/gr
 MLP1_VULKAN_RUNTIME="${MLP1_VULKAN_RUNTIME:-$MLP1_GRAPHICS_RUNTIME/vulkan/rk3566-g52-g29p1}"
 MLP1_DRASTIC_PACKAGE="${MLP1_DRASTIC_PACKAGE:-$LEAF_ROOT/build/drastic/mlp1/drastic}"
 MLP1_MUPEN64PLUS_PACKAGE="${MLP1_MUPEN64PLUS_PACKAGE:-$N64_STANDALONE_DIR/output/mlp1/mupen64plus}"
+MLP1_FLYCAST_PACKAGE="${MLP1_FLYCAST_PACKAGE:-$FLYCAST_STANDALONE_DIR/output/mlp1/flycast}"
 MLP1_RETROARCH_PATCH_SET="${MLP1_RETROARCH_PATCH_SET:-portrait-rotation,command-menu,jawaka-load-content}"
 
 usage() {
@@ -48,7 +50,7 @@ Environment:
   LEAF_WORKSPACE_DIR=<workspace root>
   TOOLCHAIN_IMAGE=<MLP1 cross-compile Docker image>
   STAGE_APPS="ssh-server Thing-File CentralScrutinizer Fugazi joes-calibrage retroarch-builds"
-  STAGE_EMULATORS="ppsspp drastic mupen64plus"
+  STAGE_EMULATORS="ppsspp drastic mupen64plus flycast"
 EOF
 }
 
@@ -330,7 +332,10 @@ for e in packaged:
         expected_sos.add(so)
         if not os.path.isfile(os.path.join(cores_dir, so)):
             missing_bin.append("%s (%s)" % (cid, so))
-    license_id = {"ppsspp_gles": "ppsspp"}.get(cid, cid)
+    license_id = {
+        "ppsspp_gles": "ppsspp",
+        "flycast_standalone": "flycast",
+    }.get(cid, cid)
     if not os.path.isfile(os.path.join(lic_dir, license_id + ".txt")):
         missing_lic.append(cid)
 staged = sorted(f for f in os.listdir(cores_dir)
@@ -552,6 +557,12 @@ package_emulator() {
             package_dir="$MLP1_MUPEN64PLUS_PACKAGE"
             remote_name="mupen64plus"
             ;;
+        flycast)
+            [ -d "$FLYCAST_STANDALONE_DIR" ] || die "missing Flycast standalone repo: $FLYCAST_STANDALONE_DIR"
+            make -C "$FLYCAST_STANDALONE_DIR" package-mlp1 TOOLCHAIN_IMAGE="$TOOLCHAIN_IMAGE"
+            package_dir="$MLP1_FLYCAST_PACKAGE"
+            remote_name="flycast"
+            ;;
         *)
             die "unsupported release emulator policy: $emulator for DEVICE=$DEVICE"
             ;;
@@ -618,6 +629,13 @@ if not rel or not target.is_file():
 
 print(f"N64 standalone release gate: {rel}")
 PY
+}
+
+validate_standalone_flycast_release() {
+    local platform_dir="$RELEASE_ROOT/platforms/mlp1"
+    python3 "$LEAF_ROOT/scripts/validate-flycast-standalone-release.py" \
+        "$platform_dir" ||
+        die "Flycast standalone release validation failed"
 }
 
 write_install_readme() {
@@ -743,6 +761,7 @@ build_install_zip() {
         package_emulator "$emulator"
     done
     validate_standalone_n64_release
+    validate_standalone_flycast_release
     validate_ppsspp_vulkan_release
 
     cp -R "$LEAF_ROOT/stage/licenses" "$RELEASE_ROOT/licenses"

--- a/scripts/validate-flycast-standalone-release-test.py
+++ b/scripts/validate-flycast-standalone-release-test.py
@@ -94,8 +94,8 @@ def fixture(root: Path) -> Path:
         "systems": [
             {
                 "id": "DC",
-                "default_core": "flycast",
-                "alternate_cores": ["flycast_standalone"],
+                "default_core": "flycast_standalone",
+                "alternate_cores": ["flycast"],
             }
         ]
     }
@@ -186,6 +186,15 @@ def main() -> None:
         lambda platform: os.chmod(platform / "emulators/flycast/launch.sh", 0o644),
         False,
     )
+
+    def restore_retroarch_default(platform: Path) -> None:
+        path = platform / "defaults/systems.json"
+        data = json.loads(path.read_text(encoding="utf-8"))
+        data["systems"][0]["default_core"] = "flycast"
+        data["systems"][0]["alternate_cores"] = ["flycast_standalone"]
+        path.write_text(json.dumps(data), encoding="utf-8")
+
+    run_case("retroarch-default", restore_retroarch_default, False)
     print("Flycast standalone release policy checks passed")
 
 

--- a/scripts/validate-flycast-standalone-release-test.py
+++ b/scripts/validate-flycast-standalone-release-test.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Self-contained policy tests for the Flycast standalone release validator."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+VALIDATOR = SCRIPT_DIR / "validate-flycast-standalone-release.py"
+LICENSES = {
+    "Boost-Nowide-BSL-1.0.txt",
+    "Breakpad-BSD-3-Clause.txt",
+    "DreamPicoPort-MIT.txt",
+    "Flycast-GPL-2.0.txt",
+    "GLM-License.txt",
+    "THIRD-PARTY-NOTICES.txt",
+    "WebSocketpp-BSD-3-Clause.txt",
+    "Zstandard-BSD-3-Clause.txt",
+    "libchdr-BSD-3-Clause.txt",
+    "libjuice-MPL-2.0.txt",
+    "libusb-LGPL-2.1.txt",
+    "libzip-BSD-3-Clause.txt",
+    "miniupnpc-BSD-3-Clause.txt",
+    "picoTCP-GPL-2.0.txt",
+    "rcheevos-MIT.txt",
+    "xBRZ-GPL-3.0.txt",
+    "xxHash-BSD-2-Clause.txt",
+}
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def write_manifest(package: Path) -> None:
+    files = []
+    for path in sorted(package.rglob("*")):
+        if path.is_file() and path.name != "manifest.json":
+            files.append(
+                {
+                    "path": path.relative_to(package).as_posix(),
+                    "sha256": sha256(path),
+                }
+            )
+    manifest = {
+        "id": "flycast_standalone",
+        "platform": "mlp1",
+        "kind": "standalone-emulator",
+        "package_schema_version": 1,
+        "config_schema_version": 1,
+        "upstream_tag": "v2.6",
+        "upstream_sha": "392a429e8b040b3e5bf6696cb4f984274fc44123",
+        "dynamic_dependencies": ["libSDL2-2.0.so.0"],
+        "binary": "bin/flycast",
+        "binary_sha256": sha256(package / "bin/flycast"),
+        "files": files,
+    }
+    (package / "manifest.json").write_text(
+        json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def fixture(root: Path) -> Path:
+    platform = root / "platforms/mlp1"
+    package = platform / "emulators/flycast"
+    for directory in (
+        platform / "defaults",
+        package / "bin",
+        package / "defaults",
+        package / "licenses",
+        package / "provenance",
+    ):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    cores = {
+        "cores": [
+            {
+                "id": "flycast_standalone",
+                "type": "path",
+                "path": "emulators/flycast/launch.sh",
+                "requires_direct_drm": True,
+                "status": "packaged",
+            }
+        ]
+    }
+    systems = {
+        "systems": [
+            {
+                "id": "DC",
+                "default_core": "flycast",
+                "alternate_cores": ["flycast_standalone"],
+            }
+        ]
+    }
+    (platform / "defaults/cores.json").write_text(
+        json.dumps(cores), encoding="utf-8"
+    )
+    (platform / "defaults/systems.json").write_text(
+        json.dumps(systems), encoding="utf-8"
+    )
+
+    fake_aarch64_elf = bytearray(64)
+    fake_aarch64_elf[:7] = b"\x7fELF\x02\x01\x01"
+    fake_aarch64_elf[18:20] = (183).to_bytes(2, "little")
+    files = {
+        "bin/flycast": bytes(fake_aarch64_elf),
+        "launch.sh": b"#!/bin/sh\nexec \"$(dirname \"$0\")/bin/flycast\" \"$@\"\n",
+        "defaults/emu.cfg": b"[config]\npvr.rend = 0\n",
+        "defaults/config.version": b"1\n",
+        "defaults/SDL_Loong Gamepad.cfg": b"[emulator]\nmapping_name=Loong\n",
+        "provenance/build-manifest.json": b"{}\n",
+    }
+    for relative, content in files.items():
+        (package / relative).write_bytes(content)
+    for name in LICENSES:
+        (package / "licenses" / name).write_text(f"{name}\n", encoding="utf-8")
+    os.chmod(package / "bin/flycast", 0o755)
+    os.chmod(package / "launch.sh", 0o755)
+    write_manifest(package)
+    return platform
+
+
+def run_case(name: str, mutate, should_pass: bool) -> None:
+    with tempfile.TemporaryDirectory(prefix=f"leaf-flycast-{name}-") as temp:
+        platform = fixture(Path(temp))
+        mutate(platform)
+        result = subprocess.run(
+            [sys.executable, str(VALIDATOR), str(platform)],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        passed = result.returncode == 0
+        if passed != should_pass:
+            print(result.stdout, end="", file=sys.stderr)
+            print(result.stderr, end="", file=sys.stderr)
+            raise SystemExit(
+                f"{name}: validator {'passed' if passed else 'failed'}, "
+                f"expected {'pass' if should_pass else 'failure'}"
+            )
+
+
+def main() -> None:
+    run_case("valid", lambda platform: None, True)
+    run_case(
+        "corrupt-binary",
+        lambda platform: (platform / "emulators/flycast/bin/flycast").write_bytes(
+            b"corrupt\n"
+        ),
+        False,
+    )
+    run_case(
+        "missing-license",
+        lambda platform: (
+            platform / "emulators/flycast/licenses/THIRD-PARTY-NOTICES.txt"
+        ).unlink(),
+        False,
+    )
+
+    def add_mutable_content(platform: Path) -> None:
+        package = platform / "emulators/flycast"
+        mutable = package / "Saves/user-vmu.bin"
+        mutable.parent.mkdir()
+        mutable.write_bytes(b"user data")
+        write_manifest(package)
+
+    run_case("mutable-content", add_mutable_content, False)
+
+    def disable_direct_drm(platform: Path) -> None:
+        path = platform / "defaults/cores.json"
+        data = json.loads(path.read_text(encoding="utf-8"))
+        data["cores"][0]["requires_direct_drm"] = False
+        path.write_text(json.dumps(data), encoding="utf-8")
+
+    run_case("shared-drm-catalog", disable_direct_drm, False)
+    run_case(
+        "non-executable-launcher",
+        lambda platform: os.chmod(platform / "emulators/flycast/launch.sh", 0o644),
+        False,
+    )
+    print("Flycast standalone release policy checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate-flycast-standalone-release.py
+++ b/scripts/validate-flycast-standalone-release.py
@@ -110,9 +110,10 @@ def validate(platform_dir: Path) -> None:
     alternates = dc.get("alternate_cores")
     if not isinstance(alternates, list):
         fail("DC alternate_cores must be an array")
-    references = [dc.get("default_core"), *alternates]
-    if CORE_ID not in references:
-        fail("DC must expose flycast_standalone as a default or alternate")
+    if dc.get("default_core") != CORE_ID:
+        fail("DC must default to flycast_standalone")
+    if "flycast" not in alternates:
+        fail("DC must retain the RetroArch Flycast core as a fallback")
 
     core_rows = [row for row in cores if row.get("id") == CORE_ID]
     if len(core_rows) != 1:

--- a/scripts/validate-flycast-standalone-release.py
+++ b/scripts/validate-flycast-standalone-release.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Validate the standalone Flycast catalog entry and packaged MLP1 payload."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import sys
+from pathlib import Path, PurePosixPath
+
+
+CORE_ID = "flycast_standalone"
+CORE_PATH = "emulators/flycast/launch.sh"
+PACKAGE_REL = Path("emulators/flycast")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+REQUIRED_LICENSES = {
+    "Boost-Nowide-BSL-1.0.txt",
+    "Breakpad-BSD-3-Clause.txt",
+    "DreamPicoPort-MIT.txt",
+    "Flycast-GPL-2.0.txt",
+    "GLM-License.txt",
+    "THIRD-PARTY-NOTICES.txt",
+    "WebSocketpp-BSD-3-Clause.txt",
+    "Zstandard-BSD-3-Clause.txt",
+    "libchdr-BSD-3-Clause.txt",
+    "libjuice-MPL-2.0.txt",
+    "libusb-LGPL-2.1.txt",
+    "libzip-BSD-3-Clause.txt",
+    "miniupnpc-BSD-3-Clause.txt",
+    "picoTCP-GPL-2.0.txt",
+    "rcheevos-MIT.txt",
+    "xBRZ-GPL-3.0.txt",
+    "xxHash-BSD-2-Clause.txt",
+}
+FORBIDDEN_TOP_LEVEL = {
+    "bios",
+    "roms",
+    "saves",
+    "states",
+    "userdata",
+    ".userdata",
+}
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"error: {message}")
+
+
+def load_json(path: Path) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        fail(f"missing JSON file: {path}")
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        fail(f"invalid JSON file {path}: {exc}")
+
+
+def rows(data: object, key: str, path: Path) -> list[dict[str, object]]:
+    value = data.get(key) if isinstance(data, dict) else data
+    if not isinstance(value, list) or not all(isinstance(row, dict) for row in value):
+        fail(f"{path} must contain a {key} array")
+    return value
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def validate_aarch64_elf(path: Path) -> None:
+    try:
+        header = path.read_bytes()[:20]
+    except OSError as exc:
+        fail(f"could not read Flycast binary {path}: {exc}")
+    if (
+        len(header) < 20
+        or header[:4] != b"\x7fELF"
+        or header[4] != 2
+        or header[5] != 1
+        or int.from_bytes(header[18:20], "little") != 183
+    ):
+        fail(f"Flycast binary is not a little-endian AArch64 ELF: {path}")
+
+
+def safe_manifest_path(value: object) -> str:
+    if not isinstance(value, str) or not value or "\\" in value:
+        fail(f"invalid package manifest path: {value!r}")
+    path = PurePosixPath(value)
+    if path.is_absolute() or "." in path.parts or ".." in path.parts:
+        fail(f"unsafe package manifest path: {value}")
+    return value
+
+
+def validate(platform_dir: Path) -> None:
+    systems_path = platform_dir / "defaults/systems.json"
+    cores_path = platform_dir / "defaults/cores.json"
+    systems = rows(load_json(systems_path), "systems", systems_path)
+    cores = rows(load_json(cores_path), "cores", cores_path)
+
+    dc_rows = [row for row in systems if row.get("id") == "DC"]
+    if len(dc_rows) != 1:
+        fail("systems.json must contain exactly one DC system")
+    dc = dc_rows[0]
+    alternates = dc.get("alternate_cores")
+    if not isinstance(alternates, list):
+        fail("DC alternate_cores must be an array")
+    references = [dc.get("default_core"), *alternates]
+    if CORE_ID not in references:
+        fail("DC must expose flycast_standalone as a default or alternate")
+
+    core_rows = [row for row in cores if row.get("id") == CORE_ID]
+    if len(core_rows) != 1:
+        fail("cores.json must contain exactly one flycast_standalone entry")
+    core = core_rows[0]
+    if core.get("type") != "path":
+        fail("flycast_standalone must be a path core")
+    if core.get("path") != CORE_PATH:
+        fail(f"flycast_standalone path must be {CORE_PATH}")
+    if core.get("requires_direct_drm") is not True:
+        fail("flycast_standalone must require direct DRM")
+
+    launcher = platform_dir / CORE_PATH
+    if not launcher.is_file() or not os.access(launcher, os.X_OK):
+        fail(f"Flycast launcher is missing or not executable: {launcher}")
+
+    package_dir = platform_dir / PACKAGE_REL
+    binary = package_dir / "bin/flycast"
+    manifest_path = package_dir / "manifest.json"
+    config_version_path = package_dir / "defaults/config.version"
+    for required in (
+        binary,
+        package_dir / "launch.sh",
+        package_dir / "defaults/emu.cfg",
+        package_dir / "defaults/SDL_Loong Gamepad.cfg",
+        config_version_path,
+        package_dir / "provenance/build-manifest.json",
+        manifest_path,
+    ):
+        if not required.is_file():
+            fail(f"missing Flycast package file: {required}")
+    if not os.access(binary, os.X_OK):
+        fail(f"Flycast binary is not executable: {binary}")
+    validate_aarch64_elf(binary)
+
+    for path in package_dir.rglob("*"):
+        if path.is_symlink():
+            fail(f"Flycast package is not FAT32-safe; symlink found: {path}")
+        relative = path.relative_to(package_dir)
+        if relative.parts and relative.parts[0].casefold() in FORBIDDEN_TOP_LEVEL:
+            fail(f"mutable/user content found in Flycast package: {relative}")
+        if path.name in {"flycast.log", "emu.cfg.save"}:
+            fail(f"mutable/user file found in Flycast package: {relative}")
+
+    license_dir = package_dir / "licenses"
+    missing_licenses = sorted(
+        name for name in REQUIRED_LICENSES if not (license_dir / name).is_file()
+    )
+    if missing_licenses:
+        fail("missing Flycast license notices: " + ", ".join(missing_licenses))
+
+    manifest = load_json(manifest_path)
+    if not isinstance(manifest, dict):
+        fail("Flycast manifest must be a JSON object")
+    expected_fields = {
+        "id": CORE_ID,
+        "platform": "mlp1",
+        "kind": "standalone-emulator",
+        "package_schema_version": 1,
+    }
+    for key, expected in expected_fields.items():
+        if manifest.get(key) != expected:
+            fail(f"Flycast manifest {key} must be {expected!r}")
+    if not isinstance(manifest.get("config_schema_version"), int):
+        fail("Flycast manifest config_schema_version must be an integer")
+    try:
+        config_version = int(config_version_path.read_text(encoding="utf-8").strip())
+    except (OSError, UnicodeError, ValueError) as exc:
+        fail(f"invalid Flycast config version: {exc}")
+    if manifest["config_schema_version"] != config_version:
+        fail("Flycast manifest config schema does not match defaults/config.version")
+    if not isinstance(manifest.get("upstream_tag"), str) or not manifest["upstream_tag"]:
+        fail("Flycast manifest must record an upstream tag")
+    if not isinstance(manifest.get("upstream_sha"), str) or not GIT_SHA_RE.fullmatch(
+        manifest["upstream_sha"]
+    ):
+        fail("Flycast manifest must record a full lowercase upstream SHA")
+    dependencies = manifest.get("dynamic_dependencies")
+    if not isinstance(dependencies, list) or not dependencies or not all(
+        isinstance(item, str) and item for item in dependencies
+    ):
+        fail("Flycast manifest must record dynamic dependencies")
+
+    file_rows = manifest.get("files")
+    if not isinstance(file_rows, list) or not file_rows:
+        fail("Flycast manifest must contain a non-empty files array")
+    expected_files: dict[str, str] = {}
+    for row in file_rows:
+        if not isinstance(row, dict):
+            fail("Flycast manifest file rows must be objects")
+        relative = safe_manifest_path(row.get("path"))
+        expected_sha = row.get("sha256")
+        if not isinstance(expected_sha, str) or not SHA256_RE.fullmatch(expected_sha):
+            fail(f"invalid checksum for Flycast package path: {relative}")
+        if relative == "manifest.json" or relative in expected_files:
+            fail(f"duplicate or self-referential Flycast manifest path: {relative}")
+        expected_files[relative] = expected_sha
+
+    actual_files = {
+        path.relative_to(package_dir).as_posix()
+        for path in package_dir.rglob("*")
+        if path.is_file() and path != manifest_path
+    }
+    if set(expected_files) != actual_files:
+        missing = sorted(actual_files - set(expected_files))
+        extra = sorted(set(expected_files) - actual_files)
+        fail(f"Flycast manifest inventory mismatch; unlisted={missing}, missing={extra}")
+    for relative, expected_sha in expected_files.items():
+        actual_sha = sha256(package_dir / relative)
+        if actual_sha != expected_sha:
+            fail(f"Flycast package checksum mismatch: {relative}")
+
+    binary_sha = sha256(binary)
+    if manifest.get("binary") != "bin/flycast":
+        fail("Flycast manifest binary path must be bin/flycast")
+    if manifest.get("binary_sha256") != binary_sha:
+        fail("Flycast manifest binary checksum does not match bin/flycast")
+
+    print(
+        "Flycast standalone release gate: "
+        f"{CORE_PATH}, {len(expected_files)} checksummed files, binary {binary_sha}"
+    )
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit(f"usage: {Path(sys.argv[0]).name} <mlp1-platform-dir>")
+    platform_dir = Path(sys.argv[1])
+    if not platform_dir.is_dir():
+        fail(f"missing MLP1 platform directory: {platform_dir}")
+    validate(platform_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/stage/common.mk
+++ b/stage/common.mk
@@ -21,6 +21,7 @@ CENTRAL_SCRUTINIZER_DIR ?= $(WORKSPACE_DIR)/CentralScrutinizer
 PPSSPP_SPRUCE_DIR     ?= $(WORKSPACE_DIR)/PPSSPP-spruce
 STEWARD_NDS_DIR        ?= $(WORKSPACE_DIR)/steward-fu-nds
 N64_STANDALONE_DIR     ?= $(WORKSPACE_DIR)/N64-standalone
+FLYCAST_STANDALONE_DIR ?= $(WORKSPACE_DIR)/Flycast-standalone
 RETROARCH_BUILDS_DIR   ?= $(WORKSPACE_DIR)/retroarch-builds
 CORES_SPRUCE_DIR       ?= $(WORKSPACE_DIR)/Cores-spruce
 TOOLCHAIN_DIR          ?= $(WORKSPACE_DIR)/mlp1-toolchain
@@ -30,7 +31,7 @@ LAUNCHER_SWITCHER_DIR  ?= $(WORKSPACE_DIR)/miniloong-launcher-switcher
 TOOLCHAIN_IMAGE ?= ghcr.io/utility-muffin-research-kitchen/mlp1-toolchain:local
 
 # Public sibling repos required for contributor build/stage workflows.
-REQUIRED_REPOS := Catastrophe Jawaka Thing-File ssh-server CentralScrutinizer Fugazi joes-calibrage PPSSPP-spruce steward-fu-nds N64-standalone \
+REQUIRED_REPOS := Catastrophe Jawaka Thing-File ssh-server CentralScrutinizer Fugazi joes-calibrage PPSSPP-spruce steward-fu-nds N64-standalone Flycast-standalone \
                   retroarch-builds Cores-spruce mlp1-toolchain miniloong-launcher-switcher \
                   miniloong-adb-keeper
 

--- a/stage/licenses/CORES.md
+++ b/stage/licenses/CORES.md
@@ -27,6 +27,7 @@ from the named upstream release asset.
 | fbneo | FB Neo (non-commercial) | https://github.com/libretro/FBNeo |
 | fceumm | GPL-2.0 | https://github.com/libretro/libretro-fceumm |
 | flycast | GPL-2.0 | https://github.com/flyinghead/flycast |
+| flycast_standalone (standalone) | GPL-2.0 / bundled third-party notices | https://github.com/flyinghead/flycast |
 | gambatte | GPL-2.0 | https://github.com/libretro/gambatte-libretro |
 | genesis_plus_gx | Genesis Plus GX (non-commercial) | https://github.com/libretro/Genesis-Plus-GX |
 | gpsp | GPL-2.0 | https://github.com/libretro/gpsp/tree/69e86ebe89f14c3f5f75b809c12c0a953b3d6ce4 |

--- a/stage/mlp1.mk
+++ b/stage/mlp1.mk
@@ -3,7 +3,7 @@
 
 # Apps staged by `make stage`.
 STAGE_APPS ?= ssh-server Thing-File CentralScrutinizer Fugazi joes-calibrage retroarch-builds
-STAGE_EMULATORS ?= ppsspp drastic mupen64plus
+STAGE_EMULATORS ?= ppsspp drastic mupen64plus flycast
 PUBLIC_ROOT_DIRS ?= Roms Images Apps BIOS Saves States Cheats
 
 # --- Launcher payload assembly inputs --------------------------------------
@@ -23,6 +23,7 @@ MLP1_GRAPHICS_RUNTIME ?= $(LEAF_ROOT)/build/mlp1/runtime/graphics
 MLP1_VULKAN_RUNTIME ?= $(MLP1_GRAPHICS_RUNTIME)/vulkan/rk3566-g52-g29p1
 MLP1_DRASTIC_PACKAGE ?= $(LEAF_ROOT)/build/drastic/mlp1/drastic
 MLP1_MUPEN64PLUS_PACKAGE ?= $(N64_STANDALONE_DIR)/output/mlp1/mupen64plus
+MLP1_FLYCAST_PACKAGE ?= $(FLYCAST_STANDALONE_DIR)/output/mlp1/flycast
 MLP1_RETROARCH_PATCH_SET ?= portrait-rotation,command-menu,jawaka-load-content,controller-bindings
 UMRK_ENV_SCRIPT    ?= $(LAUNCHER_SWITCHER_DIR)/device/umrk-env.sh
 REMOTE_SDCARD_PATH ?= auto
@@ -239,6 +240,12 @@ stage-emulator:
 			package_dir="$(MLP1_MUPEN64PLUS_PACKAGE)"; \
 			remote_name="mupen64plus"; \
 			;; \
+		flycast) \
+			test -d "$(FLYCAST_STANDALONE_DIR)" || { echo "missing repo: $(FLYCAST_STANDALONE_DIR)" >&2; exit 1; }; \
+			$(MAKE) -C "$(FLYCAST_STANDALONE_DIR)" package-mlp1 TOOLCHAIN_IMAGE="$(TOOLCHAIN_IMAGE)"; \
+			package_dir="$(MLP1_FLYCAST_PACKAGE)"; \
+			remote_name="flycast"; \
+			;; \
 		*) \
 			echo "unsupported emulator policy: $(EMULATOR) for DEVICE=$(DEVICE)" >&2; \
 			exit 1; \
@@ -356,6 +363,7 @@ release-zips:
 	PPSSPP_SPRUCE_DIR="$(PPSSPP_SPRUCE_DIR)" \
 	STEWARD_NDS_DIR="$(STEWARD_NDS_DIR)" \
 	N64_STANDALONE_DIR="$(N64_STANDALONE_DIR)" \
+	FLYCAST_STANDALONE_DIR="$(FLYCAST_STANDALONE_DIR)" \
 	RETROARCH_BUILDS_DIR="$(RETROARCH_BUILDS_DIR)" \
 	CORES_SPRUCE_DIR="$(CORES_SPRUCE_DIR)" \
 	LAUNCHER_SWITCHER_DIR="$(LAUNCHER_SWITCHER_DIR)" \
@@ -369,6 +377,7 @@ release-zips:
 	MLP1_VULKAN_RUNTIME="$(MLP1_VULKAN_RUNTIME)" \
 	MLP1_DRASTIC_PACKAGE="$(MLP1_DRASTIC_PACKAGE)" \
 	MLP1_MUPEN64PLUS_PACKAGE="$(MLP1_MUPEN64PLUS_PACKAGE)" \
+	MLP1_FLYCAST_PACKAGE="$(MLP1_FLYCAST_PACKAGE)" \
 	MLP1_RETROARCH_PATCH_SET="$(MLP1_RETROARCH_PATCH_SET)" \
 	"$(LEAF_ROOT)/scripts/make-sd-release-zip.sh" both
 
@@ -384,6 +393,7 @@ release-sd-zip:
 	PPSSPP_SPRUCE_DIR="$(PPSSPP_SPRUCE_DIR)" \
 	STEWARD_NDS_DIR="$(STEWARD_NDS_DIR)" \
 	N64_STANDALONE_DIR="$(N64_STANDALONE_DIR)" \
+	FLYCAST_STANDALONE_DIR="$(FLYCAST_STANDALONE_DIR)" \
 	RETROARCH_BUILDS_DIR="$(RETROARCH_BUILDS_DIR)" \
 	CORES_SPRUCE_DIR="$(CORES_SPRUCE_DIR)" \
 	LAUNCHER_SWITCHER_DIR="$(LAUNCHER_SWITCHER_DIR)" \
@@ -397,6 +407,7 @@ release-sd-zip:
 	MLP1_VULKAN_RUNTIME="$(MLP1_VULKAN_RUNTIME)" \
 	MLP1_DRASTIC_PACKAGE="$(MLP1_DRASTIC_PACKAGE)" \
 	MLP1_MUPEN64PLUS_PACKAGE="$(MLP1_MUPEN64PLUS_PACKAGE)" \
+	MLP1_FLYCAST_PACKAGE="$(MLP1_FLYCAST_PACKAGE)" \
 	MLP1_RETROARCH_PATCH_SET="$(MLP1_RETROARCH_PATCH_SET)" \
 	"$(LEAF_ROOT)/scripts/make-sd-release-zip.sh" install
 


### PR DESCRIPTION
## What changed

- Register the standalone Flycast sibling repository in Leaf bootstrap/staging.
- Add `stage-emulator EMULATOR=flycast`, include Flycast in staged emulator sets, and package it into MLP1 releases.
- Add Flycast license ownership and an independent release validator for package integrity, ABI, source provenance, dependencies, immutable contents, and notices.
- Require Dreamcast to default to `flycast_standalone` while retaining RetroArch Flycast as a fallback.

## Why

The performant device-tested Flycast build needs a reproducible Leaf-owned path from sibling checkout through staging and release assembly. The catalog default must not be allowed to point at a missing or malformed standalone package.

## Validation

- `python3 scripts/validate-flycast-standalone-release-test.py` passes, including deliberate package-policy failures and a regression fixture that restores RetroArch as the default.
- Reproducible MLP1 Flycast package verification passes with 33 files.
- `make stage-emulator EMULATOR=flycast DEVICE=mlp1` rebuilt, packaged, validated, and deployed the pinned v2.6 binary.
- Device binary SHA-256 matches `c3a20c13d605660cab12e4bd9a9f1f955be202dd173d9514692c5c36eff22352`.
- Device defaults were refreshed and verified after launcher reboot.

## Dependencies

Merge with the corresponding Flycast-standalone, Jawaka, and miniloong-launcher-switcher PRs. No release tag is included.
