### PR TITLE
Add record-indicator to the MLP1 RetroArch patch set

### DIFF
--- a/config/mlp1-retroarch-patch-set.txt
+++ b/config/mlp1-retroarch-patch-set.txt
@@ -29,4 +29,12 @@
 # rumbles through its own SDL2 joypad driver and the fallback that wrote
 # duty_cycle directly never engages. See retroarch-builds #2 (closed) for the
 # patch if a device ever needs it.
-portrait-rotation,command-menu,jawaka-load-content,controller-bindings,record-scale-clamp
+# record-indicator: RetroArch shows NOTHING on screen while recording -- the toggle
+# calls RECORD_INIT/DEINIT, neither pushes a message, and record_driver.c has no
+# runloop_msg_queue_push at all. This draws a pulsing dot inside gfx_widgets_frame.
+# Inside RA's own render pass on purpose: a second permanently-mapped Wayland
+# surface from our OSD could cost the compositor direct scanout and slow the game
+# for the whole recording. It does not appear in the clip (capture taps the core
+# framebuffer before this pass, same reason shaders are not captured).
+#
+portrait-rotation,command-menu,jawaka-load-content,controller-bindings,record-scale-clamp,record-indicator


### PR DESCRIPTION
Enables the on-screen recording indicator from Utility-Muffin-Research-Kitchen/retroarch-builds#5, which merges first.

RetroArch shows nothing on screen while recording — the toggle calls `RECORD_INIT`/`RECORD_DEINIT`, neither pushes a message, and `record_driver.c` has no `runloop_msg_queue_push` at all. Without this the only sign a recording is running is a line in a log file, which on a handheld with no tally light is no sign at all.

The patch draws inside RetroArch's own widget pass rather than from our OSD process, because a second permanently-mapped Wayland surface could cost the compositor direct scanout and slow the game for the whole recording. It does not appear in the resulting clip.

Adding an entry invalidates any existing RetroArch build, exactly as dropping `record-extension` did: `validate-mlp1-retroarch-build.py` compares the manifest against the requested set and correctly refuses to reuse a binary built with a different one. The next release therefore rebuilds RetroArch, which has already been done and verified on hardware.