### PR TITLE
Require opt-in for full MLP1 core rebuilds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ LARGE_LIBRARY_FIXTURE_ENV = \
 	REMOTE_SDCARD_PATH="$(REMOTE_SDCARD_PATH)"
 
 .DEFAULT_GOAL := help
-.PHONY: help bootstrap doctor status status-internal pakrat-local-feed-test leaf-release-policy-test shader-bundle-release-policy-test flycast-release-policy-smoke package-quiesce-smoke adb-enable-marker adb-disable-marker adb-tail-logs adb-large-library-create adb-large-library-clean adb-large-library-status adb-install-wrapper adb-uninstall-wrapper benchmark-ppsspp
+.PHONY: help bootstrap doctor status status-internal pakrat-local-feed-test leaf-release-policy-test shader-bundle-release-policy-test flycast-release-policy-smoke core-rebuild-gate-test package-quiesce-smoke adb-enable-marker adb-disable-marker adb-tail-logs adb-large-library-create adb-large-library-clean adb-large-library-status adb-install-wrapper adb-uninstall-wrapper benchmark-ppsspp
 
 help:
 	@echo "Leaf workspace commands (DEVICE=$(DEVICE), WORKSPACE_DIR=$(WORKSPACE_DIR)):"
@@ -48,6 +48,7 @@ help:
 	@echo "  make stage-app APP=Nimbus DEVICE=mlp1       explicitly stage the optional Nimbus app"
 	@echo "  make stage-app APP=PortMaster-mlp1 DEVICE=mlp1 explicitly stage the optional PortMaster app"
 	@echo "  make release-zips DEVICE=mlp1             build end-user install + recovery ZIPs"
+	@echo "    REBUILD_CORES=1                         explicitly permit a missing/stale full core rebuild"
 	@echo "  make beta-zips TAG=v0.8.0-beta.3 DEVICE=mlp1  build clean beta ZIPs from one tag, then verify"
 	@echo "  make release-sd-zip DEVICE=mlp1           build end-user install ZIP"
 	@echo "  make release-recovery-zip DEVICE=mlp1     build end-user recovery ZIP"
@@ -55,6 +56,7 @@ help:
 	@echo "  make leaf-release-policy-test             test release identity, artifacts, provenance, and gates"
 	@echo "  make shader-bundle-release-policy-test    test shader bundle integrity release gates"
 	@echo "  make flycast-release-policy-smoke         test standalone Flycast release gates"
+	@echo "  make core-rebuild-gate-test               test explicit long core-rebuild authorization"
 	@echo "  make package-quiesce-smoke                test fail-closed stage-app service barrier"
 	@echo "  make adb-enable-marker                    enable Leaf launcher marker"
 	@echo "  make adb-disable-marker                   disable Leaf launcher marker"
@@ -110,6 +112,9 @@ leaf-release-policy-test:
 
 shader-bundle-release-policy-test:
 	python3 scripts/validate-shader-bundle-release-test.py
+
+core-rebuild-gate-test:
+	bash scripts/ensure-mlp1-cores-test.sh
 
 package-quiesce-smoke:
 	@bash scripts/adb-stage-app-package-smoke.sh

--- a/scripts/ensure-mlp1-cores-test.sh
+++ b/scripts/ensure-mlp1-cores-test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+CORES_REPO="$TEST_ROOT/Cores-spruce"
+CORES_DIR="$CORES_REPO/output/mlp1/cores"
+REPORT="$CORES_REPO/output/mlp1/build-report.json"
+REPORT_TOOL="$CORES_REPO/scripts/mlp1-core-report.py"
+BUILD_LOG="$TEST_ROOT/build.log"
+
+mkdir -p "$CORES_DIR" "$CORES_REPO/scripts"
+touch "$CORES_DIR/test_libretro.so" "$REPORT"
+
+cat >"$REPORT_TOOL" <<'PY'
+#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+valid = os.environ.get("FAKE_REPORT_VALID") == "1"
+build_log = os.environ.get("BUILD_LOG")
+sys.exit(0 if valid or (build_log and Path(build_log).is_file()) else 1)
+PY
+chmod +x "$REPORT_TOOL"
+
+cat >"$CORES_REPO/build-mlp1.sh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$BUILD_LOG"
+touch output/mlp1/cores/test_libretro.so output/mlp1/build-report.json
+SH
+chmod +x "$CORES_REPO/build-mlp1.sh"
+
+run_gate() {
+    CORES_SPRUCE_DIR="$CORES_REPO" \
+    MLP1_CORES_DIR="$CORES_DIR" \
+    MLP1_CORES_REPORT="$REPORT" \
+    MLP1_CORE_REPORT_TOOL="$REPORT_TOOL" \
+    BUILD_LOG="$BUILD_LOG" \
+    "$SCRIPT_DIR/ensure-mlp1-cores.sh"
+}
+
+FAKE_REPORT_VALID=1 run_gate >/dev/null
+[ ! -e "$BUILD_LOG" ] || {
+    echo "valid report unexpectedly rebuilt cores" >&2
+    exit 1
+}
+
+set +e
+FAKE_REPORT_VALID=0 run_gate >"$TEST_ROOT/refusal.out" 2>&1
+status=$?
+set -e
+[ "$status" -eq 2 ] || {
+    echo "invalid report returned $status instead of 2" >&2
+    exit 1
+}
+grep -q 'REBUILD_CORES=1' "$TEST_ROOT/refusal.out"
+[ ! -e "$BUILD_LOG" ] || {
+    echo "invalid report rebuilt cores without authorization" >&2
+    exit 1
+}
+
+FAKE_REPORT_VALID=0 REBUILD_CORES=1 run_gate >/dev/null
+[ "$(wc -l <"$BUILD_LOG" | tr -d '[:space:]')" = "1" ]
+grep -qx -- '--stock-parity' "$BUILD_LOG"
+
+echo "ensure-mlp1-cores-test: PASS"

--- a/scripts/ensure-mlp1-cores.sh
+++ b/scripts/ensure-mlp1-cores.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LEAF_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKSPACE_DIR="${LEAF_WORKSPACE_DIR:-$(cd "$LEAF_ROOT/.." && pwd)}"
+
+CORES_SPRUCE_DIR="${CORES_SPRUCE_DIR:-$WORKSPACE_DIR/Cores-spruce}"
+MLP1_CORES_DIR="${MLP1_CORES_DIR:-$CORES_SPRUCE_DIR/output/mlp1/cores}"
+MLP1_CORES_REPORT="${MLP1_CORES_REPORT:-$CORES_SPRUCE_DIR/output/mlp1/build-report.json}"
+MLP1_CORE_REPORT_TOOL="${MLP1_CORE_REPORT_TOOL:-$CORES_SPRUCE_DIR/scripts/mlp1-core-report.py}"
+REBUILD_CORES="${REBUILD_CORES:-0}"
+
+case "$REBUILD_CORES" in
+    0|1) ;;
+    *)
+        echo "error: REBUILD_CORES must be 0 or 1, got: $REBUILD_CORES" >&2
+        exit 2
+        ;;
+esac
+
+core_report_valid() {
+    [ -d "$MLP1_CORES_DIR" ] &&
+        find "$MLP1_CORES_DIR" -maxdepth 1 -type f -name '*_libretro.so' -print -quit | grep -q . &&
+        python3 "$MLP1_CORE_REPORT_TOOL" manifest \
+            --report "$MLP1_CORES_REPORT" \
+            --cores-dir "$MLP1_CORES_DIR" >/dev/null 2>&1
+}
+
+if core_report_valid; then
+    echo "Reusing checksum-validated MLP1 core set: $MLP1_CORES_REPORT"
+    exit 0
+fi
+
+if [ "$REBUILD_CORES" != "1" ]; then
+    echo "error: MLP1 cores are missing or their build report is invalid." >&2
+    echo "Refusing to start the long stock-parity core build implicitly." >&2
+    echo "Inspect the report, or rerun intentionally with REBUILD_CORES=1." >&2
+    exit 2
+fi
+
+[ -x "$CORES_SPRUCE_DIR/build-mlp1.sh" ] || {
+    echo "error: missing core builder: $CORES_SPRUCE_DIR/build-mlp1.sh" >&2
+    exit 2
+}
+
+echo "REBUILD_CORES=1: building the complete MLP1 stock-parity core set"
+(
+    cd "$CORES_SPRUCE_DIR"
+    ./build-mlp1.sh --stock-parity
+)
+
+core_report_valid || {
+    echo "error: rebuilt MLP1 core set still has an invalid report" >&2
+    exit 1
+}
+
+echo "Built and validated MLP1 core set: $MLP1_CORES_REPORT"

--- a/scripts/make-sd-release-zip.sh
+++ b/scripts/make-sd-release-zip.sh
@@ -57,6 +57,8 @@ Environment:
   RELEASE_ID=<filesystem-safe id>
   LEAF_WORKSPACE_DIR=<workspace root>
   TOOLCHAIN_IMAGE=<MLP1 cross-compile Docker image>
+  REBUILD_CORES=1  explicitly allow a full stock-parity core rebuild when the
+                   existing checksum-bound core report is missing or invalid
   STAGE_APPS="ssh-server Thing-File CentralScrutinizer Fugazi joes-calibrage retroarch-builds"
   STAGE_EMULATORS="ppsspp drastic mupen64plus flycast"
 EOF
@@ -599,17 +601,12 @@ build_missing_platform_bits() {
     python3 "$MLP1_SHADER_TOOL" validate --output "$MLP1_SHADERS_DIR" ||
         die "MLP1 shader bundle validation failed"
 
-    if ! ( [ -d "$MLP1_CORES_DIR" ] && find "$MLP1_CORES_DIR" -maxdepth 1 -type f -name '*_libretro.so' | grep -q . ); then
-        echo "MLP1 cores missing; building in $CORES_SPRUCE_DIR"
-        (cd "$CORES_SPRUCE_DIR" && ./build-mlp1.sh --stock-parity)
-    fi
-
-    if ! python3 "$MLP1_CORE_REPORT_TOOL" manifest \
-            --report "$MLP1_CORES_REPORT" \
-            --cores-dir "$MLP1_CORES_DIR" >/dev/null 2>&1; then
-        echo "MLP1 core identity report is missing, stale, or checksum-invalid; rebuilding stock-parity cores"
-        (cd "$CORES_SPRUCE_DIR" && ./build-mlp1.sh --stock-parity)
-    fi
+    REBUILD_CORES="${REBUILD_CORES:-0}" \
+    CORES_SPRUCE_DIR="$CORES_SPRUCE_DIR" \
+    MLP1_CORES_DIR="$MLP1_CORES_DIR" \
+    MLP1_CORES_REPORT="$MLP1_CORES_REPORT" \
+    MLP1_CORE_REPORT_TOOL="$MLP1_CORE_REPORT_TOOL" \
+        "$LEAF_ROOT/scripts/ensure-mlp1-cores.sh"
 
     if ! python3 "$MLP1_CORE_REPORT_TOOL" verify \
             --report "$MLP1_CORES_REPORT" \

--- a/stage/mlp1.mk
+++ b/stage/mlp1.mk
@@ -192,16 +192,12 @@ stage-retroarch:
 			--manifest "$(MLP1_RETROARCH_MANIFEST)" \
 			--expected-patch-set "$(MLP1_RETROARCH_PATCH_SET)"; \
 	fi
-	@if ! ( [ -d "$(MLP1_CORES_DIR)" ] && find "$(MLP1_CORES_DIR)" -maxdepth 1 -type f -name '*_libretro.so' | grep -q . ); then \
-		echo "MLP1 cores missing; building in $(CORES_SPRUCE_DIR)"; \
-		cd "$(CORES_SPRUCE_DIR)" && ./build-mlp1.sh --stock-parity; \
-	fi
-	@if ! python3 "$(MLP1_CORE_REPORT_TOOL)" manifest \
-			--report "$(MLP1_CORES_REPORT)" \
-			--cores-dir "$(MLP1_CORES_DIR)" >/dev/null 2>&1; then \
-		echo "MLP1 core identity report is missing, stale, or checksum-invalid; rebuilding stock-parity cores"; \
-		cd "$(CORES_SPRUCE_DIR)" && ./build-mlp1.sh --stock-parity; \
-	fi
+	@REBUILD_CORES="$(REBUILD_CORES)" \
+		CORES_SPRUCE_DIR="$(CORES_SPRUCE_DIR)" \
+		MLP1_CORES_DIR="$(MLP1_CORES_DIR)" \
+		MLP1_CORES_REPORT="$(MLP1_CORES_REPORT)" \
+		MLP1_CORE_REPORT_TOOL="$(MLP1_CORE_REPORT_TOOL)" \
+		"$(LEAF_ROOT)/scripts/ensure-mlp1-cores.sh"
 	@test -f "$(MLP1_RETROARCH_BIN)" || { echo "missing RetroArch binary: $(MLP1_RETROARCH_BIN)" >&2; exit 1; }
 	@test -d "$(MLP1_CORES_DIR)" || { echo "missing cores dir: $(MLP1_CORES_DIR)" >&2; exit 1; }
 	@$(MAKE) -C "$(RETROARCH_BUILDS_DIR)" shaders-mlp1 MLP1_SHADER_OUTPUT="$(MLP1_SHADERS_DIR)"
@@ -457,6 +453,7 @@ release-zips:
 	MLP1_SHADERS_DIR="$(MLP1_SHADERS_DIR)" \
 	MLP1_CORES_DIR="$(MLP1_CORES_DIR)" \
 	MLP1_CORES_REPORT="$(MLP1_CORES_REPORT)" \
+	REBUILD_CORES="$(REBUILD_CORES)" \
 	MLP1_PPSSPP_PACKAGE="$(MLP1_PPSSPP_PACKAGE)" \
 	MLP1_GRAPHICS_RUNTIME="$(MLP1_GRAPHICS_RUNTIME)" \
 	MLP1_VULKAN_RUNTIME="$(MLP1_VULKAN_RUNTIME)" \
@@ -493,6 +490,7 @@ release-sd-zip:
 	MLP1_SHADERS_DIR="$(MLP1_SHADERS_DIR)" \
 	MLP1_CORES_DIR="$(MLP1_CORES_DIR)" \
 	MLP1_CORES_REPORT="$(MLP1_CORES_REPORT)" \
+	REBUILD_CORES="$(REBUILD_CORES)" \
 	MLP1_PPSSPP_PACKAGE="$(MLP1_PPSSPP_PACKAGE)" \
 	MLP1_GRAPHICS_RUNTIME="$(MLP1_GRAPHICS_RUNTIME)" \
 	MLP1_VULKAN_RUNTIME="$(MLP1_VULKAN_RUNTIME)" \


### PR DESCRIPTION
## What changed

- centralize MLP1 core artifact validation in `ensure-mlp1-cores.sh`
- reuse a checksum-valid core report without compiling
- fail fast when cores are missing or invalid unless `REBUILD_CORES=1` is explicit
- apply the same guard to release ZIP assembly and `stage-retroarch`
- add a focused shell test for reuse, refusal, and authorized rebuild behavior

## Why

A missing or stale core report previously caused an implicit full stock-parity compile. That can take more than an hour, especially with MAME and FBNeo, and should never begin as a surprise side effect of an SD/release build.

## Checks

- `make core-rebuild-gate-test`
- `bash -n scripts/ensure-mlp1-cores.sh scripts/ensure-mlp1-cores-test.sh scripts/make-sd-release-zip.sh`
- `make leaf-release-policy-test`
- `make pakrat-local-feed-test`
- real existing 27-core report reused successfully with `REBUILD_CORES=0`
