### PR TITLE
Package MLP1 shader bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ LARGE_LIBRARY_FIXTURE_ENV = \
 	REMOTE_SDCARD_PATH="$(REMOTE_SDCARD_PATH)"
 
 .DEFAULT_GOAL := help
-.PHONY: help bootstrap doctor status status-internal pakrat-local-feed-test leaf-release-policy-test flycast-release-policy-smoke adb-enable-marker adb-disable-marker adb-tail-logs adb-large-library-create adb-large-library-clean adb-large-library-status adb-install-wrapper adb-uninstall-wrapper benchmark-ppsspp
+.PHONY: help bootstrap doctor status status-internal pakrat-local-feed-test leaf-release-policy-test shader-bundle-release-policy-test flycast-release-policy-smoke adb-enable-marker adb-disable-marker adb-tail-logs adb-large-library-create adb-large-library-clean adb-large-library-status adb-install-wrapper adb-uninstall-wrapper benchmark-ppsspp
 
 help:
 	@echo "Leaf workspace commands (DEVICE=$(DEVICE), WORKSPACE_DIR=$(WORKSPACE_DIR)):"
@@ -34,7 +34,7 @@ help:
 	@echo "  make stage-refresh DEVICE=mlp1            full stage, then run refresh helper"
 	@echo "  make refresh-jawaka DEVICE=mlp1           refresh helper (reboot advised with init hook)"
 	@echo "  make stage-jawaka DEVICE=mlp1             launcher payload only"
-	@echo "  make stage-retroarch DEVICE=mlp1          RetroArch binary + cores + info"
+	@echo "  make stage-retroarch DEVICE=mlp1          RetroArch binary + cores + info + shaders"
 	@echo "  make stage-emulator EMULATOR=ppsspp DEVICE=mlp1 stage a standalone emulator"
 	@echo "  make stage-emulator EMULATOR=drastic DEVICE=mlp1 stage DraStic"
 	@echo "  make stage-emulator EMULATOR=mupen64plus DEVICE=mlp1 stage standalone N64"
@@ -50,6 +50,7 @@ help:
 	@echo "  make release-recovery-zip DEVICE=mlp1     build end-user recovery ZIP"
 	@echo "  make pakrat-local-feed-test               test multi-app and exact-artifact local feeds"
 	@echo "  make leaf-release-policy-test             test stable identity, provenance, and candidate gates"
+	@echo "  make shader-bundle-release-policy-test    test shader bundle integrity release gates"
 	@echo "  make flycast-release-policy-smoke         test standalone Flycast release gates"
 	@echo "  make adb-enable-marker                    enable Leaf launcher marker"
 	@echo "  make adb-disable-marker                   disable Leaf launcher marker"
@@ -101,6 +102,9 @@ pakrat-local-feed-test:
 
 leaf-release-policy-test:
 	python3 scripts/validate-leaf-release-test.py
+
+shader-bundle-release-policy-test:
+	python3 scripts/validate-shader-bundle-release-test.py
 
 adb-enable-marker:
 	scripts/adb-set-marker.sh on

--- a/README.md
+++ b/README.md
@@ -238,8 +238,11 @@ $SDCARD_PATH/.system/leaf/platforms/mlp1/launcher/env.sh
 $SDCARD_PATH/.system/leaf/platforms/mlp1/launcher/bin/...
 $SDCARD_PATH/.system/leaf/platforms/mlp1/bin/
 $SDCARD_PATH/.system/leaf/platforms/mlp1/cores/
+$SDCARD_PATH/.system/leaf/platforms/mlp1/shaders/ # validated release source
 $SDCARD_PATH/.system/leaf/platforms/mlp1/emulators/
 $SDCARD_PATH/.umrk/mlp1/                       # launcher control state (library.db, wifi.conf, ...)
+$SDCARD_PATH/.umrk/mlp1/retroarch/.config/retroarch/shaders/
+                                                # durable Leaf/updater/custom shader browser root
 $SDCARD_PATH/.umrk/mlp1/adb-enabled
 $SDCARD_PATH/.userdata/mlp1/logs/              # durable user/app data + logs
 $SDCARD_PATH/.userdata/shared/

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ make stage DEVICE=mlp1                      # full: launcher payload + all apps
 make stage-refresh DEVICE=mlp1              # full stage, then restart Jawaka GUI
 make refresh-jawaka DEVICE=mlp1             # restart Jawaka/Loong GUI stack only
 make stage-jawaka DEVICE=mlp1               # launcher payload only
-make stage-retroarch DEVICE=mlp1            # RetroArch binary + cores + info
+make stage-retroarch DEVICE=mlp1            # RetroArch binary + cores + info + shaders
 make stage-emulator EMULATOR=drastic DEVICE=mlp1
 make stage-emulator EMULATOR=mupen64plus DEVICE=mlp1
 make stage-emulator EMULATOR=flycast DEVICE=mlp1

--- a/scripts/adb-stage-sd-bundle.sh
+++ b/scripts/adb-stage-sd-bundle.sh
@@ -65,6 +65,18 @@ REMOTE_PLATFORM_ROOT="${REMOTE_PLATFORM_ROOT:-$REMOTE_SYSTEM_PATH/platforms}"
 REMOTE_PLATFORM_PATH="${REMOTE_PLATFORM_PATH:-$REMOTE_PLATFORM_ROOT/$PLATFORM_ID}"
 REMOTE_LAUNCHER_PATH="${REMOTE_LAUNCHER_PATH:-${REMOTE_BUNDLE:-$REMOTE_PLATFORM_PATH/launcher}}"
 MARKER="${UMRK_MARKER_PATH:-$REMOTE_PLATFORM_PATH/enabled}"
+SHADER_PAYLOAD="$PLATFORM_DIR/shaders"
+
+if [ "$PLATFORM_ID" = "mlp1" ] &&
+   [ -d "$SHADER_PAYLOAD/leaf-bundled" ] &&
+   [ -d "$SHADER_PAYLOAD/leaf-recommended" ]; then
+    ADB_SERIAL="$serial" \
+    PLATFORM_ID="$PLATFORM_ID" \
+    REMOTE_SDCARD_PATH="$REMOTE_SDCARD_PATH" \
+    REMOTE_SYSTEM_PATH="$REMOTE_SYSTEM_PATH" \
+    REMOTE_PLATFORM_PATH="$REMOTE_PLATFORM_PATH" \
+        "$ROOT_DIR/scripts/adb-sync-shader-namespaces.sh" --migrate-only
+fi
 
 echo "Deploying bundle to $REMOTE_LAUNCHER_PATH"
 "${ADB[@]}" shell "mkdir -p '$REMOTE_PLATFORM_PATH' && rm -rf '$REMOTE_LAUNCHER_PATH' && mkdir -p '$REMOTE_LAUNCHER_PATH'"
@@ -75,7 +87,7 @@ if [ -d "$PLATFORM_DIR" ]; then
     echo "Deploying platform payload to $REMOTE_PLATFORM_PATH ($PLATFORM_MODE)"
     "${ADB[@]}" shell "mkdir -p '$REMOTE_PLATFORM_PATH'"
     if [ "$PLATFORM_MODE" = "replace" ]; then
-        for name in bin cores info defaults platform.d autoconfig boot-animation manifest.json; do
+        for name in bin cores info defaults platform.d autoconfig boot-animation shaders manifest.json; do
             "${ADB[@]}" shell "rm -rf '$REMOTE_PLATFORM_PATH/$name'"
         done
     fi
@@ -95,6 +107,17 @@ if [ -d "$PLATFORM_DIR" ]; then
             "${ADB[@]}" push "$entry" "$remote_entry" >/dev/null
         fi
     done
+fi
+
+if [ "$PLATFORM_ID" = "mlp1" ] &&
+   [ -d "$SHADER_PAYLOAD/leaf-bundled" ] &&
+   [ -d "$SHADER_PAYLOAD/leaf-recommended" ]; then
+    ADB_SERIAL="$serial" \
+    PLATFORM_ID="$PLATFORM_ID" \
+    REMOTE_SDCARD_PATH="$REMOTE_SDCARD_PATH" \
+    REMOTE_SYSTEM_PATH="$REMOTE_SYSTEM_PATH" \
+    REMOTE_PLATFORM_PATH="$REMOTE_PLATFORM_PATH" \
+        "$ROOT_DIR/scripts/adb-sync-shader-namespaces.sh" --sync-only
 fi
 
 case "$MARKER_MODE" in

--- a/scripts/adb-sync-shader-namespaces.sh
+++ b/scripts/adb-sync-shader-namespaces.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLATFORM_ID="${PLATFORM_ID:-mlp1}"
+REQUESTED_REMOTE_SDCARD_PATH="${REMOTE_SDCARD_PATH:-auto}"
+MODE="all"
+
+case "${1:-}" in
+    "") ;;
+    --migrate-only) MODE="migrate" ;;
+    --sync-only) MODE="sync" ;;
+    *)
+        echo "usage: $0 [--migrate-only|--sync-only]" >&2
+        exit 1
+        ;;
+esac
+
+if [ -n "${ADB_SERIAL:-}" ]; then
+    serial="$ADB_SERIAL"
+else
+    serial="$(adb devices | awk 'NR>1 && $2=="device" {print $1; exit}')"
+fi
+[ -n "${serial:-}" ] || {
+    echo "No online adb device found." >&2
+    exit 1
+}
+ADB=(adb -s "$serial")
+
+remote_sd="$(
+    PLATFORM_ID="$PLATFORM_ID" \
+    REMOTE_SDCARD_PATH="$REQUESTED_REMOTE_SDCARD_PATH" \
+    ADB_SERIAL="$serial" \
+        "$ROOT_DIR/scripts/adb-resolve-umrk-sd.sh"
+)"
+remote_system="${REMOTE_SYSTEM_PATH:-$remote_sd/.system/leaf}"
+remote_platform="${REMOTE_PLATFORM_PATH:-$remote_system/platforms/$PLATFORM_ID}"
+remote_bundle="$remote_platform/shaders"
+remote_user_shaders="${UMRK_RETROARCH_USER_SHADERS_DIR:-$remote_sd/.umrk/$PLATFORM_ID/retroarch/.config/retroarch/shaders}"
+
+"${ADB[@]}" shell sh -s -- "$remote_bundle" "$remote_user_shaders" "$MODE" <<'REMOTE_SH'
+set -eu
+
+bundle_root="$1"
+user_root="$2"
+mode="$3"
+
+migrate_legacy_downloads() {
+    legacy="$bundle_root/shaders_glsl"
+    downloaded="$user_root/shaders_glsl"
+    [ -d "$legacy" ] || return 0
+    [ ! -e "$downloaded" ] || return 0
+    preset_count="$(find "$legacy" -type f -name '*.glslp' 2>/dev/null |
+        wc -l | tr -d ' ')"
+    case "$preset_count" in
+        ''|*[!0-9]*) return 0 ;;
+    esac
+    [ "$preset_count" -gt 11 ] || return 0
+    mkdir -p "$user_root"
+    tmp="$downloaded.tmp.$$"
+    rm -rf "$tmp" 2>/dev/null || true
+    cp -R "$legacy" "$tmp"
+    mv "$tmp" "$downloaded"
+    echo "Preserved $preset_count updater shader presets at $downloaded"
+}
+
+sync_namespace() {
+    namespace="$1"
+    src="$bundle_root/$namespace"
+    dst="$user_root/$namespace"
+    tmp="$dst.tmp.$$"
+    previous="$dst.previous.$$"
+    [ -d "$src" ] || {
+        echo "missing Leaf shader namespace: $src" >&2
+        exit 1
+    }
+    rm -rf "$tmp" "$previous" 2>/dev/null || true
+    cp -R "$src" "$tmp"
+    if [ -e "$dst" ]; then
+        mv "$dst" "$previous"
+    fi
+    if ! mv "$tmp" "$dst"; then
+        [ ! -e "$previous" ] || mv "$previous" "$dst" 2>/dev/null || true
+        echo "failed to promote Leaf shader namespace: $namespace" >&2
+        exit 1
+    fi
+    rm -rf "$previous" 2>/dev/null || true
+}
+
+case "$mode" in
+    all|migrate) migrate_legacy_downloads ;;
+esac
+case "$mode" in
+    all|sync)
+        mkdir -p "$user_root/custom"
+        sync_namespace leaf-bundled
+        sync_namespace leaf-recommended
+        echo "Synchronized Leaf shader namespaces at $user_root"
+        ;;
+esac
+REMOTE_SH

--- a/scripts/make-sd-release-zip.sh
+++ b/scripts/make-sd-release-zip.sh
@@ -30,6 +30,8 @@ MLP1_CORE_PROBE_RUNNER="${MLP1_CORE_PROBE_RUNNER:-$CORES_SPRUCE_DIR/probe-mlp1-c
 TOOLCHAIN_IMAGE="${TOOLCHAIN_IMAGE:-ghcr.io/utility-muffin-research-kitchen/mlp1-toolchain:local}"
 MLP1_RETROARCH_BIN="${MLP1_RETROARCH_BIN:-$RETROARCH_BUILDS_DIR/output/mlp1/bin/retroarch}"
 MLP1_RETROARCH_MANIFEST="${MLP1_RETROARCH_MANIFEST:-$RETROARCH_BUILDS_DIR/output/mlp1/build-manifest.json}"
+MLP1_SHADERS_DIR="${MLP1_SHADERS_DIR:-$RETROARCH_BUILDS_DIR/output/mlp1/shaders}"
+MLP1_SHADER_TOOL="${MLP1_SHADER_TOOL:-$RETROARCH_BUILDS_DIR/scripts/mlp1_shader_bundle.py}"
 MLP1_CORES_DIR="${MLP1_CORES_DIR:-$CORES_SPRUCE_DIR/output/mlp1/cores}"
 MLP1_CORES_REPORT="${MLP1_CORES_REPORT:-$CORES_SPRUCE_DIR/output/mlp1/build-report.json}"
 MLP1_PPSSPP_PACKAGE="${MLP1_PPSSPP_PACKAGE:-$PPSSPP_SPRUCE_DIR/output/mlp1/ppsspp}"
@@ -460,6 +462,15 @@ validate_retroarch_contract() {
         || die "RetroArch runtime metadata contract validation failed"
 }
 
+validate_shader_bundle() {
+    local platform_dir="$1"
+    local license_root="$2"
+    python3 "$MLP1_SHADER_TOOL" validate --output "$platform_dir/shaders" ||
+        die "MLP1 shader bundle release validation failed"
+    [ -f "$license_root/SHADERS.md" ] ||
+        die "missing shader license notice: $license_root/SHADERS.md"
+}
+
 validate_portmaster_integration() {
     local release_root="$1"
     python3 - "$release_root" <<'EOF' || die "PortMaster integration validation failed"
@@ -567,6 +578,11 @@ build_missing_platform_bits() {
         echo "MLP1 RetroArch missing; building in $RETROARCH_BUILDS_DIR"
         (cd "$RETROARCH_BUILDS_DIR" && MLP1_PATCH_SET="$MLP1_RETROARCH_PATCH_SET" ./build-mlp1.sh)
     fi
+
+    make -C "$RETROARCH_BUILDS_DIR" shaders-mlp1 \
+        MLP1_SHADER_OUTPUT="$MLP1_SHADERS_DIR"
+    python3 "$MLP1_SHADER_TOOL" validate --output "$MLP1_SHADERS_DIR" ||
+        die "MLP1 shader bundle validation failed"
 
     if ! ( [ -d "$MLP1_CORES_DIR" ] && find "$MLP1_CORES_DIR" -maxdepth 1 -type f -name '*_libretro.so' | grep -q . ); then
         echo "MLP1 cores missing; building in $CORES_SPRUCE_DIR"
@@ -825,6 +841,7 @@ build_install_zip() {
         DEVICE=mlp1 \
         MLP1_RETROARCH_BIN="$MLP1_RETROARCH_BIN" \
         MLP1_RETROARCH_MANIFEST="$MLP1_RETROARCH_MANIFEST" \
+        MLP1_SHADERS_DIR="$MLP1_SHADERS_DIR" \
         MLP1_CORES_DIR="$MLP1_CORES_DIR" \
         MLP1_CORES_REPORT="$MLP1_CORES_REPORT" \
         assemble-jawaka
@@ -857,6 +874,7 @@ build_install_zip() {
     cp -R "$LEAF_ROOT/stage/licenses" "$RELEASE_ROOT/licenses"
     validate_packaged_cores "$RELEASE_ROOT"
     validate_retroarch_contract "$RELEASE_ROOT/platforms/mlp1"
+    validate_shader_bundle "$RELEASE_ROOT/platforms/mlp1" "$RELEASE_ROOT/licenses"
 
     for app in $STAGE_APPS; do
         package_app "$app"

--- a/scripts/validate-shader-bundle-release-test.py
+++ b/scripts/validate-shader-bundle-release-test.py
@@ -60,6 +60,13 @@ def main() -> int:
         raise SystemExit("missing Leaf shader notice")
 
     manifest = json.loads((BUNDLE / "manifest.json").read_text(encoding="utf-8"))
+    preset_paths = {row["path"] for row in manifest["presets"]}
+    if any(path.startswith("shaders_glsl/") for path in preset_paths):
+        raise SystemExit("release bundle collides with RetroArch updater namespace")
+    if not any(path.startswith("leaf-bundled/") for path in preset_paths):
+        raise SystemExit("release bundle lacks isolated leaf-bundled presets")
+    if not any(path.startswith("leaf-recommended/") for path in preset_paths):
+        raise SystemExit("release bundle lacks leaf-recommended presets")
     shader_path = next(
         row["path"]
         for row in manifest["files"]

--- a/scripts/validate-shader-bundle-release-test.py
+++ b/scripts/validate-shader-bundle-release-test.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Smoke-test Leaf's MLP1 shader bundle release gate."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+LEAF_ROOT = Path(__file__).resolve().parents[1]
+WORKSPACE_ROOT = LEAF_ROOT.parent
+RETROARCH_BUILDS = WORKSPACE_ROOT / "retroarch-builds"
+TOOL = RETROARCH_BUILDS / "scripts" / "mlp1_shader_bundle.py"
+BUNDLE = RETROARCH_BUILDS / "output" / "mlp1" / "shaders"
+
+
+def run(*args: str, expect_success: bool) -> None:
+    result = subprocess.run(
+        args,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if (result.returncode == 0) != expect_success:
+        detail = result.stderr.strip() or result.stdout.strip()
+        expectation = "succeed" if expect_success else "fail"
+        raise SystemExit(f"expected {' '.join(args)} to {expectation}: {detail}")
+
+
+def validate(path: Path, expect_success: bool) -> None:
+    run(
+        "python3",
+        str(TOOL),
+        "validate",
+        "--output",
+        str(path),
+        expect_success=expect_success,
+    )
+
+
+def fixture_copy(root: Path, name: str) -> Path:
+    destination = root / name
+    shutil.copytree(BUNDLE, destination)
+    return destination
+
+
+def main() -> int:
+    run(
+        "make",
+        "-C",
+        str(RETROARCH_BUILDS),
+        "shaders-mlp1",
+        expect_success=True,
+    )
+    if not (LEAF_ROOT / "stage" / "licenses" / "SHADERS.md").is_file():
+        raise SystemExit("missing Leaf shader notice")
+
+    manifest = json.loads((BUNDLE / "manifest.json").read_text(encoding="utf-8"))
+    shader_path = next(
+        row["path"]
+        for row in manifest["files"]
+        if row["path"].endswith((".glsl", ".glslp"))
+    )
+
+    with tempfile.TemporaryDirectory(prefix="leaf-shader-release-") as temporary:
+        root = Path(temporary)
+        valid = fixture_copy(root, "valid")
+        validate(valid, expect_success=True)
+
+        partial = fixture_copy(root, "partial")
+        (partial / shader_path).unlink()
+        validate(partial, expect_success=False)
+
+        modified = fixture_copy(root, "modified")
+        with (modified / shader_path).open("a", encoding="utf-8") as handle:
+            handle.write("\n// release-gate tamper fixture\n")
+        validate(modified, expect_success=False)
+
+        contaminated = fixture_copy(root, "contaminated")
+        state = contaminated / ".umrk" / "should-not-ship.txt"
+        state.parent.mkdir()
+        state.write_text("mutable state\n", encoding="utf-8")
+        validate(contaminated, expect_success=False)
+
+    print("shader-bundle-release-policy-test: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/stage/licenses/SHADERS.md
+++ b/stage/licenses/SHADERS.md
@@ -24,3 +24,9 @@ full game-content gates and back five of those recommendations. CRT Lottes Fast
 loads safely but remains advanced-only because it measured 34.017 FPS at 60 Hz.
 CRT Lite must be used with BFI off. Qualification details and constraints are
 recorded in the bundle manifest and its pinned recommendation metadata.
+
+The installed release keeps this manifest-validated source bundle under the
+platform tree, but RetroArch browses a synchronized durable shader root. Leaf
+updates replace only `leaf-bundled/` and `leaf-recommended/` there.
+RetroArch's online updater owns `shaders_glsl/`, and users own `custom/`; those
+namespaces are preserved across Leaf install and staging updates.

--- a/stage/licenses/SHADERS.md
+++ b/stage/licenses/SHADERS.md
@@ -1,0 +1,20 @@
+# RetroArch GLSL shader notices
+
+Leaf's MLP1 shader bundle is built from the
+[`libretro/glsl-shaders`](https://github.com/libretro/glsl-shaders) repository
+at the exact commit recorded in
+`platforms/mlp1/shaders/manifest.json`.
+
+The initial bundle contains only presets whose complete dependency closures
+carry an embedded public-domain notice. Those notices remain present inside the
+copied shader source files. The bundle manifest records the source path,
+SHA-256 digest, license classification, and evidence path for every installed
+file.
+
+Leaf does not enable a shader automatically. Every preset in the initial bundle
+is marked at least `loads` after MLP1 compile, render, lifecycle, and relaunch
+checks. The four thin presets under `leaf-recommended/` also passed visual
+review and 60-second performance checks at 60/120 Hz, with Black Frame
+Insertion tested where the core/content path is compatible. Qualification
+details and constraints are recorded in the bundle manifest and its pinned
+recommendation metadata.

--- a/stage/licenses/SHADERS.md
+++ b/stage/licenses/SHADERS.md
@@ -1,20 +1,26 @@
 # RetroArch GLSL shader notices
 
-Leaf's MLP1 shader bundle is built from the
-[`libretro/glsl-shaders`](https://github.com/libretro/glsl-shaders) repository
-at the exact commit recorded in
-`platforms/mlp1/shaders/manifest.json`.
+Leaf's MLP1 shader bundle is assembled directly from the original upstream
+repositories at the exact commits recorded in
+`platforms/mlp1/shaders/manifest.json`:
 
-The initial bundle contains only presets whose complete dependency closures
-carry an embedded public-domain notice. Those notices remain present inside the
-copied shader source files. The bundle manifest records the source path,
-SHA-256 digest, license classification, and evidence path for every installed
-file.
+- [`libretro/glsl-shaders`](https://github.com/libretro/glsl-shaders):
+  selected public-domain and MIT-licensed files with embedded notices.
+- [`SkyWalker541/PT-SkyWalker541`](https://github.com/SkyWalker541/PT-SkyWalker541):
+  MIT.
+- [`Woohyun-Kang/Sharp-Shimmerless-Shader`](https://github.com/Woohyun-Kang/Sharp-Shimmerless-Shader):
+  CC0 1.0.
 
-Leaf does not enable a shader automatically. Every preset in the initial bundle
-is marked at least `loads` after MLP1 compile, render, lifecycle, and relaunch
-checks. The four thin presets under `leaf-recommended/` also passed visual
-review and 60-second performance checks at 60/120 Hz, with Black Frame
-Insertion tested where the core/content path is compatible. Qualification
-details and constraints are recorded in the bundle manifest and its pinned
-recommendation metadata.
+Leaf does not source these files from another firmware. The generated bundle
+ships the applicable repository license texts and retains embedded notices.
+Its manifest records the original upstream, commit, tree, source path, SHA-256
+digest, license classification, and evidence path for every installed file.
+
+Leaf does not enable a shader automatically. The nine thin presets under
+`leaf-recommended/` passed visual review and 60-second performance checks at
+60/120 Hz, with Black Frame Insertion tested where the core/content path is
+compatible. PT SkyWalker541, Sharp Shimmerless, and CRT Hyllian Fast passed the
+full game-content gates and back five of those recommendations. CRT Lottes Fast
+loads safely but remains advanced-only because it measured 34.017 FPS at 60 Hz.
+CRT Lite must be used with BFI off. Qualification details and constraints are
+recorded in the bundle manifest and its pinned recommendation metadata.

--- a/stage/mlp1.mk
+++ b/stage/mlp1.mk
@@ -12,6 +12,8 @@ DEVICE_OVERLAY   ?= $(LAUNCHER_SWITCHER_DIR)/device/mlp1
 CATASTROPHE_ASSETS_DIR ?= $(CATASTROPHE_DIR)/res/assets
 MLP1_RETROARCH_BIN ?= $(RETROARCH_BUILDS_DIR)/output/mlp1/bin/retroarch
 MLP1_RETROARCH_MANIFEST ?= $(RETROARCH_BUILDS_DIR)/output/mlp1/build-manifest.json
+MLP1_SHADERS_DIR    ?= $(RETROARCH_BUILDS_DIR)/output/mlp1/shaders
+MLP1_SHADER_TOOL    ?= $(RETROARCH_BUILDS_DIR)/scripts/mlp1_shader_bundle.py
 MLP1_CORES_DIR     ?= $(CORES_SPRUCE_DIR)/output/mlp1/cores
 MLP1_CORES_REPORT  ?= $(CORES_SPRUCE_DIR)/output/mlp1/build-report.json
 MLP1_INFO_DIR      ?= $(CORES_SPRUCE_DIR)/output/mlp1/info
@@ -38,16 +40,21 @@ LEAF_SYSTEM_PAYLOAD_DIR := $(PAYLOAD_ROOT)/.system/leaf
 PLATFORM_PAYLOAD_DIR := $(LEAF_SYSTEM_PAYLOAD_DIR)/platforms/mlp1
 PAYLOAD_DIR          := $(PLATFORM_PAYLOAD_DIR)/launcher
 
-.PHONY: stage stage-app stage-emulator stage-emulators stage-public-root stage-retroarch stage-refresh refresh-jawaka jawaka-build assemble-jawaka stage-jawaka release-zips release-sd-zip release-recovery-zip
+.PHONY: stage stage-app stage-emulator stage-emulators stage-public-root stage-retroarch stage-refresh refresh-jawaka jawaka-build shader-bundle-mlp1 assemble-jawaka stage-jawaka release-zips release-sd-zip release-recovery-zip
 
 # Build the Jawaka MLP1 binaries (cross-compile via its own Docker target).
 jawaka-build:
 	$(MAKE) -C "$(JAWAKA_DIR)" mlp1
 
+shader-bundle-mlp1:
+	$(MAKE) -C "$(RETROARCH_BUILDS_DIR)" shaders-mlp1 MLP1_SHADER_OUTPUT="$(MLP1_SHADERS_DIR)"
+	python3 "$(MLP1_SHADER_TOOL)" validate --output "$(MLP1_SHADERS_DIR)"
+
 # Assemble the launcher payload tree from Jawaka + Catastrophe + RetroArch +
-# cores. Mirrors the former miniloong-launcher-switcher `jawaka-package` target;
-# the device overlay still comes from launcher-switcher (device/mlp1 defaults).
-assemble-jawaka: jawaka-build
+# cores + shaders. Mirrors the former miniloong-launcher-switcher
+# `jawaka-package` target; the device overlay still comes from
+# launcher-switcher (device/mlp1 defaults).
+assemble-jawaka: jawaka-build shader-bundle-mlp1
 	$(MAKE) -C "$(CATASTROPHE_DIR)" assets
 	@for scale in 1 2 3 4; do \
 		asset="$(CATASTROPHE_ASSETS_DIR)/assets@$${scale}x.png"; \
@@ -106,6 +113,10 @@ assemble-jawaka: jawaka-build
 		mkdir -p "$(PLATFORM_PAYLOAD_DIR)/info"; \
 		find "$(MLP1_INFO_DIR)" -maxdepth 1 -type f -name '*_libretro.info' -exec cp -f {} "$(PLATFORM_PAYLOAD_DIR)/info/" \;; \
 	fi
+	@test -d "$(MLP1_SHADERS_DIR)" || { echo "missing MLP1 shader bundle: $(MLP1_SHADERS_DIR)" >&2; exit 1; }
+	@mkdir -p "$(PLATFORM_PAYLOAD_DIR)/shaders"
+	@cp -Rf "$(MLP1_SHADERS_DIR)/." "$(PLATFORM_PAYLOAD_DIR)/shaders/"
+	@python3 "$(MLP1_SHADER_TOOL)" validate --output "$(PLATFORM_PAYLOAD_DIR)/shaders"
 	@test -f "$(PLATFORM_PAYLOAD_DIR)/cores/build-report.json" || { echo "missing MLP1 core build report: $(PLATFORM_PAYLOAD_DIR)/cores/build-report.json" >&2; exit 1; }
 	@python3 "$(UMRK_WORKSPACE_DIR)/scripts/retroarch_validate_package.py" \
 		--metadata-dir "$(MLP1_METADATA_DIR)" \
@@ -139,6 +150,8 @@ stage-retroarch:
 	fi
 	@test -f "$(MLP1_RETROARCH_BIN)" || { echo "missing RetroArch binary: $(MLP1_RETROARCH_BIN)" >&2; exit 1; }
 	@test -d "$(MLP1_CORES_DIR)" || { echo "missing cores dir: $(MLP1_CORES_DIR)" >&2; exit 1; }
+	@$(MAKE) -C "$(RETROARCH_BUILDS_DIR)" shaders-mlp1 MLP1_SHADER_OUTPUT="$(MLP1_SHADERS_DIR)"
+	@python3 "$(MLP1_SHADER_TOOL)" validate --output "$(MLP1_SHADERS_DIR)"
 	@if ! python3 "$(MLP1_CORE_REPORT_TOOL)" verify \
 			--report "$(MLP1_CORES_REPORT)" \
 			--cores-dir "$(MLP1_CORES_DIR)"; then \
@@ -171,7 +184,7 @@ stage-retroarch:
 	if [ -z "$$remote_system" ]; then remote_system="$$remote_sd/.system/leaf"; fi; \
 	remote_platform="$(REMOTE_PLATFORM_PATH)"; \
 	if [ -z "$$remote_platform" ]; then remote_platform="$$remote_system/platforms/mlp1"; fi; \
-	"$${ADB[@]}" shell "mkdir -p '$$remote_platform' && rm -rf '$$remote_platform/bin' '$$remote_platform/cores' '$$remote_platform/info' && mkdir -p '$$remote_platform/bin' '$$remote_platform/cores' '$$remote_platform/info'"; \
+	"$${ADB[@]}" shell "mkdir -p '$$remote_platform' && rm -rf '$$remote_platform/bin' '$$remote_platform/cores' '$$remote_platform/info' '$$remote_platform/shaders' && mkdir -p '$$remote_platform/bin' '$$remote_platform/cores' '$$remote_platform/info' '$$remote_platform/shaders'"; \
 	"$${ADB[@]}" push "$(MLP1_RETROARCH_BIN)" "$$remote_platform/bin/retroarch" >/dev/null; \
 	if [ -f "$(MLP1_RETROARCH_MANIFEST)" ]; then \
 		"$${ADB[@]}" push "$(MLP1_RETROARCH_MANIFEST)" "$$remote_platform/bin/retroarch.build-manifest.json" >/dev/null; \
@@ -183,6 +196,7 @@ stage-retroarch:
 	if [ -d "$(MLP1_INFO_DIR)" ]; then \
 		"$${ADB[@]}" push "$(MLP1_INFO_DIR)/." "$$remote_platform/info/" >/dev/null; \
 	fi; \
+	"$${ADB[@]}" push "$(MLP1_SHADERS_DIR)/." "$$remote_platform/shaders/" >/dev/null; \
 	"$${ADB[@]}" shell "chmod 755 '$$remote_platform/bin/retroarch' '$$remote_platform/cores/'*_libretro.so 2>/dev/null || true"; \
 	"$${ADB[@]}" shell sync; \
 	echo "RetroArch platform payload staged."
@@ -371,6 +385,7 @@ release-zips:
 	TOOLCHAIN_IMAGE="$(TOOLCHAIN_IMAGE)" \
 	MLP1_RETROARCH_BIN="$(MLP1_RETROARCH_BIN)" \
 	MLP1_RETROARCH_MANIFEST="$(MLP1_RETROARCH_MANIFEST)" \
+	MLP1_SHADERS_DIR="$(MLP1_SHADERS_DIR)" \
 	MLP1_CORES_DIR="$(MLP1_CORES_DIR)" \
 	MLP1_CORES_REPORT="$(MLP1_CORES_REPORT)" \
 	MLP1_PPSSPP_PACKAGE="$(MLP1_PPSSPP_PACKAGE)" \
@@ -401,6 +416,7 @@ release-sd-zip:
 	TOOLCHAIN_IMAGE="$(TOOLCHAIN_IMAGE)" \
 	MLP1_RETROARCH_BIN="$(MLP1_RETROARCH_BIN)" \
 	MLP1_RETROARCH_MANIFEST="$(MLP1_RETROARCH_MANIFEST)" \
+	MLP1_SHADERS_DIR="$(MLP1_SHADERS_DIR)" \
 	MLP1_CORES_DIR="$(MLP1_CORES_DIR)" \
 	MLP1_CORES_REPORT="$(MLP1_CORES_REPORT)" \
 	MLP1_PPSSPP_PACKAGE="$(MLP1_PPSSPP_PACKAGE)" \

--- a/stage/mlp1.mk
+++ b/stage/mlp1.mk
@@ -184,6 +184,11 @@ stage-retroarch:
 	if [ -z "$$remote_system" ]; then remote_system="$$remote_sd/.system/leaf"; fi; \
 	remote_platform="$(REMOTE_PLATFORM_PATH)"; \
 	if [ -z "$$remote_platform" ]; then remote_platform="$$remote_system/platforms/mlp1"; fi; \
+	ADB_SERIAL="$$serial" PLATFORM_ID="mlp1" \
+		REMOTE_SDCARD_PATH="$$remote_sd" \
+		REMOTE_SYSTEM_PATH="$$remote_system" \
+		REMOTE_PLATFORM_PATH="$$remote_platform" \
+		"$(LEAF_ROOT)/scripts/adb-sync-shader-namespaces.sh" --migrate-only; \
 	"$${ADB[@]}" shell "mkdir -p '$$remote_platform' && rm -rf '$$remote_platform/bin' '$$remote_platform/cores' '$$remote_platform/info' '$$remote_platform/shaders' && mkdir -p '$$remote_platform/bin' '$$remote_platform/cores' '$$remote_platform/info' '$$remote_platform/shaders'"; \
 	"$${ADB[@]}" push "$(MLP1_RETROARCH_BIN)" "$$remote_platform/bin/retroarch" >/dev/null; \
 	if [ -f "$(MLP1_RETROARCH_MANIFEST)" ]; then \
@@ -197,6 +202,11 @@ stage-retroarch:
 		"$${ADB[@]}" push "$(MLP1_INFO_DIR)/." "$$remote_platform/info/" >/dev/null; \
 	fi; \
 	"$${ADB[@]}" push "$(MLP1_SHADERS_DIR)/." "$$remote_platform/shaders/" >/dev/null; \
+	ADB_SERIAL="$$serial" PLATFORM_ID="mlp1" \
+		REMOTE_SDCARD_PATH="$$remote_sd" \
+		REMOTE_SYSTEM_PATH="$$remote_system" \
+		REMOTE_PLATFORM_PATH="$$remote_platform" \
+		"$(LEAF_ROOT)/scripts/adb-sync-shader-namespaces.sh" --sync-only; \
 	"$${ADB[@]}" shell "chmod 755 '$$remote_platform/bin/retroarch' '$$remote_platform/cores/'*_libretro.so 2>/dev/null || true"; \
 	"$${ADB[@]}" shell sync; \
 	echo "RetroArch platform payload staged."


### PR DESCRIPTION
## Summary

- Build, validate, license, and package the pinned 20-preset MLP1 shader source bundle.
- Add an ADB helper that preserves a legacy updater pack and atomically refreshes only `leaf-bundled/` and `leaf-recommended/` in durable state.
- Use it in full SD staging and focused `stage-retroarch`, and replace the release shader payload with other managed platform directories.
- Reject release bundles that collide with updater-owned `shaders_glsl/`.
- Document namespace ownership in release and runtime docs.

## Why

RetroArch's updater extracts the official GLSL collection into `video_shader_dir/shaders_glsl`. Sharing that path let updater files invalidate Leaf's manifest and made them vulnerable to deletion.

## Impact

The release source stays manifest-validated while RetroArch browses a durable copy. Leaf updates only its namespaces; updater downloads and personal shaders survive. No shader is enabled automatically.

## Validation

- `python3 scripts/validate-shader-bundle-release-test.py`
- Shell syntax checks for both staging scripts
- Full `make stage-jawaka DEVICE=mlp1` build and hardware stage
- Release and durable roots each contain 20 presets; release has no `shaders_glsl/`
- Device migration/sync fixture passed
- All 20 presets passed two hardware load/render runs
