### PR TITLE
release: derive beta identity from one tag, and verify it in the artifact

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,11 @@ help:
 	@echo "  make stage-app APP=Nimbus DEVICE=mlp1       explicitly stage the optional Nimbus app"
 	@echo "  make stage-app APP=PortMaster-mlp1 DEVICE=mlp1 explicitly stage the optional PortMaster app"
 	@echo "  make release-zips DEVICE=mlp1             build end-user install + recovery ZIPs"
-	@echo "  make beta-zips TAG=v0.8.0-beta.3 DEVICE=mlp1  build beta ZIPs (derives all 4 identity values, then verifies)"
+	@echo "  make beta-zips TAG=v0.8.0-beta.3 DEVICE=mlp1  build clean beta ZIPs from one tag, then verify"
 	@echo "  make release-sd-zip DEVICE=mlp1           build end-user install ZIP"
 	@echo "  make release-recovery-zip DEVICE=mlp1     build end-user recovery ZIP"
 	@echo "  make pakrat-local-feed-test               test multi-app and exact-artifact local feeds"
-	@echo "  make leaf-release-policy-test             test stable identity, provenance, and candidate gates"
+	@echo "  make leaf-release-policy-test             test release identity, artifacts, provenance, and gates"
 	@echo "  make shader-bundle-release-policy-test    test shader bundle integrity release gates"
 	@echo "  make flycast-release-policy-smoke         test standalone Flycast release gates"
 	@echo "  make adb-enable-marker                    enable Leaf launcher marker"
@@ -103,6 +103,7 @@ pakrat-local-feed-test:
 
 leaf-release-policy-test:
 	python3 scripts/validate-leaf-release-test.py
+	python3 scripts/verify-release-identity-test.py
 
 shader-bundle-release-policy-test:
 	python3 scripts/validate-shader-bundle-release-test.py

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ help:
 	@echo "  make stage-app APP=Nimbus DEVICE=mlp1       explicitly stage the optional Nimbus app"
 	@echo "  make stage-app APP=PortMaster-mlp1 DEVICE=mlp1 explicitly stage the optional PortMaster app"
 	@echo "  make release-zips DEVICE=mlp1             build end-user install + recovery ZIPs"
+	@echo "  make beta-zips TAG=v0.8.0-beta.3 DEVICE=mlp1  build beta ZIPs (derives all 4 identity values, then verifies)"
 	@echo "  make release-sd-zip DEVICE=mlp1           build end-user install ZIP"
 	@echo "  make release-recovery-zip DEVICE=mlp1     build end-user recovery ZIP"
 	@echo "  make pakrat-local-feed-test               test multi-app and exact-artifact local feeds"

--- a/README.md
+++ b/README.md
@@ -152,34 +152,53 @@ build/release/leaf-mlp1-sd-<release_id>.zip
 build/release/leaf-mlp1-recovery-<release_id>.zip
 ```
 
-`<release_id>` defaults to the current date plus the Leaf git short SHA. To
-choose it explicitly:
+`<release_id>` defaults to the current date plus the Leaf git short SHA for
+untagged local/development builds. To choose it explicitly:
 
 ```sh
 make release-zips DEVICE=mlp1 RELEASE_ID=2026-06-05-test1
 ```
 
-Stable release builds deliberately keep the filesystem/build identity separate
-from the compatibility version. They require an explicit semantic version and
-matching Git tag:
+Published builds use the Git tag as their exact release ID. Stable builds
+require an explicit semantic version and matching tag:
 
 ```sh
 make release-zips DEVICE=mlp1 \
-  RELEASE_ID=2026-07-20-gabc1234 \
+  RELEASE_ID=v0.7.0 \
   LEAF_RELEASE_CHANNEL=stable \
   LEAF_RELEASE_VERSION=0.7.0 \
   LEAF_RELEASE_TAG=v0.7.0
 ```
 
-The build fails before packaging if those values disagree, or if Leaf, the
-launcher, the launcher switcher, Catastrophe, or a bundled app has uncommitted
-changes. Exact component commits are recorded inside the release at
-`provenance/components.json`. Unqualified local builds use the `dev` channel;
-their version may fall back to `RELEASE_ID`. Stable output is only selected
-when `LEAF_RELEASE_CHANNEL=stable` is passed with the version and tag above.
-Beta-channel manifests link to the tester release in `Leaf-beta`; other
-channels default to the main Leaf repository. `LEAF_RELEASE_REPOSITORY` can
-override the target for an intentional alternate release host.
+For a beta, use the guarded one-input target:
+
+```sh
+make beta-zips TAG=v0.8.0-beta.3 DEVICE=mlp1
+```
+
+It accepts only `vX.Y.Z-beta.N`, derives the complete beta identity, builds both
+ZIPs, and verifies the embedded provenance plus `leaf-update.json`. Beta assets
+belong in `Utility-Muffin-Research-Kitchen/Leaf-beta`. Release-candidate tags
+are a separate main-repository/local-manifest rehearsal lane and are
+intentionally not accepted by `beta-zips`.
+
+A tagged build carries four related values:
+
+| Value | Role |
+| --- | --- |
+| `RELEASE_ID` | Exact artifact name, on-card release directory, and OTA equality identity. |
+| `LEAF_RELEASE_VERSION` | Installed Device Info label and semantic Pak Rat compatibility identity. Prerelease suffixes remain visible; compatibility compares the `MAJOR.MINOR.PATCH` core. |
+| `LEAF_RELEASE_CHANNEL` | Build/publication policy and default release-notes repository. The device's own update-channel setting chooses which feed it checks. |
+| `LEAF_RELEASE_TAG` | GitHub publication reference recorded in provenance. |
+
+All tagged install builds fail before packaging if Leaf, the launcher, the
+launcher switcher, Catastrophe, or a bundled app has uncommitted changes.
+Tagged builds also require `RELEASE_ID` to match `LEAF_RELEASE_TAG`. Exact
+component commits are recorded inside the release at
+`provenance/components.json`. Unqualified local builds use the `dev` channel
+and may fall back to `RELEASE_ID` for version. `LEAF_RELEASE_REPOSITORY` can
+override the default host when calling `release-zips` directly; `beta-zips`
+pins it to `Leaf-beta`.
 
 The install ZIP is extracted directly to the SD-card root. It must not be
 placed inside another folder. The SD card should be FAT32 or ext4; do not use

--- a/scripts/make-sd-release-zip.sh
+++ b/scripts/make-sd-release-zip.sh
@@ -160,7 +160,7 @@ configure_release_components() {
 write_component_provenance() {
     local output="$1"
     local clean_args=()
-    if [ "$LEAF_RELEASE_CHANNEL" = "stable" ]; then
+    if [ -n "$LEAF_RELEASE_TAG" ]; then
         clean_args+=(--require-clean)
     fi
     python3 "$RELEASE_POLICY_TOOL" provenance \

--- a/scripts/validate-leaf-release-test.py
+++ b/scripts/validate-leaf-release-test.py
@@ -41,20 +41,22 @@ def init_repo(path: Path) -> None:
 
 class IdentityTests(unittest.TestCase):
     def test_stable_identity_requires_explicit_matching_version_and_tag(self):
-        MODULE.validate_identity("stable", "0.7.0", "v0.7.0", "build-123")
+        MODULE.validate_identity("stable", "0.7.0", "v0.7.0", "v0.7.0")
         with self.assertRaisesRegex(MODULE.PolicyError, "LEAF_RELEASE_VERSION"):
-            MODULE.validate_identity("stable", "", "v0.7.0", "build-123")
+            MODULE.validate_identity("stable", "", "v0.7.0", "v0.7.0")
         with self.assertRaisesRegex(MODULE.PolicyError, "does not match"):
-            MODULE.validate_identity("stable", "0.7.0", "v0.7.1", "build-123")
+            MODULE.validate_identity("stable", "0.7.0", "v0.7.1", "v0.7.1")
         with self.assertRaisesRegex(MODULE.PolicyError, "explicit LEAF_RELEASE_TAG"):
-            MODULE.validate_identity("stable", "0.7.0", "", "build-123")
+            MODULE.validate_identity("stable", "0.7.0", "", "v0.7.0")
+        with self.assertRaisesRegex(MODULE.PolicyError, "RELEASE_ID"):
+            MODULE.validate_identity("stable", "0.7.0", "v0.7.0", "build-123")
 
     def test_stable_identity_accepts_supported_ota_suffix(self):
         MODULE.validate_identity(
             "stable",
             "0.7.0-save-isolation-ota1",
             "v0.7.0-save-isolation-ota1",
-            "build-123",
+            "v0.7.0-save-isolation-ota1",
         )
 
     def test_nonstable_identity_may_use_build_identity_as_version(self):
@@ -64,6 +66,25 @@ class IdentityTests(unittest.TestCase):
             "",
             "2026-07-20-gabc1234",
         )
+
+    def test_beta_tag_requires_exact_numeric_beta_shape(self):
+        for tag in ("v0.8.0-beta.1", "v12.34.56-beta.9"):
+            with self.subTest(tag=tag):
+                self.assertEqual(MODULE.validate_beta_tag(tag), tag[1:])
+
+        for tag in (
+            "",
+            "0.8.0-beta.1",
+            "v0.8-beta.1",
+            "v0.8.0-beta.",
+            "v0.8.0-beta.1junk",
+            "v0.8.0-foo-beta.1",
+            "v0.8.0-beta.1+build",
+            "v0.8.0-rc.1",
+        ):
+            with self.subTest(tag=tag):
+                with self.assertRaisesRegex(MODULE.PolicyError, "must match"):
+                    MODULE.validate_beta_tag(tag)
 
 
 class ProvenanceTests(unittest.TestCase):
@@ -82,7 +103,7 @@ class ProvenanceTests(unittest.TestCase):
                 channel="stable",
                 version="0.7.0",
                 tag="v0.7.0",
-                release_id="build-123",
+                release_id="v0.7.0",
                 component=components,
                 require_clean=True,
             )
@@ -97,7 +118,7 @@ class ProvenanceTests(unittest.TestCase):
             self.assertTrue(all(len(row["commit"]) == 40 for row in rows))
             self.assertTrue(all(row["dirty"] is False for row in rows))
 
-    def test_stable_provenance_rejects_dirty_component(self):
+    def test_tagged_provenance_rejects_dirty_component(self):
         with tempfile.TemporaryDirectory() as raw:
             base = Path(raw)
             components = []
@@ -110,12 +131,63 @@ class ProvenanceTests(unittest.TestCase):
                 channel="stable",
                 version="0.7.0",
                 tag="v0.7.0",
-                release_id="build-123",
+                release_id="v0.7.0",
                 component=components,
                 require_clean=True,
             )
-            with self.assertRaisesRegex(MODULE.PolicyError, "stable component is dirty"):
+            with self.assertRaisesRegex(
+                MODULE.PolicyError, "tagged release component is dirty"
+            ):
                 MODULE.build_provenance(args)
+
+    def test_tagged_beta_provenance_is_clean_even_without_explicit_flag(self):
+        with tempfile.TemporaryDirectory() as raw:
+            base = Path(raw)
+            components = []
+            for name in ("leaf", "launcher", "launcher-switcher"):
+                repo = base / name
+                init_repo(repo)
+                components.append(f"{name}={repo}")
+            (base / "launcher" / "tracked.txt").write_text(
+                "dirty\n", encoding="utf-8"
+            )
+            args = SimpleNamespace(
+                channel="beta",
+                version="0.8.0-beta.1",
+                tag="v0.8.0-beta.1",
+                release_id="v0.8.0-beta.1",
+                component=components,
+                require_clean=False,
+            )
+            with self.assertRaisesRegex(
+                MODULE.PolicyError, "tagged release component is dirty"
+            ):
+                MODULE.build_provenance(args)
+
+    def test_untagged_dev_provenance_records_dirty_component(self):
+        with tempfile.TemporaryDirectory() as raw:
+            base = Path(raw)
+            components = []
+            for name in ("leaf", "launcher", "launcher-switcher"):
+                repo = base / name
+                init_repo(repo)
+                components.append(f"{name}={repo}")
+            (base / "launcher" / "tracked.txt").write_text(
+                "dirty\n", encoding="utf-8"
+            )
+            args = SimpleNamespace(
+                channel="dev",
+                version="build-123",
+                tag="",
+                release_id="build-123",
+                component=components,
+                require_clean=False,
+            )
+            result = MODULE.build_provenance(args)
+            launcher = next(
+                row for row in result["components"] if row["name"] == "launcher"
+            )
+            self.assertTrue(launcher["dirty"])
 
 
 class CandidateTests(unittest.TestCase):
@@ -157,7 +229,7 @@ class CandidateTests(unittest.TestCase):
                 "channel": "stable",
                 "version": "0.7.0",
                 "tag": "v0.7.0",
-                "release_id": "build-123",
+                "release_id": "v0.7.0",
             },
             "components": [
                 {"name": name, "commit": "a" * 40, "dirty": False, "remote": None}
@@ -176,7 +248,7 @@ class CandidateTests(unittest.TestCase):
         write_executable(
             install / "umrk-launcher-install.sh",
             (
-                '#!/bin/sh\nRELEASE_ID="build-123"\nRELEASE_VERSION="0.7.0"\n'
+                '#!/bin/sh\nRELEASE_ID="v0.7.0"\nRELEASE_VERSION="0.7.0"\n'
                 'cat <<EOF\n"version": "$RELEASE_VERSION"\n'
                 '"release_id": "$RELEASE_ID"\nEOF\n'
             ).encode(),
@@ -185,7 +257,7 @@ class CandidateTests(unittest.TestCase):
             release_root=root,
             install_stage=install,
             version="0.7.0",
-            release_id="build-123",
+            release_id="v0.7.0",
             required_component=[
                 "leaf",
                 "launcher",
@@ -260,6 +332,54 @@ class CandidateTests(unittest.TestCase):
             )
             config.write_text('input_player1_l3_btn = "nul"\n', encoding="utf-8")
             with self.assertRaisesRegex(MODULE.PolicyError, "input_player1_l3_btn"):
+                MODULE.validate_candidate(args)
+
+    def test_candidate_rejects_dirty_tagged_beta_provenance(self):
+        with tempfile.TemporaryDirectory() as raw:
+            args = self.make_candidate(Path(raw))
+            provenance_path = args.release_root / "provenance" / "components.json"
+            provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+            provenance["release"]["channel"] = "beta"
+            provenance["release"]["version"] = "0.7.0-beta.1"
+            provenance["release"]["tag"] = "v0.7.0-beta.1"
+            provenance["release"]["release_id"] = "v0.7.0-beta.1"
+            provenance["components"][0]["dirty"] = True
+            provenance_path.write_text(json.dumps(provenance), encoding="utf-8")
+            args.version = "0.7.0-beta.1"
+            args.release_id = "v0.7.0-beta.1"
+            installer = args.install_stage / "umrk-launcher-install.sh"
+            installer.write_text(
+                installer.read_text(encoding="utf-8")
+                .replace('RELEASE_ID="v0.7.0"', 'RELEASE_ID="v0.7.0-beta.1"')
+                .replace(
+                    'RELEASE_VERSION="0.7.0"',
+                    'RELEASE_VERSION="0.7.0-beta.1"',
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(
+                MODULE.PolicyError,
+                "tagged release component provenance is dirty",
+            ):
+                MODULE.validate_candidate(args)
+
+    def test_candidate_rejects_tag_and_release_id_mismatch(self):
+        with tempfile.TemporaryDirectory() as raw:
+            args = self.make_candidate(Path(raw))
+            provenance_path = args.release_root / "provenance" / "components.json"
+            provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+            provenance["release"]["release_id"] = "build-123"
+            provenance_path.write_text(json.dumps(provenance), encoding="utf-8")
+            args.release_id = "build-123"
+            installer = args.install_stage / "umrk-launcher-install.sh"
+            installer.write_text(
+                installer.read_text(encoding="utf-8").replace(
+                    'RELEASE_ID="v0.7.0"',
+                    'RELEASE_ID="build-123"',
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(MODULE.PolicyError, "RELEASE_ID"):
                 MODULE.validate_candidate(args)
 
 

--- a/scripts/validate-leaf-release-test.py
+++ b/scripts/validate-leaf-release-test.py
@@ -77,6 +77,8 @@ class IdentityTests(unittest.TestCase):
             "0.8.0-beta.1",
             "v0.8-beta.1",
             "v0.8.0-beta.",
+            "v0.8.0-beta.0",
+            "v0.8.0-beta.01",
             "v0.8.0-beta.1junk",
             "v0.8.0-foo-beta.1",
             "v0.8.0-beta.1+build",

--- a/scripts/validate-leaf-release.py
+++ b/scripts/validate-leaf-release.py
@@ -18,6 +18,7 @@ VERSION_RE = re.compile(
     r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
     r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
 )
+BETA_TAG_RE = re.compile(r"v[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+")
 COMPONENT_NAME_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]*")
 REQUIRED_PATH_LISTS = {
     "SDCARD_PATHS": ("/mnt/sdcard", "/media/sdcard1"),
@@ -56,11 +57,22 @@ def normalized_tag(tag: str) -> str:
     return validate_version(tag[1:], "release tag")
 
 
+def validate_beta_tag(tag: str) -> str:
+    if not BETA_TAG_RE.fullmatch(tag or ""):
+        raise PolicyError("beta tag must match vX.Y.Z-beta.N exactly")
+    return validate_version(tag[1:], "beta tag")
+
+
 def validate_identity(channel: str, version: str, tag: str, release_id: str) -> None:
     if not channel:
         raise PolicyError("release channel must not be empty")
     if not release_id:
         raise PolicyError("release id must not be empty")
+    if tag and release_id != tag:
+        raise PolicyError(
+            "tagged releases require RELEASE_ID to match LEAF_RELEASE_TAG: "
+            f"{release_id!r} != {tag!r}"
+        )
     if channel == "stable":
         validate_version(version, "LEAF_RELEASE_VERSION")
         tag_version = normalized_tag(tag)
@@ -131,7 +143,7 @@ def inspect_component(name: str, repo: Path, require_clean: bool) -> dict[str, o
     dirty = bool(status)
     if require_clean and dirty:
         preview = ", ".join(line[3:] for line in status.splitlines()[:5])
-        raise PolicyError(f"stable component is dirty: {name} ({preview})")
+        raise PolicyError(f"tagged release component is dirty: {name} ({preview})")
     remote = run_git(
         repo,
         "config",
@@ -150,6 +162,7 @@ def inspect_component(name: str, repo: Path, require_clean: bool) -> dict[str, o
 
 def build_provenance(args: argparse.Namespace) -> dict[str, object]:
     validate_identity(args.channel, args.version, args.tag, args.release_id)
+    require_clean = args.require_clean or bool(args.tag)
     seen: set[str] = set()
     components: list[dict[str, object]] = []
     for raw in args.component:
@@ -157,7 +170,7 @@ def build_provenance(args: argparse.Namespace) -> dict[str, object]:
         if name in seen:
             raise PolicyError(f"duplicate component name: {name}")
         seen.add(name)
-        components.append(inspect_component(name, repo, args.require_clean))
+        components.append(inspect_component(name, repo, require_clean))
     for required in ("leaf", "launcher", "launcher-switcher"):
         if required not in seen:
             raise PolicyError(f"missing required provenance component: {required}")
@@ -299,16 +312,25 @@ def validate_candidate(args: argparse.Namespace) -> None:
     release = provenance.get("release")
     if not isinstance(release, dict):
         raise PolicyError("component provenance is missing release identity")
+    channel = release.get("channel")
+    version = release.get("version")
+    tag = release.get("tag")
+    release_id = release.get("release_id")
     if (
-        release.get("version") != args.version
-        or release.get("release_id") != args.release_id
+        not isinstance(channel, str)
+        or not isinstance(version, str)
+        or (tag is not None and not isinstance(tag, str))
+        or not isinstance(release_id, str)
     ):
+        raise PolicyError("component provenance contains an invalid release identity")
+    validate_identity(channel, version, tag or "", release_id)
+    if version != args.version or release_id != args.release_id:
         raise PolicyError("component provenance release identity does not match candidate")
     components = provenance.get("components")
     if not isinstance(components, list):
         raise PolicyError("component provenance is missing components")
     names: set[str] = set()
-    stable = release.get("channel") == "stable"
+    tagged = bool(tag)
     for item in components:
         if not isinstance(item, dict):
             raise PolicyError("component provenance contains a non-object entry")
@@ -320,8 +342,8 @@ def validate_candidate(args: argparse.Namespace) -> None:
             raise PolicyError(f"component provenance contains duplicate name: {name}")
         if not isinstance(commit, str) or not re.fullmatch(r"[0-9a-f]{40,64}", commit):
             raise PolicyError(f"component provenance contains invalid commit: {name}")
-        if stable and item.get("dirty") is not False:
-            raise PolicyError(f"stable component provenance is dirty: {name}")
+        if tagged and item.get("dirty") is not False:
+            raise PolicyError(f"tagged release component provenance is dirty: {name}")
         names.add(name)
     for required in args.required_component:
         if required not in names:
@@ -354,6 +376,9 @@ def make_parser() -> argparse.ArgumentParser:
     identity.add_argument("--tag", default="")
     identity.add_argument("--release-id", required=True)
 
+    beta_tag = subparsers.add_parser("beta-tag")
+    beta_tag.add_argument("--tag", required=True)
+
     provenance = subparsers.add_parser("provenance")
     provenance.add_argument("--channel", required=True)
     provenance.add_argument("--version", default="")
@@ -382,6 +407,9 @@ def main() -> None:
                 f"version={args.version or '(unset)'} "
                 f"tag={args.tag or '(unset)'} release_id={args.release_id}"
             )
+        elif args.command == "beta-tag":
+            version = validate_beta_tag(args.tag)
+            print(f"beta release identity: tag={args.tag} version={version}")
         elif args.command == "provenance":
             value = build_provenance(args)
             write_json(args.output, value)

--- a/scripts/validate-leaf-release.py
+++ b/scripts/validate-leaf-release.py
@@ -18,7 +18,7 @@ VERSION_RE = re.compile(
     r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
     r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
 )
-BETA_TAG_RE = re.compile(r"v[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+")
+BETA_TAG_RE = re.compile(r"v[0-9]+\.[0-9]+\.[0-9]+-beta\.[1-9][0-9]*")
 COMPONENT_NAME_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]*")
 REQUIRED_PATH_LISTS = {
     "SDCARD_PATHS": ("/mnt/sdcard", "/media/sdcard1"),

--- a/scripts/verify-release-identity-test.py
+++ b/scripts/verify-release-identity-test.py
@@ -246,6 +246,8 @@ class BetaMakeTargetTests(unittest.TestCase):
             "0.8.0-beta.1",
             "v0.8-beta.1",
             "v0.8.0-beta.",
+            "v0.8.0-beta.0",
+            "v0.8.0-beta.01",
             "v0.8.0-beta.1junk",
             "v0.8.0-foo-beta.1",
             "v0.8.0-beta.1+build",

--- a/scripts/verify-release-identity-test.py
+++ b/scripts/verify-release-identity-test.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "verify-release-identity.py"
+BETA_REPOSITORY = "Utility-Muffin-Research-Kitchen/Leaf-beta"
+
+
+def release_payload(tag: str, channel: str = "beta") -> dict[str, object]:
+    return {
+        "schema": 1,
+        "product": "leaf",
+        "release": {
+            "channel": channel,
+            "version": tag[1:],
+            "tag": tag,
+            "release_id": tag,
+        },
+        "components": [],
+    }
+
+
+def release_manifest(
+    tag: str,
+    channel: str = "beta",
+    repository: str = BETA_REPOSITORY,
+) -> dict[str, object]:
+    return {
+        "schema": 1,
+        "product": "leaf",
+        "channel": channel,
+        "version": tag[1:],
+        "release_id": tag,
+        "platforms": {
+            "mlp1": {
+                "artifact": {"name": f"leaf-mlp1-sd-{tag}.zip"},
+                "recovery_zip": {
+                    "name": f"leaf-mlp1-recovery-{tag}.zip"
+                },
+            }
+        },
+        "notes": {
+            "url": f"https://github.com/{repository}/releases/tag/{tag}"
+        },
+    }
+
+
+def write_release_zip(path: Path, tag: str, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    member = (
+        f".system/leaf/releases/{tag}/provenance/components.json"
+    )
+    with zipfile.ZipFile(path, "w") as zf:
+        if isinstance(payload, str):
+            zf.writestr(member, payload)
+        else:
+            zf.writestr(member, json.dumps(payload))
+
+
+def file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def write_release_manifest(
+    path: Path,
+    tag: str,
+    install_path: Path,
+    recovery_path: Path,
+    repository: str = BETA_REPOSITORY,
+) -> None:
+    payload = release_manifest(tag, repository=repository)
+    mlp1 = payload["platforms"]["mlp1"]
+    mlp1["artifact"].update(
+        {"size": install_path.stat().st_size, "sha256": file_sha256(install_path)}
+    )
+    mlp1["recovery_zip"].update(
+        {
+            "size": recovery_path.stat().st_size,
+            "sha256": file_sha256(recovery_path),
+        }
+    )
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def run_verifier(
+    zip_path: Path,
+    tag: str,
+    manifest_path: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    command = [
+        "python3",
+        str(SCRIPT),
+        str(zip_path),
+        "--tag",
+        tag,
+        "--channel",
+        "beta",
+    ]
+    if manifest_path is not None:
+        command += [
+            "--manifest",
+            str(manifest_path),
+            "--repository",
+            BETA_REPOSITORY,
+        ]
+    return subprocess.run(command, capture_output=True, text=True)
+
+
+class VerifierTests(unittest.TestCase):
+    def assert_clean_failure(
+        self, result: subprocess.CompletedProcess[str]
+    ) -> None:
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("error:", result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
+
+    def test_valid_zip_and_manifest(self):
+        tag = "v8.7.6-beta.5"
+        with tempfile.TemporaryDirectory() as raw:
+            base = Path(raw)
+            zip_path = base / f"leaf-mlp1-sd-{tag}.zip"
+            recovery_path = base / f"leaf-mlp1-recovery-{tag}.zip"
+            manifest_path = base / "leaf-update.json"
+            write_release_zip(zip_path, tag, release_payload(tag))
+            recovery_path.write_bytes(b"recovery fixture\n")
+            write_release_manifest(
+                manifest_path, tag, zip_path, recovery_path
+            )
+
+            result = run_verifier(zip_path, tag, manifest_path)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("release manifest OK", result.stdout)
+        self.assertIn("release identity OK", result.stdout)
+
+    def test_missing_or_invalid_zip_has_concise_error(self):
+        tag = "v8.7.6-beta.5"
+        with tempfile.TemporaryDirectory() as raw:
+            base = Path(raw)
+            missing = run_verifier(base / "missing.zip", tag)
+            self.assert_clean_failure(missing)
+
+            invalid_path = base / "invalid.zip"
+            invalid_path.write_bytes(b"not a zip")
+            invalid = run_verifier(invalid_path, tag)
+            self.assert_clean_failure(invalid)
+
+    def test_malformed_or_nonobject_provenance_has_concise_error(self):
+        tag = "v8.7.6-beta.5"
+        with tempfile.TemporaryDirectory() as raw:
+            base = Path(raw)
+            malformed_path = base / "malformed.zip"
+            write_release_zip(malformed_path, tag, "{not json")
+            malformed = run_verifier(malformed_path, tag)
+            self.assert_clean_failure(malformed)
+
+            nonobject_path = base / "nonobject.zip"
+            write_release_zip(nonobject_path, tag, [])
+            nonobject = run_verifier(nonobject_path, tag)
+            self.assert_clean_failure(nonobject)
+
+    def test_manifest_repository_mismatch_fails(self):
+        tag = "v8.7.6-beta.5"
+        with tempfile.TemporaryDirectory() as raw:
+            base = Path(raw)
+            zip_path = base / f"leaf-mlp1-sd-{tag}.zip"
+            recovery_path = base / f"leaf-mlp1-recovery-{tag}.zip"
+            manifest_path = base / "leaf-update.json"
+            write_release_zip(zip_path, tag, release_payload(tag))
+            recovery_path.write_bytes(b"recovery fixture\n")
+            write_release_manifest(
+                manifest_path,
+                tag,
+                zip_path,
+                recovery_path,
+                repository="Utility-Muffin-Research-Kitchen/Leaf",
+            )
+
+            result = run_verifier(zip_path, tag, manifest_path)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("notes.url", result.stderr)
+
+    def test_missing_or_corrupt_recovery_zip_fails(self):
+        tag = "v8.7.6-beta.5"
+        with tempfile.TemporaryDirectory() as raw:
+            base = Path(raw)
+            zip_path = base / f"leaf-mlp1-sd-{tag}.zip"
+            recovery_path = base / f"leaf-mlp1-recovery-{tag}.zip"
+            manifest_path = base / "leaf-update.json"
+            write_release_zip(zip_path, tag, release_payload(tag))
+            recovery_path.write_bytes(b"recovery fixture\n")
+            write_release_manifest(
+                manifest_path, tag, zip_path, recovery_path
+            )
+
+            recovery_path.unlink()
+            missing = run_verifier(zip_path, tag, manifest_path)
+            self.assertEqual(missing.returncode, 1)
+            self.assertIn("recovery_zip.file", missing.stderr)
+
+            recovery_path.write_bytes(b"corrupt replacement\n")
+            corrupt = run_verifier(zip_path, tag, manifest_path)
+            self.assertEqual(corrupt.returncode, 1)
+            self.assertIn("recovery_zip.sha256", corrupt.stderr)
+
+
+class BetaMakeTargetTests(unittest.TestCase):
+    def run_make(
+        self,
+        *arguments: str,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                "make",
+                "-C",
+                str(ROOT),
+                "--no-print-directory",
+                *arguments,
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    def test_beta_target_accepts_only_exact_beta_tags(self):
+        accepted = self.run_make(
+            "beta-zips", "TAG=v0.8.0-beta.1", "MAKE=true"
+        )
+        self.assertEqual(accepted.returncode, 0, accepted.stderr)
+
+        for tag in (
+            "",
+            "0.8.0-beta.1",
+            "v0.8-beta.1",
+            "v0.8.0-beta.",
+            "v0.8.0-beta.1junk",
+            "v0.8.0-foo-beta.1",
+            "v0.8.0-beta.1+build",
+            "v0.8.0-rc.1",
+        ):
+            with self.subTest(tag=tag):
+                assignment = f"TAG={tag}"
+                result = self.run_make(
+                    "beta-zips", assignment, "MAKE=true"
+                )
+                self.assertNotEqual(result.returncode, 0)
+
+    def test_tag_text_is_not_evaluated_by_make_or_recipe_shell(self):
+        with tempfile.TemporaryDirectory() as raw:
+            base = Path(raw)
+            values = (
+                f"v0.8.0-beta.1`id>{base / 'shell-substitution-ran'}`",
+                f"v0.8.0-beta.1$(shell touch {base / 'make-function-ran'})",
+            )
+            for tag in values:
+                with self.subTest(tag=tag):
+                    result = self.run_make(
+                        "beta-zips", f"TAG={tag}", "MAKE=true"
+                    )
+                    self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(list(base.iterdir()), [])
+
+    def test_derived_identity_wins_over_outer_make_assignments(self):
+        tag = "v0.8.0-beta.3"
+        result = self.run_make(
+            "beta-zips",
+            f"TAG={tag}",
+            "LEAF_RELEASE_CHANNEL=stable",
+            "LEAF_RELEASE_VERSION=9.9.9",
+            "LEAF_RELEASE_TAG=v9.9.9",
+            "LEAF_RELEASE_REPOSITORY=example/incorrect",
+            "MAKE=echo",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(f"RELEASE_ID={tag}", result.stdout)
+        self.assertIn("LEAF_RELEASE_CHANNEL=beta", result.stdout)
+        self.assertIn(f"LEAF_RELEASE_VERSION={tag[1:]}", result.stdout)
+        self.assertIn(f"LEAF_RELEASE_TAG={tag}", result.stdout)
+        self.assertIn(
+            f"LEAF_RELEASE_REPOSITORY={BETA_REPOSITORY}",
+            result.stdout,
+        )
+
+    def test_github_tag_context_is_used_and_must_match(self):
+        env = os.environ.copy()
+        env.pop("TAG", None)
+        env["GITHUB_REF_TYPE"] = "tag"
+        env["GITHUB_REF_NAME"] = "v0.8.0-beta.4"
+        accepted = self.run_make("beta-zips", "MAKE=true", env=env)
+        self.assertEqual(accepted.returncode, 0, accepted.stderr)
+
+        env["GITHUB_REF_NAME"] = ""
+        missing = self.run_make("beta-zips", "MAKE=true", env=env)
+        self.assertNotEqual(missing.returncode, 0)
+        self.assertIn("GITHUB_REF_NAME is empty", missing.stderr)
+
+        env["GITHUB_REF_NAME"] = "v0.8.0-beta.4"
+        rejected = self.run_make(
+            "beta-zips",
+            "TAG=v0.8.0-beta.5",
+            "MAKE=true",
+            env=env,
+        )
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("does not match GITHUB_REF_NAME", rejected.stderr)
+
+    def test_verify_target_uses_custom_release_build(self):
+        tag = "v98.76.54-beta.321"
+        with tempfile.TemporaryDirectory() as raw:
+            release_build = Path(raw) / "custom release"
+            zip_path = release_build / f"leaf-mlp1-sd-{tag}.zip"
+            recovery_path = release_build / f"leaf-mlp1-recovery-{tag}.zip"
+            manifest_path = release_build / "leaf-update.json"
+            write_release_zip(zip_path, tag, release_payload(tag))
+            recovery_path.write_bytes(b"recovery fixture\n")
+            write_release_manifest(
+                manifest_path, tag, zip_path, recovery_path
+            )
+
+            result = self.run_make(
+                "verify-beta-zips",
+                f"TAG={tag}",
+                f"RELEASE_BUILD={release_build}",
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("release identity OK", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify-release-identity.py
+++ b/scripts/verify-release-identity.py
@@ -1,44 +1,160 @@
 #!/usr/bin/env python3
-"""Read release identity back out of a built ZIP and check it against the tag.
+"""Read release identity back out of built release artifacts.
 
 Every other identity check in this repo runs on the INPUTS, before the build.
 This one reads the artifact after the fact, which is the only way to catch an
 environment variable that was never set: an unset LEAF_RELEASE_CHANNEL does not
 fail anything, it quietly defaults to "dev" and ships.
 
-That is not hypothetical. Five hand-run betas produced five different metadata
-shapes -- one with channel "stable", two whose version could not tell beta.1
-from beta.2 -- because release_id is the only field with visible consequences
-when it is wrong, so the rest degraded unnoticed for weeks.
+Release ID is the exact artifact/filesystem/OTA identity. Version is the
+installed display and compatibility identity, channel records build policy and
+the default publication repository, and tag records the publication reference.
+They are related, but none is a substitute for another.
 """
 
 from __future__ import annotations
 
 import argparse
-import fnmatch
+import hashlib
 import json
 import sys
 import zipfile
+from pathlib import Path
 
 
-COMPONENTS_GLOB = ".system/leaf/releases/*/provenance/components.json"
+def fail(message: str) -> None:
+    raise SystemExit(f"error: {message}")
 
 
-def load_release_block(zip_path: str) -> dict[str, object]:
-    with zipfile.ZipFile(zip_path) as zf:
-        matches = [n for n in zf.namelist() if fnmatch.fnmatch(n, COMPONENTS_GLOB)]
-        if not matches:
-            raise SystemExit(f"{zip_path}: no {COMPONENTS_GLOB} inside the ZIP")
-        if len(matches) > 1:
-            raise SystemExit(
-                f"{zip_path}: {len(matches)} provenance files, expected 1:\n  "
-                + "\n  ".join(sorted(matches))
-            )
-        payload = json.loads(zf.read(matches[0]))
+def load_release_block(zip_path: str, release_id: str) -> dict[str, object]:
+    member = (
+        f".system/leaf/releases/{release_id}/provenance/components.json"
+    )
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            matches = [name for name in zf.namelist() if name == member]
+            if not matches:
+                fail(f"{zip_path}: no {member} inside the ZIP")
+            if len(matches) > 1:
+                fail(f"{zip_path}: {len(matches)} copies of {member}, expected 1")
+            raw = zf.read(member)
+    except SystemExit:
+        raise
+    except (KeyError, OSError, RuntimeError, zipfile.BadZipFile) as exc:
+        fail(f"{zip_path}: cannot read release provenance: {exc}")
+
+    try:
+        payload = json.loads(raw)
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        fail(f"{zip_path}: {member} is not valid JSON: {exc}")
+    if not isinstance(payload, dict):
+        fail(f"{zip_path}: {member} must contain a JSON object")
     release = payload.get("release")
     if not isinstance(release, dict):
-        raise SystemExit(f"{zip_path}: provenance has no 'release' object")
+        fail(f"{zip_path}: provenance has no 'release' object")
     return release
+
+
+def load_json_object(path: str, label: str) -> dict[str, object]:
+    try:
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        fail(f"{path}: cannot read {label}: {exc}")
+    if not isinstance(payload, dict):
+        fail(f"{path}: {label} must contain a JSON object")
+    return payload
+
+
+def artifact_file_identity(
+    path: Path,
+    descriptor: dict[str, object] | None,
+    label: str,
+) -> dict[str, tuple[object, object]]:
+    if not path.is_file():
+        return {f"{label}.file": ("present", "missing")}
+
+    try:
+        size = path.stat().st_size
+        digest = hashlib.sha256()
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as exc:
+        fail(f"{path}: cannot inspect release artifact: {exc}")
+
+    actual_digest = digest.hexdigest()
+    recorded_size = descriptor.get("size") if descriptor else None
+    recorded_digest = descriptor.get("sha256") if descriptor else None
+    bad: dict[str, tuple[object, object]] = {}
+    if recorded_size != size:
+        bad[f"{label}.size"] = (size, recorded_size)
+    if recorded_digest != actual_digest:
+        bad[f"{label}.sha256"] = (actual_digest, recorded_digest)
+    return bad
+
+
+def manifest_identity(
+    manifest_path: str,
+    install_path: str,
+    tag: str,
+    channel: str,
+    repository: str | None,
+) -> dict[str, tuple[object, object]]:
+    payload = load_json_object(manifest_path, "release manifest")
+    version = tag[1:] if tag.startswith("v") else tag
+    expected: dict[str, object] = {
+        "channel": channel,
+        "version": version,
+        "release_id": tag,
+        "artifact.name": f"leaf-mlp1-sd-{tag}.zip",
+        "recovery_zip.name": f"leaf-mlp1-recovery-{tag}.zip",
+    }
+    if repository:
+        expected["notes.url"] = (
+            f"https://github.com/{repository}/releases/tag/{tag}"
+        )
+
+    platforms = payload.get("platforms")
+    mlp1 = platforms.get("mlp1") if isinstance(platforms, dict) else None
+    artifact = mlp1.get("artifact") if isinstance(mlp1, dict) else None
+    recovery = mlp1.get("recovery_zip") if isinstance(mlp1, dict) else None
+    notes = payload.get("notes")
+    actual = {
+        "channel": payload.get("channel"),
+        "version": payload.get("version"),
+        "release_id": payload.get("release_id"),
+        "artifact.name": artifact.get("name") if isinstance(artifact, dict) else None,
+        "recovery_zip.name": (
+            recovery.get("name") if isinstance(recovery, dict) else None
+        ),
+        "notes.url": notes.get("url") if isinstance(notes, dict) else None,
+    }
+    bad = {
+        key: (want, actual.get(key))
+        for key, want in expected.items()
+        if actual.get(key) != want
+    }
+    install = Path(install_path)
+    if install.name != expected["artifact.name"]:
+        bad["artifact.file_name"] = (expected["artifact.name"], install.name)
+    bad.update(
+        artifact_file_identity(
+            install,
+            artifact if isinstance(artifact, dict) else None,
+            "artifact",
+        )
+    )
+    recovery_path = (
+        Path(manifest_path).parent / str(expected["recovery_zip.name"])
+    )
+    bad.update(
+        artifact_file_identity(
+            recovery_path,
+            recovery if isinstance(recovery, dict) else None,
+            "recovery_zip",
+        )
+    )
+    return bad
 
 
 def main() -> int:
@@ -46,12 +162,14 @@ def main() -> int:
     ap.add_argument("zip", help="built SD release ZIP")
     ap.add_argument("--tag", required=True, help="the release tag, e.g. v0.8.0-beta.3")
     ap.add_argument("--channel", required=True, choices=("dev", "beta", "stable"))
+    ap.add_argument("--manifest", help="optional leaf-update.json to verify")
+    ap.add_argument(
+        "--repository",
+        help="expected owner/repository used by the manifest release-notes URL",
+    )
     args = ap.parse_args()
 
     tag = args.tag
-    # The one asymmetry worth stating outright: version drops the leading "v",
-    # the other three keep it. Getting this backwards is silent and cosmetic,
-    # which is exactly why it went wrong repeatedly.
     expected = {
         "channel": args.channel,
         "version": tag[1:] if tag.startswith("v") else tag,
@@ -59,7 +177,7 @@ def main() -> int:
         "release_id": tag,
     }
 
-    release = load_release_block(args.zip)
+    release = load_release_block(args.zip, tag)
     bad = {k: (v, release.get(k)) for k, v in expected.items() if release.get(k) != v}
 
     for key in ("channel", "version", "tag", "release_id"):
@@ -72,15 +190,30 @@ def main() -> int:
         for key, (want, got) in bad.items():
             print(f"  {key}: expected {want!r}, got {got!r}", file=sys.stderr)
         print(
-            "\nThese come from RELEASE_ID / LEAF_RELEASE_CHANNEL / "
-            "LEAF_RELEASE_VERSION / LEAF_RELEASE_TAG.\n"
-            "Set them as environment variables BEFORE make, not as make "
-            "variables -- release-zips only forwards RELEASE_ID explicitly.",
+            "\nThese values come from RELEASE_ID, LEAF_RELEASE_CHANNEL, "
+            "LEAF_RELEASE_VERSION, and LEAF_RELEASE_TAG.",
             file=sys.stderr,
         )
         return 1
 
-    print(f"\nrelease identity OK for {tag}")
+    if args.manifest:
+        manifest_bad = manifest_identity(
+            args.manifest, args.zip, tag, args.channel, args.repository
+        )
+        if manifest_bad:
+            print(
+                f"\n{args.manifest}: release manifest does not match {tag}",
+                file=sys.stderr,
+            )
+            for key, (want, got) in manifest_bad.items():
+                print(
+                    f"  {key}: expected {want!r}, got {got!r}",
+                    file=sys.stderr,
+                )
+            return 1
+        print(f"\nrelease manifest OK for {tag}")
+
+    print(f"release identity OK for {tag}")
     return 0
 
 

--- a/scripts/verify-release-identity.py
+++ b/scripts/verify-release-identity.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Read release identity back out of a built ZIP and check it against the tag.
+
+Every other identity check in this repo runs on the INPUTS, before the build.
+This one reads the artifact after the fact, which is the only way to catch an
+environment variable that was never set: an unset LEAF_RELEASE_CHANNEL does not
+fail anything, it quietly defaults to "dev" and ships.
+
+That is not hypothetical. Five hand-run betas produced five different metadata
+shapes -- one with channel "stable", two whose version could not tell beta.1
+from beta.2 -- because release_id is the only field with visible consequences
+when it is wrong, so the rest degraded unnoticed for weeks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import sys
+import zipfile
+
+
+COMPONENTS_GLOB = ".system/leaf/releases/*/provenance/components.json"
+
+
+def load_release_block(zip_path: str) -> dict[str, object]:
+    with zipfile.ZipFile(zip_path) as zf:
+        matches = [n for n in zf.namelist() if fnmatch.fnmatch(n, COMPONENTS_GLOB)]
+        if not matches:
+            raise SystemExit(f"{zip_path}: no {COMPONENTS_GLOB} inside the ZIP")
+        if len(matches) > 1:
+            raise SystemExit(
+                f"{zip_path}: {len(matches)} provenance files, expected 1:\n  "
+                + "\n  ".join(sorted(matches))
+            )
+        payload = json.loads(zf.read(matches[0]))
+    release = payload.get("release")
+    if not isinstance(release, dict):
+        raise SystemExit(f"{zip_path}: provenance has no 'release' object")
+    return release
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("zip", help="built SD release ZIP")
+    ap.add_argument("--tag", required=True, help="the release tag, e.g. v0.8.0-beta.3")
+    ap.add_argument("--channel", required=True, choices=("dev", "beta", "stable"))
+    args = ap.parse_args()
+
+    tag = args.tag
+    # The one asymmetry worth stating outright: version drops the leading "v",
+    # the other three keep it. Getting this backwards is silent and cosmetic,
+    # which is exactly why it went wrong repeatedly.
+    expected = {
+        "channel": args.channel,
+        "version": tag[1:] if tag.startswith("v") else tag,
+        "tag": tag,
+        "release_id": tag,
+    }
+
+    release = load_release_block(args.zip)
+    bad = {k: (v, release.get(k)) for k, v in expected.items() if release.get(k) != v}
+
+    for key in ("channel", "version", "tag", "release_id"):
+        got = release.get(key)
+        mark = "  " if key not in bad else "->"
+        print(f"{mark} {key:<11} {got!r}")
+
+    if bad:
+        print(f"\n{args.zip}: release identity does not match {tag}", file=sys.stderr)
+        for key, (want, got) in bad.items():
+            print(f"  {key}: expected {want!r}, got {got!r}", file=sys.stderr)
+        print(
+            "\nThese come from RELEASE_ID / LEAF_RELEASE_CHANNEL / "
+            "LEAF_RELEASE_VERSION / LEAF_RELEASE_TAG.\n"
+            "Set them as environment variables BEFORE make, not as make "
+            "variables -- release-zips only forwards RELEASE_ID explicitly.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"\nrelease identity OK for {tag}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/stage/mlp1.mk
+++ b/stage/mlp1.mk
@@ -37,10 +37,19 @@ REMOTE_APPS_PATH ?=
 
 # --- Leaf staging output (gitignored under /build) -------------------------
 STAGE_BUILD          ?= $(LEAF_ROOT)/build/stage/mlp1
+RELEASE_BUILD        ?= $(LEAF_ROOT)/build/release
 PAYLOAD_ROOT         := $(STAGE_BUILD)/package
 LEAF_SYSTEM_PAYLOAD_DIR := $(PAYLOAD_ROOT)/.system/leaf
 PLATFORM_PAYLOAD_DIR := $(LEAF_SYSTEM_PAYLOAD_DIR)/platforms/mlp1
 PAYLOAD_DIR          := $(PLATFORM_PAYLOAD_DIR)/launcher
+export RELEASE_BUILD
+
+# Command-line variables are automatically exported after recursive expansion.
+# Capture TAG without rescanning it so an untrusted ref cannot invoke a Make
+# function before the recipe's strict beta-tag validator sees it.
+override LEAF_BETA_TAG_INPUT := $(value TAG)
+unexport TAG
+export LEAF_BETA_TAG_INPUT
 
 .PHONY: stage stage-app stage-emulator stage-emulators stage-public-root stage-retroarch stage-refresh refresh-jawaka jawaka-build shader-bundle-mlp1 assemble-jawaka stage-jawaka release-zips release-sd-zip release-recovery-zip beta-zips verify-beta-zips
 
@@ -393,7 +402,12 @@ stage-app:
 release-zips:
 	DEVICE="$(DEVICE)" \
 	LEAF_WORKSPACE_DIR="$(WORKSPACE_DIR)" \
+	RELEASE_BUILD="$(RELEASE_BUILD)" \
 	RELEASE_ID="$(RELEASE_ID)" \
+	LEAF_RELEASE_CHANNEL="$(LEAF_RELEASE_CHANNEL)" \
+	LEAF_RELEASE_VERSION="$(LEAF_RELEASE_VERSION)" \
+	LEAF_RELEASE_TAG="$(LEAF_RELEASE_TAG)" \
+	LEAF_RELEASE_REPOSITORY="$(LEAF_RELEASE_REPOSITORY)" \
 	STAGE_APPS="$(STAGE_APPS)" \
 	STAGE_EMULATORS="$(STAGE_EMULATORS)" \
 	PUBLIC_ROOT_DIRS="$(PUBLIC_ROOT_DIRS)" \
@@ -424,7 +438,12 @@ release-zips:
 release-sd-zip:
 	DEVICE="$(DEVICE)" \
 	LEAF_WORKSPACE_DIR="$(WORKSPACE_DIR)" \
+	RELEASE_BUILD="$(RELEASE_BUILD)" \
 	RELEASE_ID="$(RELEASE_ID)" \
+	LEAF_RELEASE_CHANNEL="$(LEAF_RELEASE_CHANNEL)" \
+	LEAF_RELEASE_VERSION="$(LEAF_RELEASE_VERSION)" \
+	LEAF_RELEASE_TAG="$(LEAF_RELEASE_TAG)" \
+	LEAF_RELEASE_REPOSITORY="$(LEAF_RELEASE_REPOSITORY)" \
 	STAGE_APPS="$(STAGE_APPS)" \
 	STAGE_EMULATORS="$(STAGE_EMULATORS)" \
 	PUBLIC_ROOT_DIRS="$(PUBLIC_ROOT_DIRS)" \
@@ -455,40 +474,73 @@ release-sd-zip:
 release-recovery-zip:
 	DEVICE="$(DEVICE)" \
 	LEAF_WORKSPACE_DIR="$(WORKSPACE_DIR)" \
+	RELEASE_BUILD="$(RELEASE_BUILD)" \
 	RELEASE_ID="$(RELEASE_ID)" \
 	LAUNCHER_SWITCHER_DIR="$(LAUNCHER_SWITCHER_DIR)" \
 	"$(LEAF_ROOT)/scripts/make-sd-release-zip.sh" recovery
 
-# Build the beta ZIPs from one input. Release identity is FOUR values, not one:
-# RELEASE_ID, LEAF_RELEASE_CHANNEL, LEAF_RELEASE_VERSION and LEAF_RELEASE_TAG.
-# Only RELEASE_ID has visible consequences when it is wrong, so on five
-# hand-typed betas the other three drifted unnoticed -- one shipped
-# channel "stable", two shipped a version that could not tell beta.1 from
-# beta.2. Deriving them here is the fix; note that version drops the leading
-# "v" while the other three keep it.
+# Build publishable beta ZIPs from one input. RELEASE_ID is the exact artifact
+# identity; LEAF_RELEASE_VERSION is the display and compatibility identity;
+# LEAF_RELEASE_CHANNEL records beta build/publication policy; LEAF_RELEASE_TAG
+# records the GitHub publication reference. Version drops the leading "v".
 #
 #   make beta-zips TAG=v0.8.0-beta.3 DEVICE=mlp1
 #
-# The env vars go BEFORE the recursive make on purpose: release-zips only
-# forwards RELEASE_ID explicitly, so the rest have to arrive as environment.
+# TAG is consumed from the recipe environment instead of interpolated into
+# shell source. Explicit child-make assignments make the derived identity win
+# over conflicting command-line variables inherited through MAKEOVERRIDES.
 beta-zips:
-	@case "$(TAG)" in \
-	  v[0-9]*-beta.[0-9]*|v[0-9]*-rc.[0-9]*) : ;; \
-	  "") echo "usage: make beta-zips TAG=v0.8.0-beta.3 [DEVICE=mlp1]" >&2; exit 2 ;; \
-	  *) echo "refusing: TAG '$(TAG)' is not a vX.Y.Z-beta.N / -rc.N tag" >&2; exit 2 ;; \
-	esac
-	@echo "==> beta identity: release_id=$(TAG) tag=$(TAG) version=$(patsubst v%,%,$(TAG)) channel=beta"
-	@RELEASE_ID="$(TAG)" \
-	LEAF_RELEASE_TAG="$(TAG)" \
-	LEAF_RELEASE_VERSION="$(patsubst v%,%,$(TAG))" \
-	LEAF_RELEASE_CHANNEL=beta \
-	$(MAKE) --no-print-directory release-zips DEVICE="$(DEVICE)" RELEASE_ID="$(TAG)"
-	@$(MAKE) --no-print-directory verify-beta-zips TAG="$(TAG)" DEVICE="$(DEVICE)"
+	@set -euo pipefail; \
+	tag="$${LEAF_BETA_TAG_INPUT:-}"; \
+	if [ "$${GITHUB_REF_TYPE:-}" = "tag" ]; then \
+		ref_tag="$${GITHUB_REF_NAME:-}"; \
+		if [ -z "$$ref_tag" ]; then \
+			echo "refusing: GITHUB_REF_TYPE is tag but GITHUB_REF_NAME is empty" >&2; \
+			exit 2; \
+		fi; \
+		if [ -n "$$tag" ] && [ "$$tag" != "$$ref_tag" ]; then \
+			echo "refusing: TAG '$$tag' does not match GITHUB_REF_NAME '$$ref_tag'" >&2; \
+			exit 2; \
+		fi; \
+		tag="$$ref_tag"; \
+	fi; \
+	if [ -z "$$tag" ]; then \
+		echo "usage: make beta-zips TAG=v0.8.0-beta.3 [DEVICE=mlp1]" >&2; \
+		exit 2; \
+	fi; \
+	python3 "$(LEAF_ROOT)/scripts/validate-leaf-release.py" beta-tag --tag "$$tag"; \
+	version="$${tag#v}"; \
+	release_build="$${RELEASE_BUILD:-$(LEAF_ROOT)/build/release}"; \
+	echo "==> beta identity: release_id=$$tag tag=$$tag version=$$version channel=beta"; \
+	$(MAKE) --no-print-directory release-zips \
+		DEVICE=mlp1 \
+		TAG="$$tag" \
+		RELEASE_BUILD="$$release_build" \
+		RELEASE_ID="$$tag" \
+		LEAF_RELEASE_CHANNEL=beta \
+		LEAF_RELEASE_VERSION="$$version" \
+		LEAF_RELEASE_TAG="$$tag" \
+		LEAF_RELEASE_REPOSITORY=Utility-Muffin-Research-Kitchen/Leaf-beta; \
+	$(MAKE) --no-print-directory verify-beta-zips \
+		DEVICE=mlp1 \
+		RELEASE_BUILD="$$release_build" \
+		TAG="$$tag"
 
 # Read the identity back out of the artifact. Every other check in this repo
 # runs on the inputs, which cannot catch a variable that was never set -- an
 # unset channel does not fail, it defaults to "dev" and ships.
 verify-beta-zips:
-	@python3 "$(LEAF_ROOT)/scripts/verify-release-identity.py" \
-	  "$(LEAF_ROOT)/build/release/leaf-mlp1-sd-$(TAG).zip" \
-	  --tag "$(TAG)" --channel beta
+	@set -euo pipefail; \
+	tag="$${LEAF_BETA_TAG_INPUT:-}"; \
+	if [ -z "$$tag" ]; then \
+		echo "usage: make verify-beta-zips TAG=v0.8.0-beta.3 [RELEASE_BUILD=...]" >&2; \
+		exit 2; \
+	fi; \
+	release_build="$${RELEASE_BUILD:-$(LEAF_ROOT)/build/release}"; \
+	python3 "$(LEAF_ROOT)/scripts/validate-leaf-release.py" beta-tag --tag "$$tag"; \
+	python3 "$(LEAF_ROOT)/scripts/verify-release-identity.py" \
+		"$$release_build/leaf-mlp1-sd-$$tag.zip" \
+		--manifest "$$release_build/leaf-update.json" \
+		--repository Utility-Muffin-Research-Kitchen/Leaf-beta \
+		--tag "$$tag" \
+		--channel beta

--- a/stage/mlp1.mk
+++ b/stage/mlp1.mk
@@ -42,7 +42,7 @@ LEAF_SYSTEM_PAYLOAD_DIR := $(PAYLOAD_ROOT)/.system/leaf
 PLATFORM_PAYLOAD_DIR := $(LEAF_SYSTEM_PAYLOAD_DIR)/platforms/mlp1
 PAYLOAD_DIR          := $(PLATFORM_PAYLOAD_DIR)/launcher
 
-.PHONY: stage stage-app stage-emulator stage-emulators stage-public-root stage-retroarch stage-refresh refresh-jawaka jawaka-build shader-bundle-mlp1 assemble-jawaka stage-jawaka release-zips release-sd-zip release-recovery-zip
+.PHONY: stage stage-app stage-emulator stage-emulators stage-public-root stage-retroarch stage-refresh refresh-jawaka jawaka-build shader-bundle-mlp1 assemble-jawaka stage-jawaka release-zips release-sd-zip release-recovery-zip beta-zips verify-beta-zips
 
 # Build the Jawaka MLP1 binaries (cross-compile via its own Docker target).
 jawaka-build:
@@ -458,3 +458,37 @@ release-recovery-zip:
 	RELEASE_ID="$(RELEASE_ID)" \
 	LAUNCHER_SWITCHER_DIR="$(LAUNCHER_SWITCHER_DIR)" \
 	"$(LEAF_ROOT)/scripts/make-sd-release-zip.sh" recovery
+
+# Build the beta ZIPs from one input. Release identity is FOUR values, not one:
+# RELEASE_ID, LEAF_RELEASE_CHANNEL, LEAF_RELEASE_VERSION and LEAF_RELEASE_TAG.
+# Only RELEASE_ID has visible consequences when it is wrong, so on five
+# hand-typed betas the other three drifted unnoticed -- one shipped
+# channel "stable", two shipped a version that could not tell beta.1 from
+# beta.2. Deriving them here is the fix; note that version drops the leading
+# "v" while the other three keep it.
+#
+#   make beta-zips TAG=v0.8.0-beta.3 DEVICE=mlp1
+#
+# The env vars go BEFORE the recursive make on purpose: release-zips only
+# forwards RELEASE_ID explicitly, so the rest have to arrive as environment.
+beta-zips:
+	@case "$(TAG)" in \
+	  v[0-9]*-beta.[0-9]*|v[0-9]*-rc.[0-9]*) : ;; \
+	  "") echo "usage: make beta-zips TAG=v0.8.0-beta.3 [DEVICE=mlp1]" >&2; exit 2 ;; \
+	  *) echo "refusing: TAG '$(TAG)' is not a vX.Y.Z-beta.N / -rc.N tag" >&2; exit 2 ;; \
+	esac
+	@echo "==> beta identity: release_id=$(TAG) tag=$(TAG) version=$(patsubst v%,%,$(TAG)) channel=beta"
+	@RELEASE_ID="$(TAG)" \
+	LEAF_RELEASE_TAG="$(TAG)" \
+	LEAF_RELEASE_VERSION="$(patsubst v%,%,$(TAG))" \
+	LEAF_RELEASE_CHANNEL=beta \
+	$(MAKE) --no-print-directory release-zips DEVICE="$(DEVICE)" RELEASE_ID="$(TAG)"
+	@$(MAKE) --no-print-directory verify-beta-zips TAG="$(TAG)" DEVICE="$(DEVICE)"
+
+# Read the identity back out of the artifact. Every other check in this repo
+# runs on the inputs, which cannot catch a variable that was never set -- an
+# unset channel does not fail, it defaults to "dev" and ships.
+verify-beta-zips:
+	@python3 "$(LEAF_ROOT)/scripts/verify-release-identity.py" \
+	  "$(LEAF_ROOT)/build/release/leaf-mlp1-sd-$(TAG).zip" \
+	  --tag "$(TAG)" --channel beta


### PR DESCRIPTION
> [!IMPORTANT]
> This changes the release path. The original implementation was independently
> audited; the findings from that review are addressed in `b489536` and covered
> by focused regression tests.

## Problem

Hand-built betas require related release identity values. Historically those
values drifted: a beta shipped with `channel: stable`, others lost their beta
suffix in `version`, and a stale documented command could silently build
`channel: dev`.

The guarded command is now:

```sh
make beta-zips TAG=v0.8.0-beta.3 DEVICE=mlp1
```

It accepts only an exact `vX.Y.Z-beta.N` tag. RC publication remains a separate
main-repository/local-manifest rehearsal lane.

## Release identity contract

- `RELEASE_ID` is the exact artifact name, on-card release directory, and OTA
  equality identity. Tagged builds require it to equal `LEAF_RELEASE_TAG`.
- `LEAF_RELEASE_VERSION` is the installed Device Info label and Pak Rat
  compatibility input. Pak Rat compares the `MAJOR.MINOR.PATCH` core;
  prerelease suffixes remain visible but do not change compatibility ordering.
- `LEAF_RELEASE_CHANNEL` records build/publication policy and selects the
  default notes repository. It does not route OTA: the device's persisted
  `update_channel` chooses the feed.
- `LEAF_RELEASE_TAG` is the GitHub publication/provenance reference.

Betas publish regular releases in
`Utility-Muffin-Research-Kitchen/Leaf-beta`; Jawaka intentionally ignores
GitHub prereleases on both feeds.

## What changed

- Validates the beta tag with an anchored Python policy check before any build.
- Captures command-line `TAG` literally so Make functions, backticks, and shell
  substitutions cannot execute before validation.
- Accepts `GITHUB_REF_NAME` in tag CI context and refuses an explicit tag that
  disagrees with it.
- Passes every derived identity value explicitly to the recursive make, so
  inherited `MAKEOVERRIDES` cannot win.
- Uses the same configurable `RELEASE_BUILD` for building and verification.
- Requires clean component worktrees for every tagged install build, including
  betas, while retaining dirty untagged development builds.
- Verifies the exact provenance path, `leaf-update.json`, notes repository,
  install/recovery filenames, sizes, and SHA-256 digests.
- Converts missing/corrupt ZIPs and malformed JSON into concise failures without
  tracebacks.
- Documents the four field roles and the beta-only/RC publication policy.

## Verification

- `make leaf-release-policy-test`: 25 tests pass.
- GNU Make 3.81 and 4.4.1 pass beta-target and `-j4` smokes.
- Coverage includes strict tag rejection, Make/shell injection sentinels,
  conflicting outer identity variables, GitHub tag matching, custom output
  paths with spaces, tagged dirty trees, exact artifact identity, malformed
  ZIP/JSON, and missing/corrupt recovery ZIPs.
- Python compilation, Bash syntax, and `git diff --check` pass.

No device runtime behavior changed, so this did not require staging or
restarting the connected MLP1.
