### PR TITLE
Add PicoDrive release license notice

### DIFF
--- a/stage/licenses/CORES.md
+++ b/stage/licenses/CORES.md
@@ -43,6 +43,7 @@ from the named upstream release asset.
 | mupen64plus_standalone (standalone) | GPL-2.0 / MIT / bundled third-party notices | https://github.com/josegonzalez/minui-n64-pak |
 | mupen64plus_next | GPL-2.0 | https://github.com/libretro/mupen64plus-libretro-nx |
 | pcsx_rearmed | GPL-2.0 | https://github.com/libretro/pcsx_rearmed |
+| picodrive | PicoDrive (non-commercial) | https://github.com/libretro/picodrive |
 | ppsspp (standalone) | GPL-2.0+ | https://github.com/hrydgard/ppsspp |
 | prosystem | GPL-2.0 | https://github.com/libretro/prosystem-libretro |
 | snes9x | Snes9x (non-commercial) | https://github.com/libretro/snes9x |

--- a/stage/licenses/cores/picodrive.txt
+++ b/stage/licenses/cores/picodrive.txt
@@ -1,0 +1,30 @@
+
+ Redistribution and use of this code or any derivative works are permitted
+ provided that the following conditions are met:
+
+ * Redistributions may not be sold, nor may they be used in a commercial
+ product or activity.
+
+ * Redistributions that are modified from the original source must include the
+ complete source code, including the source code for all components used by a
+ binary built from the modified sources. However, as a special exception, the
+ source code distributed need not include anything that is normally distributed
+ (in either source or binary form) with the major components (compiler, kernel,
+ and so on) of the operating system on which the executable runs, unless that
+ component itself accompanies the executable.
+
+ * Redistributions must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other
+ materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
## Summary

- add PicoDrive to the MLP1 core-license inventory
- include PicoDrive's upstream `COPYING` notice in the staged release licenses

## Why

PicoDrive is now part of the MLP1 stock-parity core set used for 32X. Leaf's release payload must carry the corresponding source and license attribution alongside the binary.

## Validation

- the checked-in notice is byte-identical to `Cores-spruce/workdir/picodrive/COPYING`
- the inventory row points to the packaged core and notice
- Leaf staged and verified the checksum-bound 27-core set on the attached MLP1

Related core packaging: https://github.com/Utility-Muffin-Research-Kitchen/Cores-spruce/pull/1  
Related metadata policy: https://github.com/Utility-Muffin-Research-Kitchen/umrk-workspace/pull/9
