### PR TITLE
MLP1: ship the recording payload and the scale-clamp patch

### DIFF
--- a/config/mlp1-retroarch-patch-set.txt
+++ b/config/mlp1-retroarch-patch-set.txt
@@ -7,8 +7,12 @@
 #
 # Comments and blank lines are ignored; the first remaining line is the set.
 #
+# record-extension: RetroArch names recordings from the quality preset, not the
+# container, so a custom MP4 preset produced a .mkv holding MP4 -- which nothing
+# previews inline. The patch reads the container out of the record config.
+#
 # No sysfs-rumble: jawakad's virtual gamepad advertises FF_RUMBLE, so RetroArch
 # rumbles through its own SDL2 joypad driver and the fallback that wrote
 # duty_cycle directly never engages. See retroarch-builds #2 (closed) for the
 # patch if a device ever needs it.
-portrait-rotation,command-menu,jawaka-load-content,controller-bindings
+portrait-rotation,command-menu,jawaka-load-content,controller-bindings,record-extension

--- a/config/mlp1-retroarch-patch-set.txt
+++ b/config/mlp1-retroarch-patch-set.txt
@@ -11,8 +11,15 @@
 # container, so a custom MP4 preset produced a .mkv holding MP4 -- which nothing
 # previews inline. The patch reads the container out of the record config.
 #
+# record-scale-clamp: the record preset's scale_factor is a plain multiplier, and
+# a value tuned for 240p pixel art is wrong for a core already at 480p. PSX Tekken
+# 3 renders 368x480, so 3x produced 1104x1440 -- 3.1x an NES capture's pixels, and
+# it pinned the encoder at 100% of its bitrate. The patch clamps the factor from
+# the core's real geometry, which only the recorder knows and which can change
+# mid-game.
+#
 # No sysfs-rumble: jawakad's virtual gamepad advertises FF_RUMBLE, so RetroArch
 # rumbles through its own SDL2 joypad driver and the fallback that wrote
 # duty_cycle directly never engages. See retroarch-builds #2 (closed) for the
 # patch if a device ever needs it.
-portrait-rotation,command-menu,jawaka-load-content,controller-bindings,record-extension
+portrait-rotation,command-menu,jawaka-load-content,controller-bindings,record-extension,record-scale-clamp

--- a/config/mlp1-retroarch-patch-set.txt
+++ b/config/mlp1-retroarch-patch-set.txt
@@ -7,9 +7,16 @@
 #
 # Comments and blank lines are ignored; the first remaining line is the set.
 #
-# record-extension: RetroArch names recordings from the quality preset, not the
-# container, so a custom MP4 preset produced a .mkv holding MP4 -- which nothing
-# previews inline. The patch reads the container out of the record config.
+# DROPPED, record-extension: RetroArch names recordings from the quality preset
+# rather than the container, so a custom MP4 preset produced a .mkv holding MP4.
+# Real, but it never fires here: capture is Matroska on purpose (it survives a
+# recording cut short, and it holds the FLAC that keeps real-time AAC away from
+# the audio path), and for Matroska the patch produces the same "mkv" upstream
+# hardcodes. It also cut the wrong way if it ever did fire -- leaf-record-convert
+# looks for .mkv, so an .mp4 capture would be skipped in silence and never
+# converted. Carrying a rebase-forever patch to protect a container we do not
+# ship was the worse trade. It is in this repo's git history if that changes;
+# the preset warns against changing "format" instead.
 #
 # record-scale-clamp: the record preset's scale_factor is a plain multiplier, and
 # a value tuned for 240p pixel art is wrong for a core already at 480p. PSX Tekken
@@ -22,4 +29,4 @@
 # rumbles through its own SDL2 joypad driver and the fallback that wrote
 # duty_cycle directly never engages. See retroarch-builds #2 (closed) for the
 # patch if a device ever needs it.
-portrait-rotation,command-menu,jawaka-load-content,controller-bindings,record-extension,record-scale-clamp
+portrait-rotation,command-menu,jawaka-load-content,controller-bindings,record-scale-clamp

--- a/stage/mlp1.mk
+++ b/stage/mlp1.mk
@@ -26,6 +26,10 @@ MLP1_VULKAN_RUNTIME ?= $(MLP1_GRAPHICS_RUNTIME)/vulkan/rk3566-g52-g29p1
 MLP1_DRASTIC_PACKAGE ?= $(LEAF_ROOT)/build/drastic/mlp1/drastic
 MLP1_MUPEN64PLUS_PACKAGE ?= $(N64_STANDALONE_DIR)/output/mlp1/mupen64plus
 MLP1_FLYCAST_PACKAGE ?= $(FLYCAST_STANDALONE_DIR)/output/mlp1/flycast
+MLP1_FFMPEG_BIN    ?= $(RETROARCH_BUILDS_DIR)/output/mlp1/ffmpeg/bin/ffmpeg
+MLP1_FFMPEG_LIBS   ?= $(RETROARCH_BUILDS_DIR)/output/mlp1/ffmpeg/flat
+MLP1_RECORD_CONVERT ?= $(RETROARCH_BUILDS_DIR)/config/mlp1/leaf-record-convert.sh
+MLP1_RECORD_PRESET ?= $(RETROARCH_BUILDS_DIR)/config/mlp1/retroarch-record-rkmpp.cfg
 MLP1_RETROARCH_PATCH_SET_FILE ?= $(LEAF_ROOT)/config/mlp1-retroarch-patch-set.txt
 MLP1_RETROARCH_PATCH_SET ?= $(shell grep -v '^\#' "$(MLP1_RETROARCH_PATCH_SET_FILE)" | grep -v '^$$' | head -1)
 MLP1_RETROARCH_VALIDATOR ?= $(LEAF_ROOT)/scripts/validate-mlp1-retroarch-build.py
@@ -116,6 +120,26 @@ assemble-jawaka: jawaka-build shader-bundle-mlp1
 		chmod 755 "$(PLATFORM_PAYLOAD_DIR)/bin/retroarch"; \
 	else \
 		echo "warning: MLP1 RetroArch not found at $(MLP1_RETROARCH_BIN); launches will fail until built (make stage-retroarch)."; \
+	fi
+	@# Recording payload. RetroArch reaches these libraries through a RUNPATH of
+	@# $$ORIGIN/../lib/ffmpeg, so bin/ and lib/ffmpeg/ must stay siblings -- moving
+	@# either breaks recording with a loader error and nothing more informative.
+	@# The libraries are already flattened to one real file per SONAME because the
+	@# SD card is FAT32 and cannot carry ffmpeg's usual symlink chain.
+	@if [ -f "$(MLP1_FFMPEG_BIN)" ] && [ -d "$(MLP1_FFMPEG_LIBS)" ]; then \
+		mkdir -p "$(PLATFORM_PAYLOAD_DIR)/bin" "$(PLATFORM_PAYLOAD_DIR)/lib/ffmpeg"; \
+		cp -f "$(MLP1_FFMPEG_BIN)" "$(PLATFORM_PAYLOAD_DIR)/bin/ffmpeg"; \
+		chmod 755 "$(PLATFORM_PAYLOAD_DIR)/bin/ffmpeg"; \
+		find "$(MLP1_FFMPEG_LIBS)" -maxdepth 1 -type f -name '*.so.*' -exec cp -f {} "$(PLATFORM_PAYLOAD_DIR)/lib/ffmpeg/" \;; \
+		chmod 755 "$(PLATFORM_PAYLOAD_DIR)/lib/ffmpeg/"*.so.* 2>/dev/null || true; \
+		test -f "$(MLP1_RECORD_CONVERT)" || { echo "missing record convert script: $(MLP1_RECORD_CONVERT)" >&2; exit 1; }; \
+		cp -f "$(MLP1_RECORD_CONVERT)" "$(PLATFORM_PAYLOAD_DIR)/bin/leaf-record-convert.sh"; \
+		chmod 755 "$(PLATFORM_PAYLOAD_DIR)/bin/leaf-record-convert.sh"; \
+		test -f "$(MLP1_RECORD_PRESET)" || { echo "missing record preset: $(MLP1_RECORD_PRESET)" >&2; exit 1; }; \
+		mkdir -p "$(PLATFORM_PAYLOAD_DIR)/defaults"; \
+		cp -f "$(MLP1_RECORD_PRESET)" "$(PLATFORM_PAYLOAD_DIR)/defaults/retroarch-record.cfg"; \
+	else \
+		echo "warning: MLP1 FFmpeg not found at $(MLP1_FFMPEG_BIN); game recording will be unavailable (run retroarch-builds/build-mlp1-ffmpeg.sh)."; \
 	fi
 	@if [ -d "$(MLP1_CORES_DIR)" ]; then \
 		mkdir -p "$(PLATFORM_PAYLOAD_DIR)/cores"; \


### PR DESCRIPTION
The Leaf side of MLP1 game recording: stage the payload into the release, and point the RetroArch patch set at the clamp.

Depends on Utility-Muffin-Research-Kitchen/retroarch-builds#4 — staging copies the conversion script and the capture preset out of that tree and hard-fails if they are missing, so that one merges first.

## What lands

**Staging** puts the recording payload into the platform release: the `ffmpeg` CLI, its shared libraries under `lib/ffmpeg/`, `leaf-record-convert.sh`, and the capture preset as `defaults/retroarch-record.cfg`. The whole block is gated on the FFmpeg binary existing, so a tree without it warns and carries on rather than failing the build — recording is simply unavailable on that device.

**The patch set** gains `record-scale-clamp`. `scale_factor` in the capture preset is a plain multiplier, so a value tuned for 240p pixel art asks far too much of a core already at 480p — PSX Tekken 3 renders 368x480, so 3x meant 1104x1440 and pinned the encoder at 100% of its bitrate. The clamp derives the factor from the core's real geometry, which only the recorder knows.

**`record-extension` was added and then dropped** in this branch. It fixes something real upstream — RetroArch names a recording after the quality preset rather than the container it writes — but it cannot fire here, since capture is Matroska deliberately and for Matroska it produces the same `mkv` upstream already hardcodes. If it ever did fire it would cut the wrong way: the conversion pass only picks up `.mkv`, so an `.mp4` capture would be skipped in silence. The preset now carries a warning against changing `format` instead, which is where someone would be standing when it mattered.

## Note for review

Dropping that entry invalidates any existing RetroArch build, because `validate-mlp1-retroarch-build.py` compares the manifest against the requested set and will correctly refuse to reuse one built with the old six-entry string. RetroArch has already been rebuilt against the new set and verified on hardware — all five patches apply cleanly to v1.22.2, and a device running the result records correctly.

The add-then-drop pair is left unsquashed; the drop commit is where the reasoning lives.