### PR TITLE
Quiesce services while staging core apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ LARGE_LIBRARY_FIXTURE_ENV = \
 	REMOTE_SDCARD_PATH="$(REMOTE_SDCARD_PATH)"
 
 .DEFAULT_GOAL := help
-.PHONY: help bootstrap doctor status status-internal pakrat-local-feed-test leaf-release-policy-test shader-bundle-release-policy-test flycast-release-policy-smoke adb-enable-marker adb-disable-marker adb-tail-logs adb-large-library-create adb-large-library-clean adb-large-library-status adb-install-wrapper adb-uninstall-wrapper benchmark-ppsspp
+.PHONY: help bootstrap doctor status status-internal pakrat-local-feed-test leaf-release-policy-test shader-bundle-release-policy-test flycast-release-policy-smoke package-quiesce-smoke adb-enable-marker adb-disable-marker adb-tail-logs adb-large-library-create adb-large-library-clean adb-large-library-status adb-install-wrapper adb-uninstall-wrapper benchmark-ppsspp
 
 help:
 	@echo "Leaf workspace commands (DEVICE=$(DEVICE), WORKSPACE_DIR=$(WORKSPACE_DIR)):"
@@ -54,6 +54,7 @@ help:
 	@echo "  make leaf-release-policy-test             test release identity, artifacts, provenance, and gates"
 	@echo "  make shader-bundle-release-policy-test    test shader bundle integrity release gates"
 	@echo "  make flycast-release-policy-smoke         test standalone Flycast release gates"
+	@echo "  make package-quiesce-smoke                test fail-closed stage-app service barrier"
 	@echo "  make adb-enable-marker                    enable Leaf launcher marker"
 	@echo "  make adb-disable-marker                   disable Leaf launcher marker"
 	@echo "  make adb-tail-logs                        tail launcher logs"
@@ -108,6 +109,9 @@ leaf-release-policy-test:
 
 shader-bundle-release-policy-test:
 	python3 scripts/validate-shader-bundle-release-test.py
+
+package-quiesce-smoke:
+	@bash scripts/adb-stage-app-package-smoke.sh
 
 adb-enable-marker:
 	scripts/adb-set-marker.sh on

--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ make release-sd-zip DEVICE=mlp1             # build end-user install ZIP only
 make release-recovery-zip DEVICE=mlp1       # build end-user recovery ZIP only
 ```
 
+On MLP1, `stage-app` uses Jawaka's `package-quiesce-v1` barrier before it
+removes or pushes any package bytes. Close foreground apps first. A missing
+daemon, stale/unverified service generation, or rejected barrier fails the
+stage without modifying the destination. After a successful push (and also on
+a failed push), the helper asks Jawaka to rescan manifests and restore only
+persistent Start-with-Leaf intent. `make package-quiesce-smoke` covers the
+ordering and failure cleanup with a fake ADB endpoint.
+
 The four first-party optional apps above are registered only for an explicit
 developer stage. They remain Pak Rat-owned and are excluded from default full
 staging, release ZIPs, `managed_apps`, and bootstrap requirements. Store

--- a/scripts/adb-package-quiesce.sh
+++ b/scripts/adb-package-quiesce.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "usage: $0 begin|end OPERATION_ID" >&2
+    exit 2
+}
+
+[ "$#" -eq 2 ] || usage
+action="$1"
+operation_id="$2"
+case "$action" in
+    begin|end) ;;
+    *) usage ;;
+esac
+case "$operation_id" in
+    ''|*[!A-Za-z0-9._-]*)
+        echo "invalid package operation id: $operation_id" >&2
+        exit 2
+        ;;
+esac
+if [ "${#operation_id}" -gt 63 ]; then
+    echo "package operation id is longer than 63 bytes" >&2
+    exit 2
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLATFORM_ID="${PLATFORM_ID:-${DEVICE:-mlp1}}"
+if [ -n "${ADB_SERIAL:-}" ]; then
+    serial="$ADB_SERIAL"
+else
+    serial="$(adb devices | awk 'NR>1 && $2=="device" {print $1; exit}')"
+fi
+if [ -z "${serial:-}" ]; then
+    echo "No online adb device found." >&2
+    exit 1
+fi
+ADB=(adb -s "$serial")
+
+remote_sd="$(
+    PLATFORM_ID="$PLATFORM_ID" \
+    REMOTE_SDCARD_PATH="${REMOTE_SDCARD_PATH:-auto}" \
+    ADB_SERIAL="$serial" \
+    "$ROOT_DIR/scripts/adb-resolve-umrk-sd.sh"
+)"
+case "$remote_sd" in
+    ''|*$'\n'*|*"'"*)
+        echo "unsupported resolved SD path: $remote_sd" >&2
+        exit 1
+        ;;
+esac
+
+request_type="package-quiesce-$action"
+request="{\"type\":\"$request_type\",\"operation_id\":\"$operation_id\"}"
+reply="$("${ADB[@]}" shell "
+set -eu
+env_file='$remote_sd/.system/leaf/platforms/$PLATFORM_ID/launcher/env.sh'
+[ -f \"\$env_file\" ] || { echo 'Leaf runtime env is missing' >&2; exit 1; }
+. \"\$env_file\"
+ctl=\"\$UMRK_LAUNCHER_PATH/bin/jawaka-platformctl\"
+[ -x \"\$ctl\" ] || { echo 'jawaka-platformctl is missing' >&2; exit 1; }
+[ -S \"\$UMRK_DAEMON_SOCKET\" ] || { echo 'jawakad socket is unavailable' >&2; exit 1; }
+\"\$ctl\" --socket \"\$UMRK_DAEMON_SOCKET\" request '$request'
+")"
+reply="${reply//$'\r'/}"
+printf '%s\n' "$reply"
+case "$reply" in
+    *'"type":"ok"'*) ;;
+    *)
+        echo "Jawaka rejected package quiesce $action." >&2
+        exit 1
+        ;;
+esac

--- a/scripts/adb-stage-app-package-smoke.sh
+++ b/scripts/adb-stage-app-package-smoke.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/leaf-pkg-quiesce.XXXXXX")"
+trap 'rm -rf "$fixture"' EXIT
+mkdir -p "$fixture/bin" "$fixture/local/bin"
+printf '#!/bin/sh\nexit 0\n' >"$fixture/local/launch.sh"
+printf '#!/bin/sh\nexit 0\n' >"$fixture/local/bin/service"
+chmod 755 "$fixture/local/launch.sh" "$fixture/local/bin/service"
+
+cat >"$fixture/bin/adb" <<'EOF'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >>"$FAKE_ADB_LOG"
+case "$*" in
+    *package-quiesce-begin*)
+        if [ "${FAKE_ADB_BEGIN_ERROR:-0}" -eq 1 ]; then
+            printf '%s\n' '{"type":"error","message":"stale-generation"}'
+        else
+            printf '%s\n' '{"type":"ok","action":"package-quiesce-begin"}'
+        fi
+        ;;
+    *package-quiesce-end*)
+        printf '%s\n' '{"type":"ok","action":"package-quiesce-end"}'
+        ;;
+    *' push '*)
+        if [ "${FAKE_ADB_PUSH_ERROR:-0}" -eq 1 ]; then exit 1; fi
+        ;;
+    *"find '"*) printf '%s\n' '/mnt/sdcard/Apps/mlp1/Test.pak/pak.json' ;;
+esac
+exit 0
+EOF
+chmod 755 "$fixture/bin/adb"
+
+export PATH="$fixture/bin:$PATH"
+export ADB_SERIAL="fixture-device"
+export PLATFORM_ID="mlp1"
+export REMOTE_SDCARD_PATH="/mnt/sdcard"
+export FAKE_ADB_LOG="$fixture/adb.log"
+remote_dir="/mnt/sdcard/Apps/mlp1/Test.pak"
+
+line_for() {
+    grep -n -m1 "$1" "$FAKE_ADB_LOG" | cut -d: -f1
+}
+
+: >"$FAKE_ADB_LOG"
+"$ROOT_DIR/scripts/adb-stage-app-package.sh" "$fixture/local" "$remote_dir" \
+    >/dev/null
+begin_line="$(line_for package-quiesce-begin)"
+remove_line="$(line_for "rm -rf '$remote_dir'")"
+push_line="$(line_for ' push ')"
+end_line="$(line_for package-quiesce-end)"
+[ "$begin_line" -lt "$remove_line" ]
+[ "$remove_line" -lt "$push_line" ]
+[ "$push_line" -lt "$end_line" ]
+
+: >"$FAKE_ADB_LOG"
+if FAKE_ADB_PUSH_ERROR=1 \
+    "$ROOT_DIR/scripts/adb-stage-app-package.sh" "$fixture/local" "$remote_dir" \
+        >/dev/null 2>&1; then
+    echo "expected a failed adb push to fail staging" >&2
+    exit 1
+fi
+grep -q package-quiesce-begin "$FAKE_ADB_LOG"
+grep -q ' push ' "$FAKE_ADB_LOG"
+grep -q package-quiesce-end "$FAKE_ADB_LOG"
+
+: >"$FAKE_ADB_LOG"
+if FAKE_ADB_BEGIN_ERROR=1 \
+    "$ROOT_DIR/scripts/adb-stage-app-package.sh" "$fixture/local" "$remote_dir" \
+        >/dev/null 2>&1; then
+    echo "expected a rejected quiesce to fail staging" >&2
+    exit 1
+fi
+grep -q package-quiesce-begin "$FAKE_ADB_LOG"
+grep -q package-quiesce-end "$FAKE_ADB_LOG"
+if grep -q "rm -rf '$remote_dir'\| push " "$FAKE_ADB_LOG"; then
+    echo "staging mutated package bytes after a rejected quiesce" >&2
+    exit 1
+fi
+
+echo "PASS adb-stage-app-package-smoke"

--- a/scripts/adb-stage-app-package.sh
+++ b/scripts/adb-stage-app-package.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+    echo "usage: $0 LOCAL_PACKAGE_DIR REMOTE_PACKAGE_DIR" >&2
+    exit 2
+fi
+local_dir="$1"
+remote_dir="$2"
+[ -d "$local_dir" ] || { echo "missing package dir: $local_dir" >&2; exit 1; }
+case "$remote_dir" in
+    ''|*$'\n'*|*"'"*)
+        echo "unsupported remote package path: $remote_dir" >&2
+        exit 2
+        ;;
+esac
+case "$remote_dir" in
+    /*/Apps/*/*.pak) ;;
+    *)
+        echo "refusing destructive stage outside an Apps/<scope>/<name>.pak path: $remote_dir" >&2
+        exit 2
+        ;;
+esac
+case "$remote_dir/" in
+    *'/../'*|*'/./'*|*'//'*)
+        echo "refusing non-normalized remote package path: $remote_dir" >&2
+        exit 2
+        ;;
+esac
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [ -n "${ADB_SERIAL:-}" ]; then
+    serial="$ADB_SERIAL"
+else
+    serial="$(adb devices | awk 'NR>1 && $2=="device" {print $1; exit}')"
+fi
+if [ -z "${serial:-}" ]; then
+    echo "No online adb device found." >&2
+    exit 1
+fi
+ADB=(adb -s "$serial")
+operation_id="stage-app-$$"
+quiesced=0
+
+release_quiesce() {
+    ADB_SERIAL="$serial" \
+    PLATFORM_ID="${PLATFORM_ID:-${DEVICE:-mlp1}}" \
+    REMOTE_SDCARD_PATH="${REMOTE_SDCARD_PATH:-auto}" \
+        "$ROOT_DIR/scripts/adb-package-quiesce.sh" end "$operation_id"
+}
+
+on_exit() {
+    rc=$?
+    trap - EXIT
+    if [ "$quiesced" -eq 1 ] && ! release_quiesce; then
+        echo "Package bytes may have changed, but Jawaka could not rescan/restore services." >&2
+        if [ "$rc" -eq 0 ]; then rc=1; fi
+    fi
+    exit "$rc"
+}
+trap on_exit EXIT
+
+if ! ADB_SERIAL="$serial" \
+    PLATFORM_ID="${PLATFORM_ID:-${DEVICE:-mlp1}}" \
+    REMOTE_SDCARD_PATH="${REMOTE_SDCARD_PATH:-auto}" \
+        "$ROOT_DIR/scripts/adb-package-quiesce.sh" begin "$operation_id"; then
+    # A preflight refusal never latched the barrier; an unverified stop did.
+    # A matching release is therefore a harmless best-effort cleanup in the
+    # first case and preserves fail-closed ownership in the second case when
+    # the survivor is still present.
+    release_quiesce >/dev/null 2>&1 || true
+    exit 1
+fi
+quiesced=1
+
+"${ADB[@]}" shell "rm -rf '$remote_dir' && mkdir -p '$remote_dir'"
+"${ADB[@]}" push "$local_dir/." "$remote_dir/" >/dev/null
+"${ADB[@]}" shell "chmod 755 '$remote_dir/launch.sh' '$remote_dir/bin/'* 2>/dev/null || true"
+"${ADB[@]}" shell "find '$remote_dir' -maxdepth 3 -type f | sort"
+
+release_quiesce
+quiesced=0
+trap - EXIT

--- a/stage/mlp1.mk
+++ b/stage/mlp1.mk
@@ -394,10 +394,10 @@ stage-app:
 	if [ -z "$$remote_apps" ]; then remote_apps="$$remote_sd/Apps"; fi; \
 	remote_dir="$$remote_apps/$$destination_platform/$$package_name"; \
 	echo "Deploying $$package_name to $$remote_dir"; \
-	"$${ADB[@]}" shell "rm -rf \"$$remote_dir\" && mkdir -p \"$$remote_dir\""; \
-	"$${ADB[@]}" push "$$package_dir/." "$$remote_dir/" >/dev/null; \
-	"$${ADB[@]}" shell "chmod 755 \"$$remote_dir/launch.sh\" \"$$remote_dir/bin/\"* 2>/dev/null || true"; \
-	"$${ADB[@]}" shell "find \"$$remote_dir\" -maxdepth 3 -type f | sort"
+	ADB_SERIAL="$$serial" PLATFORM_ID="mlp1" \
+	REMOTE_SDCARD_PATH="$$remote_sd" \
+		"$(LEAF_ROOT)/scripts/adb-stage-app-package.sh" \
+		"$$package_dir" "$$remote_dir"
 
 release-zips:
 	DEVICE="$(DEVICE)" \


### PR DESCRIPTION
## Summary

- route MLP1 `make stage-app` through Jawaka `package-quiesce-v1` before any package deletion or push
- fail without byte mutation when Jawaka is absent or reports a stale/unverified generation
- always request the matching rescan/restore after success or push failure
- validate destructive targets as normalized `Apps/<scope>/<name>.pak` paths
- add a fake-ADB smoke covering ordering, rejected preflight, push failure cleanup, and best-effort failed-begin release

This is stacked on draft PR #23 and coordinates with Jawaka draft PR #39. Do not merge it independently or before the Release A assembled pass.

## Verification

- `make package-quiesce-smoke`
- `bash -n scripts/adb-package-quiesce.sh scripts/adb-stage-app-package.sh scripts/adb-stage-app-package-smoke.sh`
- `shellcheck` on all three scripts

Physical MLP1 serial `b1622a9e81b735ad`:

- enabled SSH stage returned quiesce begin/end `ok`, changed Dropbear PID 19169 -> 23883, and never had a writer while the package executable was absent
- a locked stale fixture made `stage-app` fail before mutation; the complete package-tree hash stayed `7d89e2f6292efbb1d6cabc17b46572ec81481239712dae2306773c9845a69ba8`
- the final stage completed with desired SSH running and unchanged host keys
