### PR TITLE
release: give stable the same guarded target betas already had

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,15 +170,21 @@ make release-zips DEVICE=mlp1 \
   LEAF_RELEASE_TAG=v0.7.0
 ```
 
-For a beta, use the guarded one-input target:
+Both channels have a guarded one-input target. Prefer these over setting the four
+values by hand:
 
 ```sh
-make beta-zips TAG=v0.8.0-beta.3 DEVICE=mlp1
+make stable-zips TAG=v0.9.0 DEVICE=mlp1
+make beta-zips   TAG=v0.9.0-beta.1 DEVICE=mlp1
 ```
 
-It accepts only `vX.Y.Z-beta.N`, derives the complete beta identity, builds both
-ZIPs, and verifies the embedded provenance plus `leaf-update.json`. Beta assets
-belong in `Utility-Muffin-Research-Kitchen/Leaf-beta`. Release-candidate tags
+`stable-zips` accepts only a bare `vX.Y.Z` and publishes to the main Leaf
+repository; `beta-zips` accepts only `vX.Y.Z-beta.N` and publishes to `Leaf-beta`.
+Each derives the complete identity from the tag and verifies the built artifact
+afterwards.
+
+Both build the install and recovery ZIPs and verify the embedded provenance plus
+`leaf-update.json`. Release-candidate tags
 are a separate main-repository/local-manifest rehearsal lane and are
 intentionally not accepted by `beta-zips`.
 

--- a/scripts/validate-leaf-release-test.py
+++ b/scripts/validate-leaf-release-test.py
@@ -88,6 +88,29 @@ class IdentityTests(unittest.TestCase):
                 with self.assertRaisesRegex(MODULE.PolicyError, "must match"):
                     MODULE.validate_beta_tag(tag)
 
+    def test_stable_tag_requires_bare_semver(self):
+        for tag in ("v0.9.0", "v1.0.0", "v12.34.56"):
+            with self.subTest(tag=tag):
+                self.assertEqual(MODULE.validate_stable_tag(tag), tag[1:])
+
+        # A stable tag must reject everything a prerelease or a sloppy tag would
+        # carry. normalized_tag accepts prereleases, so this is the strict form.
+        for tag in (
+            "",
+            "0.9.0",
+            "v0.9",
+            "v0.9.0.1",
+            "v0.09.0",
+            "vv0.9.0",
+            "v0.9.0-beta.1",
+            "v0.9.0-rc.1",
+            "v0.9.0+build",
+            "v0.9.0junk",
+        ):
+            with self.subTest(tag=tag):
+                with self.assertRaisesRegex(MODULE.PolicyError, "must match"):
+                    MODULE.validate_stable_tag(tag)
+
 
 class ProvenanceTests(unittest.TestCase):
     def test_provenance_records_exact_clean_commits(self):

--- a/scripts/validate-leaf-release.py
+++ b/scripts/validate-leaf-release.py
@@ -19,6 +19,10 @@ VERSION_RE = re.compile(
     r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
 )
 BETA_TAG_RE = re.compile(r"v[0-9]+\.[0-9]+\.[0-9]+-beta\.[1-9][0-9]*")
+# A stable tag carries no prerelease or build suffix at all. normalized_tag
+# below is deliberately looser -- it accepts any valid semver tag, including
+# prereleases -- so the guarded stable target needs its own strict form.
+STABLE_TAG_RE = re.compile(r"v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)")
 COMPONENT_NAME_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]*")
 REQUIRED_PATH_LISTS = {
     "SDCARD_PATHS": ("/mnt/sdcard", "/media/sdcard1"),
@@ -61,6 +65,15 @@ def validate_beta_tag(tag: str) -> str:
     if not BETA_TAG_RE.fullmatch(tag or ""):
         raise PolicyError("beta tag must match vX.Y.Z-beta.N exactly")
     return validate_version(tag[1:], "beta tag")
+
+
+def validate_stable_tag(tag: str) -> str:
+    if not STABLE_TAG_RE.fullmatch(tag or ""):
+        raise PolicyError(
+            "stable tag must match vX.Y.Z exactly, with no prerelease or build "
+            "suffix and no zero-padded components"
+        )
+    return validate_version(tag[1:], "stable tag")
 
 
 def validate_identity(channel: str, version: str, tag: str, release_id: str) -> None:
@@ -379,6 +392,9 @@ def make_parser() -> argparse.ArgumentParser:
     beta_tag = subparsers.add_parser("beta-tag")
     beta_tag.add_argument("--tag", required=True)
 
+    stable_tag = subparsers.add_parser("stable-tag")
+    stable_tag.add_argument("--tag", required=True)
+
     provenance = subparsers.add_parser("provenance")
     provenance.add_argument("--channel", required=True)
     provenance.add_argument("--version", default="")
@@ -410,6 +426,9 @@ def main() -> None:
         elif args.command == "beta-tag":
             version = validate_beta_tag(args.tag)
             print(f"beta release identity: tag={args.tag} version={version}")
+        elif args.command == "stable-tag":
+            version = validate_stable_tag(args.tag)
+            print(f"stable release identity: tag={args.tag} version={version}")
         elif args.command == "provenance":
             value = build_provenance(args)
             write_json(args.output, value)

--- a/stage/mlp1.mk
+++ b/stage/mlp1.mk
@@ -51,7 +51,7 @@ override LEAF_BETA_TAG_INPUT := $(value TAG)
 unexport TAG
 export LEAF_BETA_TAG_INPUT
 
-.PHONY: stage stage-app stage-emulator stage-emulators stage-public-root stage-retroarch stage-refresh refresh-jawaka jawaka-build shader-bundle-mlp1 assemble-jawaka stage-jawaka release-zips release-sd-zip release-recovery-zip beta-zips verify-beta-zips
+.PHONY: stage stage-app stage-emulator stage-emulators stage-public-root stage-retroarch stage-refresh refresh-jawaka jawaka-build shader-bundle-mlp1 assemble-jawaka stage-jawaka release-zips release-sd-zip release-recovery-zip beta-zips verify-beta-zips stable-zips verify-stable-zips
 
 # Build the Jawaka MLP1 binaries (cross-compile via its own Docker target).
 jawaka-build:
@@ -544,3 +544,68 @@ verify-beta-zips:
 		--repository Utility-Muffin-Research-Kitchen/Leaf-beta \
 		--tag "$$tag" \
 		--channel beta
+
+# The stable twin of beta-zips. Stable was still four hand-typed env vars after
+# betas got a guarded target, which is the wrong way round: a stable mistake
+# reaches everyone, not just testers. v0.8.0 was cut by hand for exactly this
+# reason. Same contract as beta-zips -- one input, derived identity, verified
+# afterwards -- except the tag must be a bare vX.Y.Z and the channel is stable,
+# which also arms the clean-worktree provenance gate.
+#
+#   make stable-zips TAG=v0.9.0 DEVICE=mlp1
+#
+# TAG is read from the recipe environment rather than interpolated into shell
+# source (see the LEAF_BETA_TAG_INPUT capture above), and the derived identity is
+# passed explicitly so it beats anything inherited through MAKEOVERRIDES.
+stable-zips:
+	@set -euo pipefail; \
+	tag="$${LEAF_BETA_TAG_INPUT:-}"; \
+	if [ "$${GITHUB_REF_TYPE:-}" = "tag" ]; then \
+		ref_tag="$${GITHUB_REF_NAME:-}"; \
+		if [ -z "$$ref_tag" ]; then \
+			echo "refusing: GITHUB_REF_TYPE is tag but GITHUB_REF_NAME is empty" >&2; \
+			exit 2; \
+		fi; \
+		if [ -n "$$tag" ] && [ "$$tag" != "$$ref_tag" ]; then \
+			echo "refusing: TAG '$$tag' does not match GITHUB_REF_NAME '$$ref_tag'" >&2; \
+			exit 2; \
+		fi; \
+		tag="$$ref_tag"; \
+	fi; \
+	if [ -z "$$tag" ]; then \
+		echo "usage: make stable-zips TAG=v0.9.0 [DEVICE=mlp1]" >&2; \
+		exit 2; \
+	fi; \
+	python3 "$(LEAF_ROOT)/scripts/validate-leaf-release.py" stable-tag --tag "$$tag"; \
+	version="$${tag#v}"; \
+	release_build="$${RELEASE_BUILD:-$(LEAF_ROOT)/build/release}"; \
+	echo "==> stable identity: release_id=$$tag tag=$$tag version=$$version channel=stable"; \
+	$(MAKE) --no-print-directory release-zips \
+		DEVICE=mlp1 \
+		TAG="$$tag" \
+		RELEASE_BUILD="$$release_build" \
+		RELEASE_ID="$$tag" \
+		LEAF_RELEASE_CHANNEL=stable \
+		LEAF_RELEASE_VERSION="$$version" \
+		LEAF_RELEASE_TAG="$$tag" \
+		LEAF_RELEASE_REPOSITORY=Utility-Muffin-Research-Kitchen/Leaf; \
+	$(MAKE) --no-print-directory verify-stable-zips \
+		DEVICE=mlp1 \
+		RELEASE_BUILD="$$release_build" \
+		TAG="$$tag"
+
+verify-stable-zips:
+	@set -euo pipefail; \
+	tag="$${LEAF_BETA_TAG_INPUT:-}"; \
+	if [ -z "$$tag" ]; then \
+		echo "usage: make verify-stable-zips TAG=v0.9.0 [RELEASE_BUILD=...]" >&2; \
+		exit 2; \
+	fi; \
+	release_build="$${RELEASE_BUILD:-$(LEAF_ROOT)/build/release}"; \
+	python3 "$(LEAF_ROOT)/scripts/validate-leaf-release.py" stable-tag --tag "$$tag"; \
+	python3 "$(LEAF_ROOT)/scripts/verify-release-identity.py" \
+		"$$release_build/leaf-mlp1-sd-$$tag.zip" \
+		--manifest "$$release_build/leaf-update.json" \
+		--repository Utility-Muffin-Research-Kitchen/Leaf \
+		--tag "$$tag" \
+		--channel stable


### PR DESCRIPTION
`beta-zips` derives all four identity values from one tag. Stable was still four hand-typed environment variables, which is the wrong way round: a beta mistake reaches testers, a stable mistake reaches everyone. **v0.8.0 was cut by hand today for exactly this reason.**

```sh
make stable-zips TAG=v0.9.0 DEVICE=mlp1
```

Same contract as `beta-zips`, deliberately:

- `TAG` is captured through `LEAF_BETA_TAG_INPUT` and read from the recipe environment rather than interpolated into shell source, so a ref containing backticks cannot execute.
- Derived values are passed explicitly on the child `make` command line, so they beat anything inherited through `MAKEOVERRIDES`.
- The built artifact is verified afterwards, automatically.
- `LEAF_RELEASE_REPOSITORY` is pinned to the main Leaf repo, as `beta-zips` pins `Leaf-beta`.

Channel `stable` also arms the clean-worktree provenance gate, which `dev` does not.

## Why the tag guard needed its own regex

`normalized_tag` accepts any valid semver tag, prereleases included, so reusing it would have let `stable-zips` accept `v0.9.0-beta.1`. `STABLE_TAG_RE` requires a bare `vX.Y.Z`: no prerelease suffix, no build metadata, no zero-padded components.

## Testing

Added `test_stable_tag_requires_bare_semver`, mirroring the beta case: accepts `v0.9.0`, `v1.0.0`, `v12.34.56`; rejects empty, `0.9.0`, `v0.9`, `v0.9.0.1`, `v0.09.0`, `vv0.9.0`, `v0.9.0-beta.1`, `v0.9.0-rc.1`, `v0.9.0+build`, `v0.9.0junk`.

Both suites pass: 16 in `validate-leaf-release-test.py`, 10 in `verify-release-identity-test.py`.

Guards exercised through make directly, including `TAG='v0.9.0`touch /tmp/PWN2`'` - rejected by the validator, and no file created.

**`verify-stable-zips` was run against the real `v0.8.0` artifact published today.** Identity and manifest both pass, so the target verifies a genuine stable release rather than only a synthetic one.

## Note

This is a build-tooling change only. It adds two targets and one validator subcommand; nothing existing changed behaviour, and `release-zips` still accepts the four values directly for anything unusual.

I have not tested it in CI, and there is still no release-building workflow. The `GITHUB_REF_TYPE` / `GITHUB_REF_NAME` handling mirrors `beta-zips` but has only ever run locally.
