### PR TITLE
Validate RECORDINGS_PATH in the release payload

### DIFF
--- a/scripts/validate-leaf-release-test.py
+++ b/scripts/validate-leaf-release-test.py
@@ -234,6 +234,8 @@ class CandidateTests(unittest.TestCase):
         ]
         for name, values in MODULE.REQUIRED_PATH_LISTS.items():
             env_lines.append(f"export {name}={':'.join(values)}")
+        for name, value in MODULE.REQUIRED_PRIMARY_PATHS.items():
+            env_lines.append(f"export {name}={value}")
         env_path = launcher / "env.sh"
         env_path.parent.mkdir(parents=True, exist_ok=True)
         env_path.write_text("\n".join(env_lines) + "\n", encoding="utf-8")
@@ -350,6 +352,27 @@ class CandidateTests(unittest.TestCase):
                 encoding="utf-8",
             )
             with self.assertRaisesRegex(MODULE.PolicyError, "VIDEO_PATHS mismatch"):
+                MODULE.validate_candidate(args)
+
+    def test_candidate_rejects_wrong_primary_recordings_path(self):
+        with tempfile.TemporaryDirectory() as raw:
+            args = self.make_candidate(Path(raw))
+            env_path = (
+                args.release_root
+                / "platforms"
+                / "mlp1"
+                / "launcher"
+                / "env.sh"
+            )
+            text = env_path.read_text(encoding="utf-8")
+            env_path.write_text(
+                text.replace(
+                    "export RECORDINGS_PATH=/mnt/sdcard/Recordings",
+                    "export RECORDINGS_PATH=/media/sdcard1/Recordings",
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(MODULE.PolicyError, "RECORDINGS_PATH mismatch"):
                 MODULE.validate_candidate(args)
 
     def test_candidate_rejects_incomplete_l3_autoconfig(self):

--- a/scripts/validate-leaf-release.py
+++ b/scripts/validate-leaf-release.py
@@ -36,6 +36,11 @@ REQUIRED_PATH_LISTS = {
     "STATES_PATHS": ("/mnt/sdcard/States", "/media/sdcard1/States"),
     "CHEATS_PATHS": ("/mnt/sdcard/Cheats", "/media/sdcard1/Cheats"),
 }
+REQUIRED_PRIMARY_PATHS = {
+    # Gameplay conversion is intentionally primary-only; this is not another
+    # SDCARD_PATHS-aligned source list.
+    "RECORDINGS_PATH": "/mnt/sdcard/Recordings",
+}
 
 
 class PolicyError(Exception):
@@ -317,6 +322,12 @@ def validate_candidate(args: argparse.Namespace) -> None:
             raise PolicyError(
                 f"runtime environment {name} mismatch: "
                 f"{actual!r} != {expected!r}"
+            )
+    for name, expected in REQUIRED_PRIMARY_PATHS.items():
+        actual = environment.get(name)
+        if actual != expected:
+            raise PolicyError(
+                f"runtime environment {name} mismatch: {actual!r} != {expected!r}"
             )
 
     provenance_path = root / "provenance" / "components.json"


### PR DESCRIPTION
Release-gate half of the singular `RECORDINGS_PATH` contract in
`umrk-workspace/plans/video-from-hell-disco-boy-gap-closure.md` §4.2.
Producer: Jawaka#48 and miniloong-launcher-switcher#16. Consumer: VideoFromHell#1.

## Summary
- require the staged runtime environment to publish `RECORDINGS_PATH` and to
  agree on the primary-card directory, so a payload cannot ship with the
  producer and consumer pointing at different paths
- add validator coverage for the mismatch case

## Validation
- `python3 scripts/validate-leaf-release-test.py` — 18 tests, OK

## Notes
Rebased onto current `main`. "Register Video From Hell and require the Videos
root" already landed via #30, so this is only the recordings-path validation.

Must land together with Jawaka#48, miniloong-launcher-switcher#16,
umrk-workspace, and VideoFromHell#1.

Video From Hell stays excluded from the default Leaf payload and release ZIPs;
this changes validation only.