### PR TITLE
Stage Syncthing only through explicit app policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ help:
 	@echo "  make stage-emulators DEVICE=mlp1          stage standalone emulators"
 	@echo "  make stage-app APP=CentralScrutinizer DEVICE=mlp1 stage a single app repo"
 	@echo "  make stage-app APP=Leaf-Itchio-Pak DEVICE=mlp1 explicitly stage the optional Itch.io app"
+	@echo "  make stage-app APP=Leaf-Syncthing-Pak DEVICE=mlp1 explicitly stage the optional Syncthing app"
 	@echo "  make stage-app APP=DiscoBoy DEVICE=mlp1 explicitly stage the optional Disco Boy app"
 	@echo "  make stage-app APP=Nimbus DEVICE=mlp1       explicitly stage the optional Nimbus app"
 	@echo "  make stage-app APP=PortMaster-mlp1 DEVICE=mlp1 explicitly stage the optional PortMaster app"

--- a/scripts/app-package-policy-smoke.sh
+++ b/scripts/app-package-policy-smoke.sh
@@ -25,6 +25,7 @@ assert_policy() {
 }
 
 assert_policy Leaf-Itchio-Pak Itch-io.pak pakrat
+assert_policy Leaf-Syncthing-Pak Syncthing.pak pakrat
 assert_policy DiscoBoy DiscoBoy.pak pakrat
 assert_policy Nimbus Nimbus.pak pakrat
 assert_policy PortMaster-mlp1 PortMaster.pak pakrat
@@ -56,8 +57,8 @@ audit_stage_apps_definitions() {
             return 1
         fi
         if printf '%s\n' "$definitions" | \
-            "$grep_bin" -qiE 'Leaf-Itchio|DiscoBoy|Nimbus|PortMaster'; then
-            echo "Pak Rat-owned optional app leaked into STAGE_APPS in $file" >&2
+            "$grep_bin" -qiE 'Leaf-Itchio|Leaf-Syncthing|DiscoBoy|Nimbus|PortMaster'; then
+            echo "optional app leaked into STAGE_APPS in $file" >&2
             return 1
         else
             status=$?
@@ -124,20 +125,25 @@ fi
 audit_stage_apps_definitions grep \
     "$LEAF_ROOT/stage/mlp1.mk" "$SCRIPT_DIR/make-sd-release-zip.sh"
 
+if grep -q 'Leaf-Syncthing-Pak' "$LEAF_ROOT/stage/common.mk"; then
+    echo "Leaf-Syncthing-Pak leaked into required bootstrap repos" >&2
+    exit 1
+fi
+
 mkdir -p "$fixture/platforms/mlp1" "$fixture/Apps/mlp1"
 printf '{"managed_apps": []}\n' >"$fixture/platforms/mlp1/manifest.json"
 : >"$fixture/managed-apps.txt"
 
-pakrat_packages=()
+release_forbidden_packages=()
 while IFS= read -r package; do
-    [ -n "$package" ] && pakrat_packages+=("$package")
+    [ -n "$package" ] && release_forbidden_packages+=("$package")
 done < <(leaf_pakrat_owned_package_names)
-python3 "$SCRIPT_DIR/audit-pakrat-owned-apps.py" "$fixture" "${pakrat_packages[@]}" >/dev/null
+python3 "$SCRIPT_DIR/audit-pakrat-owned-apps.py" "$fixture" "${release_forbidden_packages[@]}" >/dev/null
 
-for package in "${pakrat_packages[@]}"; do
+for package in "${release_forbidden_packages[@]}"; do
     printf 'mlp1/%s\n' "$package" >"$fixture/managed-apps.txt"
     if python3 "$SCRIPT_DIR/audit-pakrat-owned-apps.py" \
-        "$fixture" "${pakrat_packages[@]}" >/dev/null 2>&1; then
+        "$fixture" "${release_forbidden_packages[@]}" >/dev/null 2>&1; then
         echo "ownership audit accepted managed $package" >&2
         exit 1
     fi
@@ -146,7 +152,7 @@ for package in "${pakrat_packages[@]}"; do
     printf '{"managed_apps": ["mlp1/%s"]}\n' "$package" \
         >"$fixture/platforms/mlp1/manifest.json"
     if python3 "$SCRIPT_DIR/audit-pakrat-owned-apps.py" \
-        "$fixture" "${pakrat_packages[@]}" >/dev/null 2>&1; then
+        "$fixture" "${release_forbidden_packages[@]}" >/dev/null 2>&1; then
         echo "ownership audit accepted manifest-owned $package" >&2
         exit 1
     fi
@@ -154,7 +160,7 @@ for package in "${pakrat_packages[@]}"; do
 
     mkdir -p "$fixture/Apps/mlp1/$package"
     if python3 "$SCRIPT_DIR/audit-pakrat-owned-apps.py" \
-        "$fixture" "${pakrat_packages[@]}" >/dev/null 2>&1; then
+        "$fixture" "${release_forbidden_packages[@]}" >/dev/null 2>&1; then
         echo "ownership audit accepted staged $package" >&2
         exit 1
     fi

--- a/scripts/app-package-policy.sh
+++ b/scripts/app-package-policy.sh
@@ -23,7 +23,8 @@ leaf_pakrat_owned_package_names() {
         "Itch-io.pak" \
         "DiscoBoy.pak" \
         "Nimbus.pak" \
-        "PortMaster.pak"
+        "PortMaster.pak" \
+        "Syncthing.pak"
 }
 
 leaf_app_policy() {
@@ -40,6 +41,15 @@ leaf_app_policy() {
     distribution=
 
     case "$app" in
+        Leaf-Syncthing-Pak)
+            package_target="package-platform"
+            package_platform="mlp1"
+            package_dir="$workspace_dir/Leaf-Syncthing-Pak/build/mlp1/package/Syncthing.pak"
+            package_name="Syncthing.pak"
+            destination_platform="mlp1"
+            supported_devices="mlp1"
+            distribution="pakrat"
+            ;;
         Leaf-Itchio-Pak)
             package_target="package-platform"
             package_platform="mlp1"


### PR DESCRIPTION
## Summary

- Add `Leaf-Syncthing-Pak` to the stable optional Pak Rat-owned app policy so it can be staged through an explicit `stage-app` request.
- Keep Syncthing out of default `STAGE_APPS`, required bootstrap repositories, `managed-apps.txt`, platform manifests, release `Apps`, and release ZIPs.
- Harden the policy smoke so missing definitions, unreadable inputs, and grep failures fail closed.

## Why

Syncthing is an optional Pak Rat product, not a release-managed Leaf app. B0a and the eventual production app need a reproducible targeted device-staging lane without creating a path into normal Leaf payloads.

## Review follow-up

- The previously local package repository now has an empty `main` and a published draft review branch: [Leaf-Syncthing-Pak PR #1](https://github.com/Utility-Muffin-Research-Kitchen/Leaf-Syncthing-Pak/pull/1).
- The `Leaf-Syncthing-Pak` name and `build/mlp1/package/Syncthing.pak` path are intentionally durable contracts; the current `0.0.0-b0a` artifact is qualification-only and must never enter a release or production catalog.
- An uncached targeted stage downloads the locked Syncthing release inputs. The package verifier restricts initial/redirect hosts and verifies the pinned signer, signatures, and digests before packaging.

## Validation

- `scripts/app-package-policy-smoke.sh` — pass
- `make leaf-release-policy-test` — 15 release-validation tests and 10 identity tests pass
- Published package branch rebuild — 31,615,873 installed bytes
- Exact targeted MLP1 stage to the explicitly selected 64 GB card — six files, 31,615,873 bytes
- Host/device combined manifest SHA-256 — `7893a53488abb0da51a408805ec7176a33c75a53506afdd18fa553ba98cbd971`
- Negative policy probes reject Syncthing from default staging, bootstrap requirements, managed manifests, and release content

This remains draft for review. No merge, release tag, or production catalog change is requested.
