### PR TITLE
Enforce Pak Rat Leaf-version compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ LARGE_LIBRARY_FIXTURE_ENV = \
 	REMOTE_SDCARD_PATH="$(REMOTE_SDCARD_PATH)"
 
 .DEFAULT_GOAL := help
-.PHONY: help bootstrap doctor status status-internal pakrat-local-feed-test flycast-release-policy-smoke adb-enable-marker adb-disable-marker adb-tail-logs adb-large-library-create adb-large-library-clean adb-large-library-status adb-install-wrapper adb-uninstall-wrapper benchmark-ppsspp
+.PHONY: help bootstrap doctor status status-internal pakrat-local-feed-test leaf-release-policy-test flycast-release-policy-smoke adb-enable-marker adb-disable-marker adb-tail-logs adb-large-library-create adb-large-library-clean adb-large-library-status adb-install-wrapper adb-uninstall-wrapper benchmark-ppsspp
 
 help:
 	@echo "Leaf workspace commands (DEVICE=$(DEVICE), WORKSPACE_DIR=$(WORKSPACE_DIR)):"
@@ -49,6 +49,7 @@ help:
 	@echo "  make release-sd-zip DEVICE=mlp1           build end-user install ZIP"
 	@echo "  make release-recovery-zip DEVICE=mlp1     build end-user recovery ZIP"
 	@echo "  make pakrat-local-feed-test               test multi-app and exact-artifact local feeds"
+	@echo "  make leaf-release-policy-test             test stable identity, provenance, and candidate gates"
 	@echo "  make flycast-release-policy-smoke         test standalone Flycast release gates"
 	@echo "  make adb-enable-marker                    enable Leaf launcher marker"
 	@echo "  make adb-disable-marker                   disable Leaf launcher marker"
@@ -97,6 +98,9 @@ status-internal:
 
 pakrat-local-feed-test:
 	python3 scripts/pakrat-local-feed-test.py
+
+leaf-release-policy-test:
+	python3 scripts/validate-leaf-release-test.py
 
 adb-enable-marker:
 	scripts/adb-set-marker.sh on

--- a/README.md
+++ b/README.md
@@ -159,6 +159,25 @@ choose it explicitly:
 make release-zips DEVICE=mlp1 RELEASE_ID=2026-06-05-test1
 ```
 
+Stable release builds deliberately keep the filesystem/build identity separate
+from the compatibility version. They require an explicit semantic version and
+matching Git tag:
+
+```sh
+make release-zips DEVICE=mlp1 \
+  RELEASE_ID=2026-07-20-gabc1234 \
+  LEAF_RELEASE_CHANNEL=stable \
+  LEAF_RELEASE_VERSION=0.7.0 \
+  LEAF_RELEASE_TAG=v0.7.0
+```
+
+The build fails before packaging if those values disagree, or if Leaf, the
+launcher, the launcher switcher, Catastrophe, or a bundled app has uncommitted
+changes. Exact component commits are recorded inside the release at
+`provenance/components.json`. Unqualified local builds use the `dev` channel;
+their version may fall back to `RELEASE_ID`. Stable output is only selected
+when `LEAF_RELEASE_CHANNEL=stable` is passed with the version and tag above.
+
 The install ZIP is extracted directly to the SD-card root. It must not be
 placed inside another folder. The SD card should be FAT32 or ext4; do not use
 exFAT because the MLP1 stock update path ignores exFAT media.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ changes. Exact component commits are recorded inside the release at
 `provenance/components.json`. Unqualified local builds use the `dev` channel;
 their version may fall back to `RELEASE_ID`. Stable output is only selected
 when `LEAF_RELEASE_CHANNEL=stable` is passed with the version and tag above.
+Beta-channel manifests link to the tester release in `Leaf-beta`; other
+channels default to the main Leaf repository. `LEAF_RELEASE_REPOSITORY` can
+override the target for an intentional alternate release host.
 
 The install ZIP is extracted directly to the SD-card root. It must not be
 placed inside another folder. The SD card should be FAT32 or ext4; do not use

--- a/scripts/make-sd-release-zip.sh
+++ b/scripts/make-sd-release-zip.sh
@@ -106,6 +106,12 @@ LEAF_RELEASE_TAG="${LEAF_RELEASE_TAG:-}"
 if [ -z "$LEAF_RELEASE_TAG" ] && [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
     LEAF_RELEASE_TAG="${GITHUB_REF_NAME:-}"
 fi
+if [ "$LEAF_RELEASE_CHANNEL" = "beta" ]; then
+    DEFAULT_RELEASE_REPOSITORY="Utility-Muffin-Research-Kitchen/Leaf-beta"
+else
+    DEFAULT_RELEASE_REPOSITORY="Utility-Muffin-Research-Kitchen/Leaf"
+fi
+LEAF_RELEASE_REPOSITORY="${LEAF_RELEASE_REPOSITORY:-$DEFAULT_RELEASE_REPOSITORY}"
 RELEASE_POLICY_TOOL="$LEAF_ROOT/scripts/validate-leaf-release.py"
 PROVENANCE_PREFLIGHT="$RELEASE_BUILD/.components-$RELEASE_ID.preflight.json"
 RELEASE_COMPONENT_ARGS=()
@@ -298,6 +304,7 @@ write_release_manifest() {
 
     validate_json_scalar "LEAF_RELEASE_VERSION" "$LEAF_RELEASE_VERSION"
     validate_json_scalar "LEAF_RELEASE_CHANNEL" "$LEAF_RELEASE_CHANNEL"
+    validate_json_scalar "LEAF_RELEASE_REPOSITORY" "$LEAF_RELEASE_REPOSITORY"
     validate_json_scalar "RELEASE_ID" "$RELEASE_ID"
 
     local install_name recovery_name published_at install_size install_installed_size install_sha release_url_ref
@@ -359,7 +366,7 @@ EOF
   },
   "notes": {
     "summary": "Leaf $RELEASE_ID",
-    "url": "https://github.com/Utility-Muffin-Research-Kitchen/Leaf/releases/tag/$release_url_ref"
+    "url": "https://github.com/$LEAF_RELEASE_REPOSITORY/releases/tag/$release_url_ref"
   }
 }
 EOF

--- a/scripts/make-sd-release-zip.sh
+++ b/scripts/make-sd-release-zip.sh
@@ -97,8 +97,19 @@ INSTALL_ZIP="$RELEASE_BUILD/leaf-mlp1-sd-$RELEASE_ID.zip"
 RECOVERY_ZIP="$RELEASE_BUILD/leaf-mlp1-recovery-$RELEASE_ID.zip"
 UPDATE_MANIFEST="$RELEASE_BUILD/leaf-update.json"
 SHA256SUMS_FILE="$RELEASE_BUILD/SHA256SUMS"
-LEAF_RELEASE_VERSION="${LEAF_RELEASE_VERSION:-${VERSION:-$RELEASE_ID}}"
-LEAF_RELEASE_CHANNEL="${LEAF_RELEASE_CHANNEL:-stable}"
+LEAF_RELEASE_CHANNEL="${LEAF_RELEASE_CHANNEL:-dev}"
+LEAF_RELEASE_VERSION="${LEAF_RELEASE_VERSION:-${VERSION:-}}"
+if [ -z "$LEAF_RELEASE_VERSION" ] && [ "$LEAF_RELEASE_CHANNEL" != "stable" ]; then
+    LEAF_RELEASE_VERSION="$RELEASE_ID"
+fi
+LEAF_RELEASE_TAG="${LEAF_RELEASE_TAG:-}"
+if [ -z "$LEAF_RELEASE_TAG" ] && [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+    LEAF_RELEASE_TAG="${GITHUB_REF_NAME:-}"
+fi
+RELEASE_POLICY_TOOL="$LEAF_ROOT/scripts/validate-leaf-release.py"
+PROVENANCE_PREFLIGHT="$RELEASE_BUILD/.components-$RELEASE_ID.preflight.json"
+RELEASE_COMPONENT_ARGS=()
+REQUIRED_COMPONENT_ARGS=()
 BUILT_INSTALL=0
 BUILT_RECOVERY=0
 
@@ -108,6 +119,76 @@ validate_json_scalar() {
     case "$value" in
         *'"'*|*\\*|*$'\n'*|*$'\r'*)
             die "$name contains characters unsupported by release metadata: $value"
+            ;;
+    esac
+}
+
+configure_release_components() {
+    local app
+    RELEASE_COMPONENT_ARGS=(
+        --component "leaf=$LEAF_ROOT"
+        --component "catastrophe=$CATASTROPHE_DIR"
+        --component "launcher=$JAWAKA_DIR"
+        --component "launcher-switcher=$LAUNCHER_SWITCHER_DIR"
+    )
+    REQUIRED_COMPONENT_ARGS=(
+        --required-component "leaf"
+        --required-component "catastrophe"
+        --required-component "launcher"
+        --required-component "launcher-switcher"
+    )
+    for app in $STAGE_APPS; do
+        RELEASE_COMPONENT_ARGS+=(--component "app:$app=$WORKSPACE_DIR/$app")
+        REQUIRED_COMPONENT_ARGS+=(--required-component "app:$app")
+    done
+}
+
+write_component_provenance() {
+    local output="$1"
+    local clean_args=()
+    if [ "$LEAF_RELEASE_CHANNEL" = "stable" ]; then
+        clean_args+=(--require-clean)
+    fi
+    python3 "$RELEASE_POLICY_TOOL" provenance \
+        --channel "$LEAF_RELEASE_CHANNEL" \
+        --version "$LEAF_RELEASE_VERSION" \
+        --tag "$LEAF_RELEASE_TAG" \
+        --release-id "$RELEASE_ID" \
+        "${clean_args[@]}" \
+        "${RELEASE_COMPONENT_ARGS[@]}" \
+        --output "$output"
+}
+
+prepare_release_policy() {
+    [ "$MODE" = "recovery" ] && return 0
+    [ -f "$RELEASE_POLICY_TOOL" ] || die "missing Leaf release policy tool: $RELEASE_POLICY_TOOL"
+    python3 "$RELEASE_POLICY_TOOL" identity \
+        --channel "$LEAF_RELEASE_CHANNEL" \
+        --version "$LEAF_RELEASE_VERSION" \
+        --tag "$LEAF_RELEASE_TAG" \
+        --release-id "$RELEASE_ID"
+    configure_release_components
+    write_component_provenance "$PROVENANCE_PREFLIGHT"
+}
+
+finalize_component_provenance() {
+    local provenance_dir="$RELEASE_ROOT/provenance"
+    local final="$provenance_dir/components.json"
+    local candidate="$provenance_dir/components.json.candidate"
+    mkdir -p "$provenance_dir"
+    write_component_provenance "$candidate"
+    cmp -s "$PROVENANCE_PREFLIGHT" "$candidate" || \
+        die "release component revisions or worktree state changed during assembly"
+    mv "$candidate" "$final"
+    echo "Wrote $final"
+}
+
+validate_configured_source_consumers() {
+    case " $STAGE_APPS " in
+        *" CentralScrutinizer "*)
+            echo "Validating bundled configured-source consumer"
+            make -C "$WORKSPACE_DIR/CentralScrutinizer" \
+                test-native TEST=tests/native/test_paths.c
             ;;
     esac
 }
@@ -219,12 +300,13 @@ write_release_manifest() {
     validate_json_scalar "LEAF_RELEASE_CHANNEL" "$LEAF_RELEASE_CHANNEL"
     validate_json_scalar "RELEASE_ID" "$RELEASE_ID"
 
-    local install_name recovery_name published_at install_size install_installed_size install_sha
+    local install_name recovery_name published_at install_size install_installed_size install_sha release_url_ref
     install_name="$(basename "$INSTALL_ZIP")"
     install_size="$(file_size "$INSTALL_ZIP")"
     install_installed_size="$(tree_size "$INSTALL_STAGE")"
     install_sha="$(file_sha256 "$INSTALL_ZIP")"
     published_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    release_url_ref="${LEAF_RELEASE_TAG:-$RELEASE_ID}"
 
     {
         cat <<EOF
@@ -277,7 +359,7 @@ EOF
   },
   "notes": {
     "summary": "Leaf $RELEASE_ID",
-    "url": "https://github.com/Utility-Muffin-Research-Kitchen/Leaf/releases/tag/$RELEASE_ID"
+    "url": "https://github.com/Utility-Muffin-Research-Kitchen/Leaf/releases/tag/$release_url_ref"
   }
 }
 EOF
@@ -729,6 +811,7 @@ zip_stage() {
 
 build_install_zip() {
     echo "Building Leaf MLP1 install ZIP release=$RELEASE_ID"
+    validate_configured_source_consumers
     build_missing_platform_bits
 
     make -C "$LEAF_ROOT" \
@@ -775,15 +858,28 @@ build_install_zip() {
     validate_pakrat_owned_apps "$RELEASE_ROOT"
     validate_portmaster_integration "$RELEASE_ROOT"
     audit_mlp1_build_tuning "$RELEASE_ROOT"
+    finalize_component_provenance
 
+    local release_version_args=()
+    if [ "$LEAF_RELEASE_CHANNEL" = "stable" ] || \
+            [ "$LEAF_RELEASE_VERSION" != "$RELEASE_ID" ]; then
+        release_version_args+=(--release-version "$LEAF_RELEASE_VERSION")
+    fi
     python3 "$LAUNCHER_SWITCHER_DIR/make_launcher_switcher_sd.py" \
         --force \
         --mode managed-install \
         --release-id "$RELEASE_ID" \
+        "${release_version_args[@]}" \
         --no-require-adb-pinned \
         --completion-action reboot \
         "$INSTALL_STAGE"
 
+    python3 "$RELEASE_POLICY_TOOL" candidate \
+        --release-root "$RELEASE_ROOT" \
+        --install-stage "$INSTALL_STAGE" \
+        --version "$LEAF_RELEASE_VERSION" \
+        --release-id "$RELEASE_ID" \
+        "${REQUIRED_COMPONENT_ARGS[@]}"
     validate_install_stage_clean "$INSTALL_STAGE"
     write_install_readme
     zip_stage "$INSTALL_STAGE" "$INSTALL_ZIP"
@@ -807,6 +903,7 @@ build_recovery_zip() {
 }
 
 mkdir -p "$RELEASE_BUILD"
+prepare_release_policy
 
 case "$MODE" in
     both)

--- a/scripts/pakrat-local-feed-test.py
+++ b/scripts/pakrat-local-feed-test.py
@@ -19,6 +19,7 @@ import zipfile
 LEAF_ROOT = Path(__file__).resolve().parent.parent
 SCRIPT = LEAF_ROOT / "scripts" / "pakrat-local-feed.py"
 OUTPUT_BASE = LEAF_ROOT / "build" / "pakrat-local"
+MATCH_METADATA = object()
 
 
 class LocalFeedTest(unittest.TestCase):
@@ -38,21 +39,27 @@ class LocalFeedTest(unittest.TestCase):
         install_name: str,
         artifact_name: str,
         version: str = "1.0.0",
+        min_leaf_version: str | None = None,
+        runtime_min_leaf_version: str | None | object = MATCH_METADATA,
     ) -> Path:
         app_dir = self.apps_root / directory
         package_dir = app_dir / "build" / "mlp1" / "package" / install_name
         package_dir.mkdir(parents=True)
+        runtime = {
+            "name": directory,
+            "icon": "res/icon.png",
+            "platform": "mlp1",
+            "pak_version": version,
+        }
+        runtime_minimum = (
+            min_leaf_version
+            if runtime_min_leaf_version is MATCH_METADATA
+            else runtime_min_leaf_version
+        )
+        if runtime_minimum is not None:
+            runtime["min_leaf_version"] = runtime_minimum
         (package_dir / "pak.json").write_text(
-            json.dumps(
-                {
-                    "name": directory,
-                    "icon": "res/icon.png",
-                    "platform": "mlp1",
-                    "pak_version": version,
-                }
-            )
-            + "\n",
-            encoding="utf-8",
+            json.dumps(runtime) + "\n", encoding="utf-8"
         )
         (package_dir / "payload.bin").write_bytes(f"payload-{app_id}".encode())
         metadata = {
@@ -78,10 +85,50 @@ class LocalFeedTest(unittest.TestCase):
                 ]
             },
         }
+        if min_leaf_version is not None:
+            metadata["leaf"]["packages"][0]["min_leaf_version"] = min_leaf_version
         (app_dir / "pakrat.json").write_text(
             json.dumps(metadata, indent=2) + "\n", encoding="utf-8"
         )
         return app_dir
+
+    def update_app(
+        self,
+        app_dir: Path,
+        version: str,
+        min_leaf_version: str | None,
+        *,
+        runtime_min_leaf_version: str | None | object = MATCH_METADATA,
+        payload: bytes | None = None,
+    ) -> None:
+        metadata_path = app_dir / "pakrat.json"
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        package = metadata["leaf"]["packages"][0]
+        package["version"] = version
+        if min_leaf_version is None:
+            package.pop("min_leaf_version", None)
+        else:
+            package["min_leaf_version"] = min_leaf_version
+        metadata_path.write_text(
+            json.dumps(metadata, indent=2) + "\n", encoding="utf-8"
+        )
+
+        package_dir = app_dir / package["package_dir"]
+        runtime_path = package_dir / package["runtime_manifest_path"]
+        runtime = json.loads(runtime_path.read_text(encoding="utf-8"))
+        runtime["pak_version"] = version
+        runtime_minimum = (
+            min_leaf_version
+            if runtime_min_leaf_version is MATCH_METADATA
+            else runtime_min_leaf_version
+        )
+        if runtime_minimum is None:
+            runtime.pop("min_leaf_version", None)
+        else:
+            runtime["min_leaf_version"] = runtime_minimum
+        runtime_path.write_text(json.dumps(runtime) + "\n", encoding="utf-8")
+        if payload is not None:
+            (package_dir / "payload.bin").write_bytes(payload)
 
     def run_feed(
         self,
@@ -130,8 +177,17 @@ class LocalFeedTest(unittest.TestCase):
         )
         for app in catalog["apps"]:
             artifact = app["packages"][0]["artifact"]
+            package = app["packages"][0]
+            self.assertEqual(package["version"], "1.0.0")
+            self.assertEqual(package["versions"][0]["version"], "1.0.0")
             artifact_path = (
-                self.output / "pakrat" / "v1" / "artifacts" / artifact["name"]
+                self.output
+                / "pakrat"
+                / "v1"
+                / "artifacts"
+                / app["id"]
+                / "1.0.0"
+                / artifact["name"]
             )
             self.assertTrue(artifact_path.is_file())
             self.assertEqual(artifact["size"], artifact_path.stat().st_size)
@@ -179,10 +235,209 @@ class LocalFeedTest(unittest.TestCase):
             "--artifact",
             f"org.example.exact={exact}",
         )
-        copied = self.output / "pakrat" / "v1" / "artifacts" / exact.name
+        copied = (
+            self.output
+            / "pakrat"
+            / "v1"
+            / "artifacts"
+            / "org.example.exact"
+            / "1.0.0"
+            / exact.name
+        )
         self.assertEqual(copied.read_bytes(), exact.read_bytes())
         package = self.catalog()["apps"][0]["packages"][0]
         self.assertEqual(package["artifact"]["installed_size"], len(runtime) + len(payload))
+
+    def test_gated_version_requires_ungated_history(self) -> None:
+        app = self.write_app(
+            "Gated",
+            "org.example.gated",
+            "Gated.pak",
+            "Gated.pak.zip",
+            version="2.0.0",
+            min_leaf_version="0.7.0",
+        )
+        result = self.run_feed([app], expected_ok=False)
+        self.assertIn("requires explicit history with an ungated safe floor", result.stderr)
+
+    def test_repeated_generation_merges_history_and_pins_safe_floor(self) -> None:
+        app = self.write_app(
+            "History",
+            "org.example.history",
+            "History.pak",
+            "History.pak.zip",
+        )
+        self.run_feed([app])
+        floor_path = (
+            self.output
+            / "pakrat"
+            / "v1"
+            / "artifacts"
+            / "org.example.history"
+            / "1.0.0"
+            / "History.pak.zip"
+        )
+        floor_bytes = floor_path.read_bytes()
+
+        self.update_app(
+            app,
+            "2.0.0",
+            "0.7.0",
+            payload=b"new-version-payload",
+        )
+        self.run_feed([app])
+        catalog = self.catalog()
+        catalog_app = catalog["apps"][0]
+        package = catalog_app["packages"][0]
+        self.assertEqual(catalog_app["version"], "1.0.0")
+        self.assertEqual(package["version"], "1.0.0")
+        self.assertEqual(
+            [entry["version"] for entry in package["versions"]],
+            ["2.0.0", "1.0.0"],
+        )
+        self.assertEqual(package["versions"][0]["min_leaf_version"], "0.7.0")
+        self.assertEqual(package["artifact"], package["versions"][1]["artifact"])
+        self.assertEqual(floor_path.read_bytes(), floor_bytes)
+        self.assertTrue(
+            (
+                self.output
+                / "pakrat"
+                / "v1"
+                / "artifacts"
+                / "org.example.history"
+                / "2.0.0"
+                / "History.pak.zip"
+            ).is_file()
+        )
+
+    def test_explicit_history_materializes_prior_artifact(self) -> None:
+        app = self.write_app(
+            "Explicit",
+            "org.example.explicit",
+            "Explicit.pak",
+            "Explicit.pak.zip",
+        )
+        self.run_feed([app])
+        history_root = self.apps_root / "history-feed"
+        shutil.copytree(self.output / "pakrat" / "v1", history_root)
+        shutil.rmtree(self.output)
+
+        self.update_app(app, "2.0.0", "0.7.0", payload=b"explicit-new")
+        self.run_feed(
+            [app],
+            "--history",
+            str(history_root / "storefront.json"),
+        )
+        package = self.catalog()["apps"][0]["packages"][0]
+        self.assertEqual(
+            [entry["version"] for entry in package["versions"]],
+            ["2.0.0", "1.0.0"],
+        )
+        self.assertTrue(
+            (
+                self.output
+                / "pakrat"
+                / "v1"
+                / "artifacts"
+                / "org.example.explicit"
+                / "1.0.0"
+                / "Explicit.pak.zip"
+            ).is_file()
+        )
+
+    def test_published_version_facts_are_immutable(self) -> None:
+        app = self.write_app(
+            "Immutable",
+            "org.example.immutable",
+            "Immutable.pak",
+            "Immutable.pak.zip",
+        )
+        self.run_feed([app])
+        before = self.catalog()
+        self.update_app(app, "1.0.0", None, payload=b"changed-without-version-bump")
+        result = self.run_feed([app], expected_ok=False)
+        self.assertIn("immutable history conflict", result.stderr)
+        self.assertEqual(self.catalog(), before)
+
+    def test_history_cannot_exceed_client_version_limit(self) -> None:
+        app = self.write_app(
+            "HistoryLimit",
+            "org.example.history-limit",
+            "HistoryLimit.pak",
+            "HistoryLimit.pak.zip",
+        )
+        self.run_feed([app])
+        history = self.catalog()
+        package = history["apps"][0]["packages"][0]
+        floor = package["versions"][0]
+        package["versions"] = [
+            {
+                "version": f"{major}.0.0",
+                **({"min_leaf_version": "0.7.0"} if major > 1 else {}),
+                "artifact": {
+                    **floor["artifact"],
+                    "url": (
+                        "https://example.invalid/artifacts/"
+                        f"org.example.history-limit/{major}.0.0/"
+                        "HistoryLimit.pak.zip"
+                    ),
+                },
+            }
+            for major in range(17, 0, -1)
+        ]
+        history_path = self.apps_root / "too-much-history.json"
+        history_path.write_text(json.dumps(history), encoding="utf-8")
+        self.update_app(app, "18.0.0", "0.7.0")
+        result = self.run_feed(
+            [app],
+            "--history",
+            str(history_path),
+            expected_ok=False,
+        )
+        self.assertIn("16-entry client limit", result.stderr)
+
+    def test_existing_history_cannot_be_silently_dropped(self) -> None:
+        first = self.write_app(
+            "KeepFirst",
+            "org.example.keep-first",
+            "KeepFirst.pak",
+            "KeepFirst.pak.zip",
+        )
+        second = self.write_app(
+            "KeepSecond",
+            "org.example.keep-second",
+            "KeepSecond.pak",
+            "KeepSecond.pak.zip",
+        )
+        self.run_feed([first, second])
+        before = self.catalog()
+        result = self.run_feed([first], expected_ok=False)
+        self.assertIn("history contains a package that was not regenerated", result.stderr)
+        self.assertEqual(self.catalog(), before)
+
+    def test_runtime_minimum_must_match_authored_gate(self) -> None:
+        app = self.write_app(
+            "Mismatch",
+            "org.example.mismatch",
+            "Mismatch.pak",
+            "Mismatch.pak.zip",
+            version="2.0.0",
+            min_leaf_version="0.7.0",
+            runtime_min_leaf_version="0.8.0",
+        )
+        result = self.run_feed([app], expected_ok=False)
+        self.assertIn("runtime min_leaf_version", result.stderr)
+
+    def test_package_versions_are_exact_numeric_triples(self) -> None:
+        app = self.write_app(
+            "BadVersion",
+            "org.example.bad-version",
+            "BadVersion.pak",
+            "BadVersion.pak.zip",
+            version="v1.0.0",
+        )
+        result = self.run_feed([app], expected_ok=False)
+        self.assertIn("exact MAJOR.MINOR.PATCH", result.stderr)
 
     def test_unsafe_exact_artifact_is_rejected(self) -> None:
         app = self.write_app(

--- a/scripts/pakrat-local-feed.py
+++ b/scripts/pakrat-local-feed.py
@@ -8,17 +8,20 @@ touch leaf-docs or the production leaf.game catalog.
 from __future__ import annotations
 
 import argparse
+import copy
 import contextlib
 import hashlib
 import http.server
 import json
 import os
 from pathlib import Path
+import re
 import shutil
 import socket
 import subprocess
 import sys
 import time
+from urllib.parse import unquote, urlsplit
 import zipfile
 
 
@@ -26,6 +29,17 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 LEAF_ROOT = SCRIPT_DIR.parent
 DEFAULT_OUTPUT = LEAF_ROOT / "build" / "pakrat-local"
 FEED_PREFIX = Path("pakrat") / "v1"
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+ARTIFACT_KEYS = (
+    "url",
+    "name",
+    "archive",
+    "size",
+    "installed_size",
+    "sha256",
+)
+MAX_VERSIONS_PER_PACKAGE = 16
 
 
 def die(message: str) -> None:
@@ -178,6 +192,279 @@ def require_metadata_string(meta: dict, key: str, source: Path) -> str:
     return value
 
 
+def require_path_segment(value: str, label: str, source: Path) -> str:
+    if (
+        not value
+        or value in (".", "..")
+        or "/" in value
+        or "\\" in value
+        or Path(value).name != value
+    ):
+        die(f"{source}: unsafe {label}: {value!r}")
+    return value
+
+
+def require_version(value: object, label: str, source: Path) -> str:
+    if not isinstance(value, str) or not VERSION_RE.fullmatch(value):
+        die(f"{source}: {label} must be an exact MAJOR.MINOR.PATCH string")
+    components = tuple(int(part) for part in value.split("."))
+    if any(part > 9999 for part in components):
+        die(f"{source}: {label} component exceeds 9999")
+    return value
+
+
+def version_key(value: str) -> tuple[int, int, int]:
+    major, minor, patch = value.split(".")
+    return int(major), int(minor), int(patch)
+
+
+def optional_min_leaf_version(meta: dict, source: Path) -> str | None:
+    if "min_leaf_version" not in meta:
+        return None
+    return require_version(
+        meta.get("min_leaf_version"), "min_leaf_version", source
+    )
+
+
+def artifact_facts(artifact: object, source: Path) -> dict:
+    if not isinstance(artifact, dict):
+        die(f"{source}: artifact must be an object")
+    facts = {key: artifact.get(key) for key in ARTIFACT_KEYS}
+    if not isinstance(facts["url"], str) or not facts["url"]:
+        die(f"{source}: artifact.url must be a non-empty string")
+    if not isinstance(facts["name"], str) or not facts["name"].endswith(".zip"):
+        die(f"{source}: artifact.name must end with .zip")
+    require_path_segment(facts["name"], "artifact.name", source)
+    if facts["archive"] != "zip":
+        die(f"{source}: artifact.archive must be zip")
+    for key in ("size", "installed_size"):
+        if (
+            isinstance(facts[key], bool)
+            or not isinstance(facts[key], int)
+            or facts[key] <= 0
+        ):
+            die(f"{source}: artifact.{key} must be a positive integer")
+    if not isinstance(facts["sha256"], str) or not SHA256_RE.fullmatch(
+        facts["sha256"]
+    ):
+        die(f"{source}: artifact.sha256 must be 64 hexadecimal characters")
+    facts["sha256"] = facts["sha256"].lower()
+    return facts
+
+
+def version_entry(entry: object, source: Path) -> dict:
+    if not isinstance(entry, dict):
+        die(f"{source}: version entry must be an object")
+    result = {
+        "version": require_version(entry.get("version"), "version", source),
+        "artifact": artifact_facts(entry.get("artifact"), source),
+    }
+    minimum = optional_min_leaf_version(entry, source)
+    if minimum is not None:
+        result["min_leaf_version"] = minimum
+    return result
+
+
+def normalized_history_package(app: dict, package: object, source: Path) -> dict:
+    if not isinstance(package, dict):
+        die(f"{source}: package must be an object")
+    platform = require_metadata_string(package, "platform", source)
+    install_name = require_metadata_string(package, "install_name", source)
+    require_path_segment(install_name, "install_name", source)
+    if not install_name.endswith(".pak"):
+        die(f"{source}: install_name must end with .pak")
+    runtime = package.get("runtime", "leaf")
+    if runtime != "leaf":
+        die(f"{source}: package runtime must be leaf")
+    runtime_manifest_path = package.get("runtime_manifest_path", "pak.json")
+    if not isinstance(runtime_manifest_path, str) or not runtime_manifest_path:
+        die(f"{source}: runtime_manifest_path must be a non-empty string")
+
+    legacy = version_entry(package, source)
+    if "min_leaf_version" in legacy:
+        die(f"{source}: legacy package version must be an ungated safe floor")
+    versions_value = package.get("versions")
+    legacy_import = versions_value is None
+    if legacy_import:
+        versions = [legacy]
+    else:
+        if not isinstance(versions_value, list) or not versions_value:
+            die(f"{source}: versions must be a non-empty array")
+        if len(versions_value) > MAX_VERSIONS_PER_PACKAGE:
+            die(
+                f"{source}: versions exceeds the "
+                f"{MAX_VERSIONS_PER_PACKAGE}-entry client limit"
+            )
+        versions = [version_entry(value, source) for value in versions_value]
+        keys = [version_key(value["version"]) for value in versions]
+        if any(left <= right for left, right in zip(keys, keys[1:])):
+            die(f"{source}: versions must be unique and strictly descending")
+
+    by_version = {value["version"]: value for value in versions}
+    if len(by_version) != len(versions):
+        die(f"{source}: duplicate package version")
+    floors = [value for value in versions if "min_leaf_version" not in value]
+    if not floors:
+        die(f"{source}: package history has no ungated safe floor")
+    floor = max(floors, key=lambda value: version_key(value["version"]))
+    if (
+        legacy["version"] != floor["version"]
+        or legacy["artifact"] != floor["artifact"]
+        or app.get("version") != floor["version"]
+    ):
+        die(f"{source}: legacy app/package fields do not match the safe floor")
+
+    return {
+        "platform": platform,
+        "runtime": "leaf",
+        "install_name": install_name,
+        "runtime_manifest_path": runtime_manifest_path,
+        "versions": versions,
+        "legacy_import": legacy_import,
+    }
+
+
+def load_history_index(path: Path | None) -> dict[tuple[str, str, str], dict]:
+    if path is None:
+        return {}
+    catalog = load_json(path)
+    if catalog.get("schema") != 1 or catalog.get("product") != "pak-rat":
+        die(f"{path}: history must be a Pak Rat schema-1 storefront")
+    apps = catalog.get("apps")
+    if not isinstance(apps, list):
+        die(f"{path}: history apps must be an array")
+    result: dict[tuple[str, str, str], dict] = {}
+    seen_ids: set[str] = set()
+    for app in apps:
+        if not isinstance(app, dict):
+            die(f"{path}: history app must be an object")
+        app_id = require_metadata_string(app, "id", path)
+        if app_id in seen_ids:
+            die(f"{path}: duplicate history app id: {app_id}")
+        seen_ids.add(app_id)
+        packages = app.get("packages")
+        if not isinstance(packages, list) or not packages:
+            die(f"{path}: history app packages must be a non-empty array")
+        for package in packages:
+            normalized = normalized_history_package(app, package, path)
+            key = (
+                app_id,
+                normalized["platform"],
+                normalized["install_name"].casefold(),
+            )
+            if key in result:
+                die(f"{path}: duplicate history package for {app_id}")
+            normalized["source_path"] = path
+            result[key] = normalized
+    return result
+
+
+def local_history_artifact_path(history_path: Path, artifact: dict) -> Path | None:
+    url_path = unquote(urlsplit(artifact["url"]).path)
+    marker = "/artifacts/"
+    if marker not in url_path:
+        return None
+    relative = Path(url_path.split(marker, 1)[1])
+    if relative.is_absolute() or ".." in relative.parts:
+        die(f"{history_path}: unsafe historical artifact URL {artifact['url']!r}")
+    return history_path.parent / "artifacts" / relative
+
+
+def verify_artifact_file(path: Path, artifact: dict, source: Path) -> None:
+    if path.stat().st_size != artifact["size"] or file_sha256(path) != artifact["sha256"]:
+        die(f"{source}: historical artifact bytes disagree with catalog facts: {path}")
+
+
+def materialize_history_versions(
+    history: dict,
+    app_id: str,
+    artifacts_root: Path,
+    base_url: str,
+) -> list[dict]:
+    versions = copy.deepcopy(history["versions"])
+    source_path: Path = history["source_path"]
+    for value in versions:
+        artifact = value["artifact"]
+        expected_relative = Path(app_id) / value["version"] / artifact["name"]
+        source_artifact = local_history_artifact_path(source_path, artifact)
+        if source_artifact is not None and source_artifact.is_file():
+            verify_artifact_file(source_artifact, artifact, source_path)
+            destination = artifacts_root / expected_relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            if destination.exists():
+                verify_artifact_file(destination, artifact, source_path)
+            elif source_artifact.resolve() != destination.resolve():
+                shutil.copy2(source_artifact, destination)
+        elif urlsplit(artifact["url"]).scheme not in ("https",):
+            die(f"{source_path}: missing local historical artifact for {artifact['url']}")
+
+        url_path = unquote(urlsplit(artifact["url"]).path)
+        expected_suffix = "/artifacts/" + expected_relative.as_posix()
+        if not url_path.endswith(expected_suffix):
+            if history["legacy_import"]:
+                artifact["url"] = base_url + f"artifacts/{expected_relative.as_posix()}"
+            elif urlsplit(artifact["url"]).scheme != "https":
+                die(
+                    f"{source_path}: historical artifact URL is not version-qualified: "
+                    f"{artifact['url']}"
+                )
+    return versions
+
+
+def merge_package_history(
+    history: dict | None,
+    current: dict,
+    app_id: str,
+    runtime_manifest_path: str,
+    artifacts_root: Path,
+    base_url: str,
+    source: Path,
+) -> tuple[list[dict], dict]:
+    if history is None:
+        versions: list[dict] = []
+    else:
+        if (
+            history["runtime"] != "leaf"
+            or history["runtime_manifest_path"] != runtime_manifest_path
+        ):
+            die(f"{source}: package identity disagrees with history")
+        versions = materialize_history_versions(
+            history, app_id, artifacts_root, base_url
+        )
+
+    existing = next(
+        (value for value in versions if value["version"] == current["version"]),
+        None,
+    )
+    if existing is not None:
+        if existing != current:
+            die(
+                f"{source}: immutable history conflict for "
+                f"{app_id} {current['version']}"
+            )
+    else:
+        if versions and version_key(current["version"]) <= max(
+            version_key(value["version"]) for value in versions
+        ):
+            die(f"{source}: new package version must be newer than history")
+        versions.append(current)
+
+    versions.sort(key=lambda value: version_key(value["version"]), reverse=True)
+    if len(versions) > MAX_VERSIONS_PER_PACKAGE:
+        die(
+            f"{source}: versions exceeds the "
+            f"{MAX_VERSIONS_PER_PACKAGE}-entry client limit"
+        )
+    floors = [value for value in versions if "min_leaf_version" not in value]
+    if not floors:
+        die(
+            f"{source}: gated version {current['version']} requires explicit "
+            "history with an ungated safe floor"
+        )
+    floor = max(floors, key=lambda value: version_key(value["version"]))
+    return versions, floor
+
+
 def resolve_app_dirs(args: argparse.Namespace) -> list[Path]:
     if args.app_dir:
         app_dirs = [Path(value).expanduser().resolve() for value in args.app_dir]
@@ -220,9 +507,16 @@ def default_lan_ip() -> str:
 
 def build_storefront(args: argparse.Namespace) -> Path:
     output_root = require_output_root(args.output)
-    if output_root.exists():
-        shutil.rmtree(output_root)
     feed_root = output_root / FEED_PREFIX
+    storefront_path = feed_root / "storefront.json"
+    explicit_history = (
+        Path(args.history).expanduser().resolve() if args.history else None
+    )
+    history_path = explicit_history
+    if history_path is None and storefront_path.is_file():
+        history_path = storefront_path
+    history_index = load_history_index(history_path)
+
     artifacts_root = feed_root / "artifacts"
     artifacts_root.mkdir(parents=True, exist_ok=True)
 
@@ -232,7 +526,7 @@ def build_storefront(args: argparse.Namespace) -> Path:
     apps: list[dict] = []
     seen_ids: set[str] = set()
     seen_install_names: set[str] = set()
-    seen_artifact_names: set[str] = set()
+    used_history_keys: set[tuple[str, str, str]] = set()
 
     for app_dir in app_dirs:
         metadata_path = app_dir / "pakrat.json"
@@ -240,6 +534,7 @@ def build_storefront(args: argparse.Namespace) -> Path:
         if meta.get("schema") != 1:
             die(f"{metadata_path}: schema must be 1")
         app_id = require_metadata_string(meta, "id", metadata_path)
+        require_path_segment(app_id, "app id", metadata_path)
         if app_id in seen_ids:
             die(f"duplicate app id: {app_id}")
         seen_ids.add(app_id)
@@ -254,8 +549,11 @@ def build_storefront(args: argparse.Namespace) -> Path:
             die(f"--artifact override for {app_id} requires exactly one MLP1 package")
 
         app_packages: list[dict] = []
-        app_versions: set[str] = set()
+        app_floor_versions: set[str] = set()
+        current_versions: set[str] = set()
         for pkg in selected:
+            if not isinstance(pkg, dict):
+                die(f"{metadata_path}: package must be an object")
             package_dir_raw = pkg.get("package_dir")
             artifact_name = pkg.get("artifact_name")
             install_name = pkg.get("install_name")
@@ -264,19 +562,21 @@ def build_storefront(args: argparse.Namespace) -> Path:
                 die(f"{metadata_path}: package_dir must be a non-empty string")
             if not isinstance(artifact_name, str) or not artifact_name.endswith(".zip"):
                 die(f"{metadata_path}: artifact_name must end with .zip")
+            require_path_segment(artifact_name, "artifact_name", metadata_path)
             if not isinstance(install_name, str) or not install_name.endswith(".pak"):
                 die(f"{metadata_path}: install_name must end with .pak")
+            require_path_segment(install_name, "install_name", metadata_path)
             if not isinstance(runtime_manifest_path, str) or not runtime_manifest_path:
                 die(f"{metadata_path}: runtime_manifest_path must be a non-empty string")
+            version = require_version(
+                pkg.get("version"), "package version", metadata_path
+            )
+            minimum = optional_min_leaf_version(pkg, metadata_path)
 
             install_key = install_name.casefold()
             if install_key in seen_install_names:
                 die(f"duplicate install name: {install_name}")
             seen_install_names.add(install_key)
-            artifact_key = artifact_name.casefold()
-            if artifact_key in seen_artifact_names:
-                die(f"duplicate artifact name: {artifact_name}")
-            seen_artifact_names.add(artifact_key)
 
             package_dir = (app_dir / package_dir_raw).resolve()
             try:
@@ -298,7 +598,13 @@ def build_storefront(args: argparse.Namespace) -> Path:
                     die(f"{metadata_path}: build_command must be a string array")
                 run_command(build_command, app_dir)
 
-            artifact_path = artifacts_root / artifact_name
+            artifact_relative = Path(app_id) / version / artifact_name
+            artifact_path = artifacts_root / artifact_relative
+            artifact_path.parent.mkdir(parents=True, exist_ok=True)
+            candidate_path = artifact_path.with_name(
+                ".candidate-" + artifact_path.name
+            )
+            candidate_path.unlink(missing_ok=True)
             if override is not None:
                 if override.name != artifact_name:
                     die(
@@ -307,44 +613,84 @@ def build_storefront(args: argparse.Namespace) -> Path:
                     )
                 if not override.is_file():
                     die(f"missing exact artifact override: {override}")
-                shutil.copy2(override, artifact_path)
+                shutil.copy2(override, candidate_path)
             else:
-                zip_pak_dir(package_dir, artifact_path)
+                zip_pak_dir(package_dir, candidate_path)
 
             runtime, installed_size = inspect_zip_artifact(
-                artifact_path, install_name, runtime_manifest_path
+                candidate_path, install_name, runtime_manifest_path
             )
-            version = pkg.get("version") or runtime.get("pak_version")
-            if not isinstance(version, str) or not version:
-                die(f"{metadata_path}: package version must be a non-empty string")
             if version != runtime.get("pak_version"):
                 die(
-                    f"{artifact_path}: runtime pak_version "
+                    f"{candidate_path}: runtime pak_version "
                     f"{runtime.get('pak_version')!r} does not match Pak Rat "
                     f"version {version!r}"
                 )
-            app_versions.add(version)
+            runtime_has_minimum = "min_leaf_version" in runtime
+            runtime_minimum = runtime.get("min_leaf_version")
+            if (
+                (minimum is None and runtime_has_minimum)
+                or (minimum is not None and runtime_minimum != minimum)
+            ):
+                die(
+                    f"{candidate_path}: runtime min_leaf_version "
+                    f"{runtime_minimum!r} does not match Pak Rat "
+                    f"min_leaf_version {minimum!r}"
+                )
+
+            artifact = {
+                "url": base_url + f"artifacts/{artifact_relative.as_posix()}",
+                "name": artifact_name,
+                "archive": "zip",
+                "size": candidate_path.stat().st_size,
+                "installed_size": installed_size,
+                "sha256": file_sha256(candidate_path),
+            }
+            current = {
+                "version": version,
+                "artifact": artifact,
+            }
+            if minimum is not None:
+                current["min_leaf_version"] = minimum
+
+            history_key = (app_id, "mlp1", install_name.casefold())
+            history = history_index.get(history_key)
+            if history is None and any(
+                key[0] == app_id for key in history_index
+            ):
+                die(f"{metadata_path}: package identity disagrees with history")
+            if history is not None:
+                used_history_keys.add(history_key)
+            versions, floor = merge_package_history(
+                history,
+                current,
+                app_id,
+                runtime_manifest_path,
+                artifacts_root,
+                base_url,
+                metadata_path,
+            )
+            candidate_path.replace(artifact_path)
+
+            current_versions.add(version)
+            app_floor_versions.add(floor["version"])
             app_packages.append(
                 {
                     "platform": "mlp1",
                     "runtime": "leaf",
-                    "version": version,
+                    "version": floor["version"],
                     "install_name": install_name,
                     "runtime_manifest_path": runtime_manifest_path,
-                    "artifact": {
-                        "url": base_url + f"artifacts/{artifact_name}",
-                        "name": artifact_name,
-                        "archive": "zip",
-                        "size": artifact_path.stat().st_size,
-                        "installed_size": installed_size,
-                        "sha256": file_sha256(artifact_path),
-                    },
+                    "artifact": copy.deepcopy(floor["artifact"]),
+                    "versions": versions,
                 }
             )
 
-        if len(app_versions) != 1:
+        if len(current_versions) != 1:
             die(f"{metadata_path}: all MLP1 packages must use one app version")
-        app_version = next(iter(app_versions))
+        if len(app_floor_versions) != 1:
+            die(f"{metadata_path}: all MLP1 packages must use one safe-floor version")
+        app_version = next(iter(app_floor_versions))
         categories = meta.get("categories", [])
         if not isinstance(categories, list) or not all(
             isinstance(value, str) and value for value in categories
@@ -367,6 +713,13 @@ def build_storefront(args: argparse.Namespace) -> Path:
     unknown_overrides = sorted(set(artifact_overrides) - seen_ids)
     if unknown_overrides:
         die(f"--artifact references unknown app ids: {', '.join(unknown_overrides)}")
+    unused_history = sorted(set(history_index) - used_history_keys)
+    if unused_history:
+        app_id, platform, install_name = unused_history[0]
+        die(
+            "history contains a package that was not regenerated: "
+            f"{app_id} {platform} {install_name}"
+        )
 
     generated_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
     storefront = {
@@ -377,14 +730,18 @@ def build_storefront(args: argparse.Namespace) -> Path:
         "apps": apps,
     }
 
-    storefront_path = feed_root / "storefront.json"
-    storefront_path.write_text(json.dumps(storefront, indent=2) + "\n", encoding="utf-8")
+    storefront_partial = storefront_path.with_suffix(".json.partial")
+    storefront_partial.write_text(
+        json.dumps(storefront, indent=2) + "\n", encoding="utf-8"
+    )
+    storefront_partial.replace(storefront_path)
     print(f"Wrote {storefront_path}")
     for app in apps:
         for pkg in app["packages"]:
-            artifact = pkg["artifact"]
+            artifact = pkg["versions"][0]["artifact"]
             print(
-                f"  {app['id']} {artifact['name']} "
+                f"  {app['id']} {pkg['versions'][0]['version']} "
+                f"{artifact['name']} "
                 f"size={artifact['size']} sha256={artifact['sha256']}"
             )
     return storefront_path
@@ -466,6 +823,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--host", default="127.0.0.1", help="serve host")
     parser.add_argument("--port", type=int, default=8765, help="serve port")
     parser.add_argument("--base-url", help="catalog artifact base URL")
+    parser.add_argument(
+        "--history",
+        help=(
+            "schema-1 storefront whose immutable version history should be "
+            "merged; defaults to the existing output storefront"
+        ),
+    )
     parser.add_argument("--serve", action="store_true", help="serve after generating")
     parser.add_argument("--skip-build", action="store_true", help="use existing package dir")
     parser.add_argument("--adb-configure", action="store_true", help="write dev-catalog-url to an attached device")

--- a/scripts/validate-leaf-release-test.py
+++ b/scripts/validate-leaf-release-test.py
@@ -75,6 +75,9 @@ class ProvenanceTests(unittest.TestCase):
                 repo = base / name
                 init_repo(repo)
                 components.append(f"{name}={repo}")
+            app_repo = base / "Thing-File"
+            init_repo(app_repo)
+            components.append(f"app:Thing-File={app_repo}")
             args = SimpleNamespace(
                 channel="stable",
                 version="0.7.0",
@@ -89,6 +92,7 @@ class ProvenanceTests(unittest.TestCase):
                 "leaf",
                 "launcher",
                 "launcher-switcher",
+                "app:Thing-File",
             ])
             self.assertTrue(all(len(row["commit"]) == 40 for row in rows))
             self.assertTrue(all(row["dirty"] is False for row in rows))
@@ -148,7 +152,12 @@ class CandidateTests(unittest.TestCase):
             },
             "components": [
                 {"name": name, "commit": "a" * 40, "dirty": False, "remote": None}
-                for name in ("leaf", "launcher", "launcher-switcher", "app:example")
+                for name in (
+                    "leaf",
+                    "launcher",
+                    "launcher-switcher",
+                    "app:Thing-File",
+                )
             ],
         }
         provenance_path = root / "provenance" / "components.json"
@@ -172,7 +181,7 @@ class CandidateTests(unittest.TestCase):
                 "leaf",
                 "launcher",
                 "launcher-switcher",
-                "app:example",
+                "app:Thing-File",
             ],
         )
 

--- a/scripts/validate-leaf-release-test.py
+++ b/scripts/validate-leaf-release-test.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+SCRIPT = Path(__file__).with_name("validate-leaf-release.py")
+SPEC = importlib.util.spec_from_file_location("validate_leaf_release", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def write_executable(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def init_repo(path: Path) -> None:
+    path.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q", str(path)], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "Test"], check=True)
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.email", "test@example.invalid"],
+        check=True,
+    )
+    (path / "tracked.txt").write_text("clean\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(path), "add", "tracked.txt"], check=True)
+    subprocess.run(["git", "-C", str(path), "commit", "-qm", "fixture"], check=True)
+
+
+class IdentityTests(unittest.TestCase):
+    def test_stable_identity_requires_explicit_matching_version_and_tag(self):
+        MODULE.validate_identity("stable", "0.7.0", "v0.7.0", "build-123")
+        with self.assertRaisesRegex(MODULE.PolicyError, "LEAF_RELEASE_VERSION"):
+            MODULE.validate_identity("stable", "", "v0.7.0", "build-123")
+        with self.assertRaisesRegex(MODULE.PolicyError, "does not match"):
+            MODULE.validate_identity("stable", "0.7.0", "v0.7.1", "build-123")
+        with self.assertRaisesRegex(MODULE.PolicyError, "explicit LEAF_RELEASE_TAG"):
+            MODULE.validate_identity("stable", "0.7.0", "", "build-123")
+
+    def test_stable_identity_accepts_supported_ota_suffix(self):
+        MODULE.validate_identity(
+            "stable",
+            "0.7.0-save-isolation-ota1",
+            "v0.7.0-save-isolation-ota1",
+            "build-123",
+        )
+
+    def test_nonstable_identity_may_use_build_identity_as_version(self):
+        MODULE.validate_identity(
+            "dev",
+            "2026-07-20-gabc1234",
+            "",
+            "2026-07-20-gabc1234",
+        )
+
+
+class ProvenanceTests(unittest.TestCase):
+    def test_provenance_records_exact_clean_commits(self):
+        with tempfile.TemporaryDirectory() as raw:
+            base = Path(raw)
+            components = []
+            for name in ("leaf", "launcher", "launcher-switcher"):
+                repo = base / name
+                init_repo(repo)
+                components.append(f"{name}={repo}")
+            args = SimpleNamespace(
+                channel="stable",
+                version="0.7.0",
+                tag="v0.7.0",
+                release_id="build-123",
+                component=components,
+                require_clean=True,
+            )
+            result = MODULE.build_provenance(args)
+            rows = result["components"]
+            self.assertEqual([row["name"] for row in rows], [
+                "leaf",
+                "launcher",
+                "launcher-switcher",
+            ])
+            self.assertTrue(all(len(row["commit"]) == 40 for row in rows))
+            self.assertTrue(all(row["dirty"] is False for row in rows))
+
+    def test_stable_provenance_rejects_dirty_component(self):
+        with tempfile.TemporaryDirectory() as raw:
+            base = Path(raw)
+            components = []
+            for name in ("leaf", "launcher", "launcher-switcher"):
+                repo = base / name
+                init_repo(repo)
+                components.append(f"{name}={repo}")
+            (base / "launcher" / "tracked.txt").write_text("dirty\n", encoding="utf-8")
+            args = SimpleNamespace(
+                channel="stable",
+                version="0.7.0",
+                tag="v0.7.0",
+                release_id="build-123",
+                component=components,
+                require_clean=True,
+            )
+            with self.assertRaisesRegex(MODULE.PolicyError, "stable component is dirty"):
+                MODULE.build_provenance(args)
+
+
+class CandidateTests(unittest.TestCase):
+    def make_candidate(self, base: Path) -> SimpleNamespace:
+        root = base / "release"
+        install = base / "install"
+        launcher = root / "platforms" / "mlp1" / "launcher"
+        write_executable(
+            launcher / "bin" / "loong_pangu",
+            b"\x7fELF fixture relocate-games-v1 fixture\n",
+        )
+        write_executable(
+            launcher / "bin" / "jawaka-inhibitctl",
+            b"\x7fELF inhibit fixture\n",
+        )
+        env_lines = [
+            "#!/bin/sh",
+            "export UMRK_SECONDARY_SDCARD_PATH=/media/sdcard1",
+        ]
+        for name, values in MODULE.REQUIRED_PATH_LISTS.items():
+            env_lines.append(f"export {name}={':'.join(values)}")
+        env_path = launcher / "env.sh"
+        env_path.parent.mkdir(parents=True, exist_ok=True)
+        env_path.write_text("\n".join(env_lines) + "\n", encoding="utf-8")
+
+        provenance = {
+            "schema": 1,
+            "product": "leaf",
+            "release": {
+                "channel": "stable",
+                "version": "0.7.0",
+                "tag": "v0.7.0",
+                "release_id": "build-123",
+            },
+            "components": [
+                {"name": name, "commit": "a" * 40, "dirty": False, "remote": None}
+                for name in ("leaf", "launcher", "launcher-switcher", "app:example")
+            ],
+        }
+        provenance_path = root / "provenance" / "components.json"
+        provenance_path.parent.mkdir(parents=True)
+        provenance_path.write_text(json.dumps(provenance), encoding="utf-8")
+
+        write_executable(
+            install / "umrk-launcher-install.sh",
+            (
+                '#!/bin/sh\nRELEASE_ID="build-123"\nRELEASE_VERSION="0.7.0"\n'
+                'cat <<EOF\n"version": "$RELEASE_VERSION"\n'
+                '"release_id": "$RELEASE_ID"\nEOF\n'
+            ).encode(),
+        )
+        return SimpleNamespace(
+            release_root=root,
+            install_stage=install,
+            version="0.7.0",
+            release_id="build-123",
+            required_component=[
+                "leaf",
+                "launcher",
+                "launcher-switcher",
+                "app:example",
+            ],
+        )
+
+    def test_candidate_accepts_required_capabilities_and_identity(self):
+        with tempfile.TemporaryDirectory() as raw:
+            MODULE.validate_candidate(self.make_candidate(Path(raw)))
+
+    def test_candidate_rejects_missing_launcher_capability(self):
+        with tempfile.TemporaryDirectory() as raw:
+            args = self.make_candidate(Path(raw))
+            daemon = (
+                args.release_root
+                / "platforms"
+                / "mlp1"
+                / "launcher"
+                / "bin"
+                / "loong_pangu"
+            )
+            daemon.write_bytes(b"\x7fELF no feature\n")
+            with self.assertRaisesRegex(MODULE.PolicyError, "relocate-games-v1"):
+                MODULE.validate_candidate(args)
+
+    def test_candidate_rejects_incomplete_configured_sources(self):
+        with tempfile.TemporaryDirectory() as raw:
+            args = self.make_candidate(Path(raw))
+            env_path = (
+                args.release_root
+                / "platforms"
+                / "mlp1"
+                / "launcher"
+                / "env.sh"
+            )
+            text = env_path.read_text(encoding="utf-8")
+            env_path.write_text(
+                text.replace(
+                    "export ROMS_PATHS=/mnt/sdcard/Roms:/media/sdcard1/Roms",
+                    "export ROMS_PATHS=/mnt/sdcard/Roms",
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(MODULE.PolicyError, "ROMS_PATHS mismatch"):
+                MODULE.validate_candidate(args)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-leaf-release.py
+++ b/scripts/validate-leaf-release.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Validate Leaf release identity, provenance, and assembled capabilities."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+
+VERSION_RE = re.compile(
+    r"[0-9]+\.[0-9]+\.[0-9]+"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+)
+COMPONENT_NAME_RE = re.compile(r"[a-z0-9][a-z0-9_.:-]*")
+REQUIRED_PATH_LISTS = {
+    "SDCARD_PATHS": ("/mnt/sdcard", "/media/sdcard1"),
+    "ROMS_PATHS": ("/mnt/sdcard/Roms", "/media/sdcard1/Roms"),
+    "IMAGES_PATHS": ("/mnt/sdcard/Images", "/media/sdcard1/Images"),
+    "MUSIC_PATHS": ("/mnt/sdcard/Music", "/media/sdcard1/Music"),
+    "APPS_PATHS": ("/mnt/sdcard/Apps", "/media/sdcard1/Apps"),
+    "BIOS_PATHS": ("/mnt/sdcard/BIOS", "/media/sdcard1/BIOS"),
+    "SAVES_PATHS": ("/mnt/sdcard/Saves", "/media/sdcard1/Saves"),
+    "STATES_PATHS": ("/mnt/sdcard/States", "/media/sdcard1/States"),
+    "CHEATS_PATHS": ("/mnt/sdcard/Cheats", "/media/sdcard1/Cheats"),
+}
+
+
+class PolicyError(Exception):
+    pass
+
+
+def validate_version(value: str, label: str = "version") -> str:
+    if not VERSION_RE.fullmatch(value or ""):
+        raise PolicyError(
+            f"{label} must be a semantic version such as 0.7.0 "
+            "or 0.7.0-save-isolation-ota1"
+        )
+    core = value.split("-", 1)[0].split("+", 1)[0]
+    if any(int(part) > 9999 for part in core.split(".")):
+        raise PolicyError(f"{label} component exceeds 9999")
+    return value
+
+
+def normalized_tag(tag: str) -> str:
+    if not tag:
+        raise PolicyError("stable releases require an explicit LEAF_RELEASE_TAG")
+    if not tag.startswith("v") or tag.startswith("vv"):
+        raise PolicyError("stable release tag must have exactly one leading lowercase v")
+    return validate_version(tag[1:], "release tag")
+
+
+def validate_identity(channel: str, version: str, tag: str, release_id: str) -> None:
+    if not channel:
+        raise PolicyError("release channel must not be empty")
+    if not release_id:
+        raise PolicyError("release id must not be empty")
+    if channel == "stable":
+        validate_version(version, "LEAF_RELEASE_VERSION")
+        tag_version = normalized_tag(tag)
+        if version != tag_version:
+            raise PolicyError(
+                "LEAF_RELEASE_VERSION does not match LEAF_RELEASE_TAG after "
+                f"normalizing its leading v: {version!r} != {tag_version!r}"
+            )
+    elif version and version != release_id:
+        validate_version(version, "LEAF_RELEASE_VERSION")
+
+
+def run_git(
+    repo: Path, *args: str, allow_empty: bool = False, allow_failure: bool = False
+) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo), *args],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        if allow_failure:
+            return ""
+        detail = exc.stderr.strip()
+        raise PolicyError(f"cannot inspect Git repository {repo}: {detail or exc}") from exc
+    except OSError as exc:
+        detail = ""
+        raise PolicyError(f"cannot inspect Git repository {repo}: {detail or exc}") from exc
+    value = result.stdout.strip()
+    if not value and not allow_empty:
+        raise PolicyError(f"Git returned no value for {repo}: {' '.join(args)}")
+    return value
+
+
+def parse_component(value: str) -> tuple[str, Path]:
+    name, separator, raw_path = value.partition("=")
+    if not separator or not COMPONENT_NAME_RE.fullmatch(name):
+        raise PolicyError(f"component must be NAME=PATH with a safe name: {value!r}")
+    path = Path(raw_path).resolve()
+    if not path.is_dir():
+        raise PolicyError(f"component repository is missing: {name}={path}")
+    return name, path
+
+
+def sanitize_remote(value: str) -> str | None:
+    if not value:
+        return None
+    parsed = urlsplit(value)
+    if parsed.scheme and parsed.hostname:
+        host = parsed.hostname
+        if parsed.port:
+            host = f"{host}:{parsed.port}"
+        return urlunsplit((parsed.scheme, host, parsed.path, parsed.query, parsed.fragment))
+    return value
+
+
+def inspect_component(name: str, repo: Path, require_clean: bool) -> dict[str, object]:
+    inside = run_git(repo, "rev-parse", "--is-inside-work-tree")
+    if inside != "true":
+        raise PolicyError(f"component is not a Git worktree: {name}={repo}")
+    commit = run_git(repo, "rev-parse", "HEAD")
+    status = run_git(
+        repo, "status", "--porcelain=v1", "--untracked-files=normal", allow_empty=True
+    )
+    dirty = bool(status)
+    if require_clean and dirty:
+        preview = ", ".join(line[3:] for line in status.splitlines()[:5])
+        raise PolicyError(f"stable component is dirty: {name} ({preview})")
+    remote = run_git(
+        repo,
+        "config",
+        "--get",
+        "remote.origin.url",
+        allow_empty=True,
+        allow_failure=True,
+    )
+    return {
+        "name": name,
+        "commit": commit,
+        "dirty": dirty,
+        "remote": sanitize_remote(remote),
+    }
+
+
+def build_provenance(args: argparse.Namespace) -> dict[str, object]:
+    validate_identity(args.channel, args.version, args.tag, args.release_id)
+    seen: set[str] = set()
+    components: list[dict[str, object]] = []
+    for raw in args.component:
+        name, repo = parse_component(raw)
+        if name in seen:
+            raise PolicyError(f"duplicate component name: {name}")
+        seen.add(name)
+        components.append(inspect_component(name, repo, args.require_clean))
+    for required in ("leaf", "launcher", "launcher-switcher"):
+        if required not in seen:
+            raise PolicyError(f"missing required provenance component: {required}")
+    return {
+        "schema": 1,
+        "product": "leaf",
+        "release": {
+            "channel": args.channel,
+            "version": args.version,
+            "tag": args.tag or None,
+            "release_id": args.release_id,
+        },
+        "components": components,
+    }
+
+
+def write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    partial = path.with_name(path.name + ".partial")
+    partial.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+    partial.replace(path)
+
+
+def read_json(path: Path, label: str) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise PolicyError(f"cannot read {label} {path}: {exc}") from exc
+
+
+def require_file(path: Path, label: str, executable: bool = False) -> None:
+    if not path.is_file() or path.stat().st_size == 0:
+        raise PolicyError(f"missing or empty {label}: {path}")
+    if executable and not os.access(path, os.X_OK):
+        raise PolicyError(f"{label} is not executable: {path}")
+
+
+def read_staged_environment(env_path: Path) -> dict[str, str]:
+    result = subprocess.run(
+        [
+            "env",
+            "-i",
+            "PATH=/usr/bin:/bin",
+            "PLATFORM=mlp1",
+            "/bin/sh",
+            "-c",
+            '. "$1"; env',
+            "sh",
+            str(env_path),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise PolicyError(
+            f"staged runtime environment cannot be sourced: {result.stderr.strip()}"
+        )
+    values: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        key, separator, value = line.partition("=")
+        if separator:
+            values[key] = value
+    return values
+
+
+def validate_candidate(args: argparse.Namespace) -> None:
+    root = args.release_root.resolve()
+    platform = root / "platforms" / "mlp1"
+    launcher = platform / "launcher"
+    daemon = launcher / "bin" / "loong_pangu"
+    inhibit = launcher / "bin" / "jawaka-inhibitctl"
+    env_path = launcher / "env.sh"
+
+    require_file(daemon, "launcher daemon", executable=True)
+    require_file(inhibit, "launcher inhibit helper", executable=True)
+    require_file(env_path, "runtime environment")
+    if b"relocate-games-v1" not in daemon.read_bytes():
+        raise PolicyError("launcher daemon does not advertise relocate-games-v1")
+
+    environment = read_staged_environment(env_path)
+    if environment.get("UMRK_SECONDARY_SDCARD_PATH") != "/media/sdcard1":
+        raise PolicyError("runtime environment does not configure the Secondary card")
+    for name, expected in REQUIRED_PATH_LISTS.items():
+        actual = tuple(environment.get(name, "").split(":"))
+        if actual != expected:
+            raise PolicyError(
+                f"runtime environment {name} mismatch: "
+                f"{actual!r} != {expected!r}"
+            )
+
+    provenance_path = root / "provenance" / "components.json"
+    provenance = read_json(provenance_path, "component provenance")
+    if not isinstance(provenance, dict) or provenance.get("schema") != 1:
+        raise PolicyError("component provenance has an unsupported schema")
+    release = provenance.get("release")
+    if not isinstance(release, dict):
+        raise PolicyError("component provenance is missing release identity")
+    if (
+        release.get("version") != args.version
+        or release.get("release_id") != args.release_id
+    ):
+        raise PolicyError("component provenance release identity does not match candidate")
+    components = provenance.get("components")
+    if not isinstance(components, list):
+        raise PolicyError("component provenance is missing components")
+    names: set[str] = set()
+    stable = release.get("channel") == "stable"
+    for item in components:
+        if not isinstance(item, dict):
+            raise PolicyError("component provenance contains a non-object entry")
+        name = item.get("name")
+        commit = item.get("commit")
+        if not isinstance(name, str) or not COMPONENT_NAME_RE.fullmatch(name):
+            raise PolicyError("component provenance contains an invalid name")
+        if name in names:
+            raise PolicyError(f"component provenance contains duplicate name: {name}")
+        if not isinstance(commit, str) or not re.fullmatch(r"[0-9a-f]{40,64}", commit):
+            raise PolicyError(f"component provenance contains invalid commit: {name}")
+        if stable and item.get("dirty") is not False:
+            raise PolicyError(f"stable component provenance is dirty: {name}")
+        names.add(name)
+    for required in args.required_component:
+        if required not in names:
+            raise PolicyError(
+                f"component provenance is missing required component: {required}"
+            )
+
+    installer = args.install_stage.resolve() / "umrk-launcher-install.sh"
+    require_file(installer, "managed installer")
+    installer_text = installer.read_text(encoding="utf-8")
+    for expected in (
+        f'RELEASE_ID="{args.release_id}"',
+        f'RELEASE_VERSION="{args.version}"',
+        '"version": "$RELEASE_VERSION"',
+        '"release_id": "$RELEASE_ID"',
+    ):
+        if expected not in installer_text:
+            raise PolicyError(
+                f"managed installer does not preserve release identity: {expected}"
+            )
+
+
+def make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    identity = subparsers.add_parser("identity")
+    identity.add_argument("--channel", required=True)
+    identity.add_argument("--version", default="")
+    identity.add_argument("--tag", default="")
+    identity.add_argument("--release-id", required=True)
+
+    provenance = subparsers.add_parser("provenance")
+    provenance.add_argument("--channel", required=True)
+    provenance.add_argument("--version", default="")
+    provenance.add_argument("--tag", default="")
+    provenance.add_argument("--release-id", required=True)
+    provenance.add_argument("--component", action="append", default=[])
+    provenance.add_argument("--require-clean", action="store_true")
+    provenance.add_argument("--output", type=Path, required=True)
+
+    candidate = subparsers.add_parser("candidate")
+    candidate.add_argument("--release-root", type=Path, required=True)
+    candidate.add_argument("--install-stage", type=Path, required=True)
+    candidate.add_argument("--version", required=True)
+    candidate.add_argument("--release-id", required=True)
+    candidate.add_argument("--required-component", action="append", default=[])
+    return parser
+
+
+def main() -> None:
+    args = make_parser().parse_args()
+    try:
+        if args.command == "identity":
+            validate_identity(args.channel, args.version, args.tag, args.release_id)
+            print(
+                f"release identity: channel={args.channel} "
+                f"version={args.version or '(unset)'} "
+                f"tag={args.tag or '(unset)'} release_id={args.release_id}"
+            )
+        elif args.command == "provenance":
+            value = build_provenance(args)
+            write_json(args.output, value)
+            print(f"Wrote {args.output}")
+        elif args.command == "candidate":
+            validate_candidate(args)
+            print("Leaf release candidate gate: identity, provenance, and capabilities verified")
+    except PolicyError as exc:
+        raise SystemExit(f"error: {exc}") from exc
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate-leaf-release.py
+++ b/scripts/validate-leaf-release.py
@@ -18,7 +18,7 @@ VERSION_RE = re.compile(
     r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
     r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
 )
-COMPONENT_NAME_RE = re.compile(r"[a-z0-9][a-z0-9_.:-]*")
+COMPONENT_NAME_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]*")
 REQUIRED_PATH_LISTS = {
     "SDCARD_PATHS": ("/mnt/sdcard", "/media/sdcard1"),
     "ROMS_PATHS": ("/mnt/sdcard/Roms", "/media/sdcard1/Roms"),

--- a/stage/mlp1.mk
+++ b/stage/mlp1.mk
@@ -60,6 +60,7 @@ assemble-jawaka: jawaka-build
 	@cp -f "$(JAWAKA_BUILD_DIR)/bin/jawaka-menu" "$(PAYLOAD_DIR)/bin/jawaka-menu"
 	@cp -f "$(JAWAKA_BUILD_DIR)/bin/jawaka-osd" "$(PAYLOAD_DIR)/bin/jawaka-osd"
 	@cp -f "$(JAWAKA_BUILD_DIR)/bin/jawaka-platformctl" "$(PAYLOAD_DIR)/bin/jawaka-platformctl"
+	@cp -f "$(JAWAKA_BUILD_DIR)/bin/jawaka-inhibitctl" "$(PAYLOAD_DIR)/bin/jawaka-inhibitctl"
 	@cp -f "$(JAWAKA_BUILD_DIR)/bin/jawaka-retroarchctl" "$(PAYLOAD_DIR)/bin/jawaka-retroarchctl"
 	@cp -f "$(JAWAKA_BUILD_DIR)/bin/jawaka-retroarch-runner" "$(PAYLOAD_DIR)/bin/jawaka-retroarch-runner"
 	@cp -f "$(JAWAKA_BUILD_DIR)/bin/jawaka-update-runner" "$(PAYLOAD_DIR)/bin/jawaka-update-runner"


### PR DESCRIPTION
## What changed

- generate immutable Pak Rat package histories with an ungated safe floor and version-qualified artifacts
- validate catalog/runtime `pak_version` and `min_leaf_version` parity
- require explicit semantic identity, clean component provenance, and release-candidate gates for stable Leaf releases
- separate compatibility `version` from date/SHA `release_id`
- include the launcher inhibit helper required by safe PortMaster package moves

## Why

PortMaster 0.2.0 depends on the coordinated dual-SD launcher/runtime contract
shipped by Leaf 0.7.0. Older devices must continue seeing the released
PortMaster 0.1.2 package until they install the compatible Leaf OTA.

## User impact

Pak Rat can retain and select the newest package version compatible with the
installed Leaf release. Stable release assembly now fails early when version
identity, provenance, required launcher capabilities, or configured-source
behavior is incomplete.

## Validation

- `make pakrat-local-feed-test` — 13 tests passed
- `make leaf-release-policy-test` — 8 tests passed
- companion launcher Pak Rat history/gating/schema smoke tests passed
- launcher-switcher runtime environment and release-version tests passed
- Central Scrutinizer configured-source path test passed
