### PR TITLE
test: require source-paths-v2 in releases

### DIFF
--- a/scripts/validate-leaf-release-test.py
+++ b/scripts/validate-leaf-release-test.py
@@ -199,7 +199,7 @@ class CandidateTests(unittest.TestCase):
         launcher = root / "platforms" / "mlp1" / "launcher"
         write_executable(
             launcher / "bin" / "loong_pangu",
-            b"\x7fELF fixture relocate-games-v1 fixture\n",
+            b"\x7fELF fixture relocate-games-v1 source-paths-v2 fixture\n",
         )
         write_executable(
             launcher / "bin" / "jawaka-inhibitctl",
@@ -207,10 +207,14 @@ class CandidateTests(unittest.TestCase):
         )
         env_lines = [
             "#!/bin/sh",
+            "export UMRK_ENV_VERSION=2",
             "export UMRK_SECONDARY_SDCARD_PATH=/media/sdcard1",
         ]
         for name, values in MODULE.REQUIRED_PATH_LISTS.items():
             env_lines.append(f"export {name}={':'.join(values)}")
+            env_lines.append(
+                f"export {MODULE.PATH_LIST_SINGULARS[name]}={values[0]}"
+            )
         env_path = launcher / "env.sh"
         env_path.parent.mkdir(parents=True, exist_ok=True)
         env_path.write_text("\n".join(env_lines) + "\n", encoding="utf-8")
@@ -287,6 +291,21 @@ class CandidateTests(unittest.TestCase):
             with self.assertRaisesRegex(MODULE.PolicyError, "relocate-games-v1"):
                 MODULE.validate_candidate(args)
 
+    def test_candidate_rejects_missing_source_paths_capability(self):
+        with tempfile.TemporaryDirectory() as raw:
+            args = self.make_candidate(Path(raw))
+            daemon = (
+                args.release_root
+                / "platforms"
+                / "mlp1"
+                / "launcher"
+                / "bin"
+                / "loong_pangu"
+            )
+            daemon.write_bytes(b"\x7fELF relocate-games-v1 only\n")
+            with self.assertRaisesRegex(MODULE.PolicyError, "source-paths-v2"):
+                MODULE.validate_candidate(args)
+
     def test_candidate_rejects_incomplete_configured_sources(self):
         with tempfile.TemporaryDirectory() as raw:
             args = self.make_candidate(Path(raw))
@@ -306,6 +325,45 @@ class CandidateTests(unittest.TestCase):
                 encoding="utf-8",
             )
             with self.assertRaisesRegex(MODULE.PolicyError, "ROMS_PATHS mismatch"):
+                MODULE.validate_candidate(args)
+
+    def test_candidate_rejects_incomplete_source_paths_v2(self):
+        with tempfile.TemporaryDirectory() as raw:
+            args = self.make_candidate(Path(raw))
+            env_path = (
+                args.release_root
+                / "platforms"
+                / "mlp1"
+                / "launcher"
+                / "env.sh"
+            )
+            text = env_path.read_text(encoding="utf-8")
+            env_path.write_text(
+                text.replace("export UMRK_ENV_VERSION=2", "export UMRK_ENV_VERSION=1"),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(MODULE.PolicyError, "source-paths-v2"):
+                MODULE.validate_candidate(args)
+
+    def test_candidate_rejects_primary_singular_mismatch(self):
+        with tempfile.TemporaryDirectory() as raw:
+            args = self.make_candidate(Path(raw))
+            env_path = (
+                args.release_root
+                / "platforms"
+                / "mlp1"
+                / "launcher"
+                / "env.sh"
+            )
+            text = env_path.read_text(encoding="utf-8")
+            env_path.write_text(
+                text.replace(
+                    "export USERDATA_PATH=/mnt/sdcard/.userdata/mlp1",
+                    "export USERDATA_PATH=/wrong/.userdata/mlp1",
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(MODULE.PolicyError, "USERDATA_PATH"):
                 MODULE.validate_candidate(args)
 
     def test_candidate_rejects_incomplete_l3_autoconfig(self):

--- a/scripts/validate-leaf-release.py
+++ b/scripts/validate-leaf-release.py
@@ -22,6 +22,14 @@ BETA_TAG_RE = re.compile(r"v[0-9]+\.[0-9]+\.[0-9]+-beta\.[1-9][0-9]*")
 COMPONENT_NAME_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]*")
 REQUIRED_PATH_LISTS = {
     "SDCARD_PATHS": ("/mnt/sdcard", "/media/sdcard1"),
+    "USERDATA_PATHS": (
+        "/mnt/sdcard/.userdata/mlp1",
+        "/media/sdcard1/.userdata/mlp1",
+    ),
+    "SHARED_USERDATA_PATHS": (
+        "/mnt/sdcard/.userdata/shared",
+        "/media/sdcard1/.userdata/shared",
+    ),
     "ROMS_PATHS": ("/mnt/sdcard/Roms", "/media/sdcard1/Roms"),
     "IMAGES_PATHS": ("/mnt/sdcard/Images", "/media/sdcard1/Images"),
     "MUSIC_PATHS": ("/mnt/sdcard/Music", "/media/sdcard1/Music"),
@@ -30,6 +38,19 @@ REQUIRED_PATH_LISTS = {
     "SAVES_PATHS": ("/mnt/sdcard/Saves", "/media/sdcard1/Saves"),
     "STATES_PATHS": ("/mnt/sdcard/States", "/media/sdcard1/States"),
     "CHEATS_PATHS": ("/mnt/sdcard/Cheats", "/media/sdcard1/Cheats"),
+}
+PATH_LIST_SINGULARS = {
+    "SDCARD_PATHS": "SDCARD_PATH",
+    "USERDATA_PATHS": "USERDATA_PATH",
+    "SHARED_USERDATA_PATHS": "SHARED_USERDATA_PATH",
+    "ROMS_PATHS": "ROMS_PATH",
+    "IMAGES_PATHS": "IMAGES_PATH",
+    "MUSIC_PATHS": "MUSIC_PATH",
+    "APPS_PATHS": "APPS_PATH",
+    "BIOS_PATHS": "BIOS_PATH",
+    "SAVES_PATHS": "SAVES_PATH",
+    "STATES_PATHS": "STATES_PATH",
+    "CHEATS_PATHS": "CHEATS_PATH",
 }
 
 
@@ -293,8 +314,12 @@ def validate_candidate(args: argparse.Namespace) -> None:
     validate_mlp1_retroarch_input_profile(platform)
     if b"relocate-games-v1" not in daemon.read_bytes():
         raise PolicyError("launcher daemon does not advertise relocate-games-v1")
+    if b"source-paths-v2" not in daemon.read_bytes():
+        raise PolicyError("launcher daemon does not advertise source-paths-v2")
 
     environment = read_staged_environment(env_path)
+    if environment.get("UMRK_ENV_VERSION") != "2":
+        raise PolicyError("runtime environment does not publish complete source-paths-v2")
     if environment.get("UMRK_SECONDARY_SDCARD_PATH") != "/media/sdcard1":
         raise PolicyError("runtime environment does not configure the Secondary card")
     for name, expected in REQUIRED_PATH_LISTS.items():
@@ -303,6 +328,11 @@ def validate_candidate(args: argparse.Namespace) -> None:
             raise PolicyError(
                 f"runtime environment {name} mismatch: "
                 f"{actual!r} != {expected!r}"
+            )
+        singular = PATH_LIST_SINGULARS[name]
+        if environment.get(singular) != expected[0]:
+            raise PolicyError(
+                f"runtime environment {singular} does not match {name} Primary"
             )
 
     provenance_path = root / "provenance" / "components.json"


### PR DESCRIPTION
## What changed

- require `UMRK_ENV_VERSION=2`, the two userdata plural lists, and all Primary singular/plural agreements in assembled MLP1 releases
- require the staged Jawaka daemon to carry the `source-paths-v2` capability
- extend release fixtures with valid PATH-2 data and rejection cases for missing capability, incomplete version, and singular mismatch

## Why

Leaf assembles the launcher producer and Jawaka consumer. Release validation must reject any payload that ships only part of the coordinated PATH-2 environment.

## Validation

- `python3 scripts/validate-leaf-release-test.py` (18 tests)

Coordinate landing with the launcher producer PR and the Jawaka validator/capability PR. Physical two-card/reboot evidence remains required.
