### PR TITLE
Gate MLP1 RetroArch L3 mappings

### DIFF
--- a/scripts/validate-leaf-release-test.py
+++ b/scripts/validate-leaf-release-test.py
@@ -140,6 +140,15 @@ class CandidateTests(unittest.TestCase):
         env_path = launcher / "env.sh"
         env_path.parent.mkdir(parents=True, exist_ok=True)
         env_path.write_text("\n".join(env_lines) + "\n", encoding="utf-8")
+        autoconfig = root / "platforms" / "mlp1" / "autoconfig" / "Loong Gamepad.cfg"
+        autoconfig.parent.mkdir(parents=True, exist_ok=True)
+        autoconfig.write_text(
+            'input_l3_btn = "7"\ninput_l3_btn_label = "L3"\n',
+            encoding="utf-8",
+        )
+        defaults = root / "platforms" / "mlp1" / "defaults" / "retroarch.cfg"
+        defaults.parent.mkdir(parents=True, exist_ok=True)
+        defaults.write_text('input_player1_l3_btn = "7"\n', encoding="utf-8")
 
         provenance = {
             "schema": 1,
@@ -223,6 +232,34 @@ class CandidateTests(unittest.TestCase):
                 encoding="utf-8",
             )
             with self.assertRaisesRegex(MODULE.PolicyError, "ROMS_PATHS mismatch"):
+                MODULE.validate_candidate(args)
+
+    def test_candidate_rejects_incomplete_l3_autoconfig(self):
+        with tempfile.TemporaryDirectory() as raw:
+            args = self.make_candidate(Path(raw))
+            config = (
+                args.release_root
+                / "platforms"
+                / "mlp1"
+                / "autoconfig"
+                / "Loong Gamepad.cfg"
+            )
+            config.write_text('input_l3_btn = "7"\n', encoding="utf-8")
+            with self.assertRaisesRegex(MODULE.PolicyError, "input_l3_btn_label"):
+                MODULE.validate_candidate(args)
+
+    def test_candidate_rejects_incomplete_l3_defaults(self):
+        with tempfile.TemporaryDirectory() as raw:
+            args = self.make_candidate(Path(raw))
+            config = (
+                args.release_root
+                / "platforms"
+                / "mlp1"
+                / "defaults"
+                / "retroarch.cfg"
+            )
+            config.write_text('input_player1_l3_btn = "nul"\n', encoding="utf-8")
+            with self.assertRaisesRegex(MODULE.PolicyError, "input_player1_l3_btn"):
                 MODULE.validate_candidate(args)
 
 

--- a/scripts/validate-leaf-release.py
+++ b/scripts/validate-leaf-release.py
@@ -195,6 +195,48 @@ def require_file(path: Path, label: str, executable: bool = False) -> None:
         raise PolicyError(f"{label} is not executable: {path}")
 
 
+def read_retroarch_config(path: Path, label: str) -> dict[str, str]:
+    require_file(path, label)
+    values: dict[str, str] = {}
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError) as exc:
+        raise PolicyError(f"cannot read {label} {path}: {exc}") from exc
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        key, separator, raw_value = stripped.partition("=")
+        if not separator:
+            continue
+        value = raw_value.strip()
+        if len(value) >= 2 and value[0] == value[-1] == '"':
+            value = value[1:-1]
+        values[key.strip()] = value
+    return values
+
+
+def validate_mlp1_retroarch_input_profile(platform: Path) -> None:
+    autoconfig = read_retroarch_config(
+        platform / "autoconfig" / "Loong Gamepad.cfg",
+        "MLP1 RetroArch gamepad autoconfig",
+    )
+    defaults = read_retroarch_config(
+        platform / "defaults" / "retroarch.cfg",
+        "MLP1 RetroArch defaults",
+    )
+    expected = (
+        (autoconfig, "input_l3_btn", "7"),
+        (autoconfig, "input_l3_btn_label", "L3"),
+        (defaults, "input_player1_l3_btn", "7"),
+    )
+    for config, key, value in expected:
+        if config.get(key) != value:
+            raise PolicyError(
+                f"MLP1 RetroArch L3 mapping mismatch: {key} must be {value!r}"
+            )
+
+
 def read_staged_environment(env_path: Path) -> dict[str, str]:
     result = subprocess.run(
         [
@@ -235,6 +277,7 @@ def validate_candidate(args: argparse.Namespace) -> None:
     require_file(daemon, "launcher daemon", executable=True)
     require_file(inhibit, "launcher inhibit helper", executable=True)
     require_file(env_path, "runtime environment")
+    validate_mlp1_retroarch_input_profile(platform)
     if b"relocate-games-v1" not in daemon.read_bytes():
         raise PolicyError("launcher daemon does not advertise relocate-games-v1")
 


### PR DESCRIPTION
## What changed

- Parse the staged RetroArch defaults and Loong Gamepad autoconfig during Leaf release validation.
- Require the MLP1 L3 binding, its controller-native label, and the matching player-one default.
- Add negative tests for incomplete autoconfig and default mappings.

## Why

The MLP1 controller exposes a physical left-stick click, but its RetroArch profile previously shipped without L3. A release-level check prevents that input mapping from silently disappearing again.

## Impact

Leaf release candidates now fail early if the companion launcher-switcher payload does not contain the complete MLP1 L3 mapping.

## Companion change

This gate accompanies Utility-Muffin-Research-Kitchen/miniloong-launcher-switcher#7, which adds the actual controller mapping.

## Validation

- `make leaf-release-policy-test` — 10 tests pass.
- `git diff --check origin/main...HEAD`
