### PR TITLE
Stage the RetroArch menu asset bundle to the durable user tree

### DIFF
--- a/scripts/adb-stage-sd-bundle.sh
+++ b/scripts/adb-stage-sd-bundle.sh
@@ -66,6 +66,7 @@ REMOTE_PLATFORM_PATH="${REMOTE_PLATFORM_PATH:-$REMOTE_PLATFORM_ROOT/$PLATFORM_ID
 REMOTE_LAUNCHER_PATH="${REMOTE_LAUNCHER_PATH:-${REMOTE_BUNDLE:-$REMOTE_PLATFORM_PATH/launcher}}"
 MARKER="${UMRK_MARKER_PATH:-$REMOTE_PLATFORM_PATH/enabled}"
 SHADER_PAYLOAD="$PLATFORM_DIR/shaders"
+ASSET_PAYLOAD="$PLATFORM_DIR/assets"
 
 if [ "$PLATFORM_ID" = "mlp1" ] &&
    [ -d "$SHADER_PAYLOAD/leaf-bundled" ] &&
@@ -87,7 +88,7 @@ if [ -d "$PLATFORM_DIR" ]; then
     echo "Deploying platform payload to $REMOTE_PLATFORM_PATH ($PLATFORM_MODE)"
     "${ADB[@]}" shell "mkdir -p '$REMOTE_PLATFORM_PATH'"
     if [ "$PLATFORM_MODE" = "replace" ]; then
-        for name in bin cores info defaults platform.d autoconfig boot-animation shaders manifest.json; do
+        for name in bin cores info defaults platform.d autoconfig boot-animation shaders assets manifest.json; do
             "${ADB[@]}" shell "rm -rf '$REMOTE_PLATFORM_PATH/$name'"
         done
     fi
@@ -118,6 +119,15 @@ if [ "$PLATFORM_ID" = "mlp1" ] &&
     REMOTE_SYSTEM_PATH="$REMOTE_SYSTEM_PATH" \
     REMOTE_PLATFORM_PATH="$REMOTE_PLATFORM_PATH" \
         "$ROOT_DIR/scripts/adb-sync-shader-namespaces.sh" --sync-only
+fi
+
+if [ "$PLATFORM_ID" = "mlp1" ] && [ -d "$ASSET_PAYLOAD/ozone" ]; then
+    ADB_SERIAL="$serial" \
+    PLATFORM_ID="$PLATFORM_ID" \
+    REMOTE_SDCARD_PATH="$REMOTE_SDCARD_PATH" \
+    REMOTE_SYSTEM_PATH="$REMOTE_SYSTEM_PATH" \
+    REMOTE_PLATFORM_PATH="$REMOTE_PLATFORM_PATH" \
+        "$ROOT_DIR/scripts/adb-sync-asset-namespaces.sh"
 fi
 
 case "$MARKER_MODE" in

--- a/scripts/adb-sync-asset-namespaces.sh
+++ b/scripts/adb-sync-asset-namespaces.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Copy the release-managed RetroArch menu asset bundle into the durable user
+# assets tree RetroArch actually reads.
+#
+# RetroArch resolves assets_directory to ~/.config/retroarch/assets, which for
+# Leaf is $SDCARD/.umrk/<platform>/retroarch/.config/retroarch/assets. That is
+# deliberately NOT the release-managed platform tree: RetroArch's Online Updater
+# has an "Update Assets" action that writes into assets_directory, and .system is
+# replaced wholesale on every Leaf update. Same split, same reasoning as
+# adb-sync-shader-namespaces.sh.
+#
+# Only the subtrees Leaf ships are replaced, so anything the updater adds
+# alongside them (xmb/automatic, rgui, sounds, ...) is left alone.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLATFORM_ID="${PLATFORM_ID:-mlp1}"
+REQUESTED_REMOTE_SDCARD_PATH="${REMOTE_SDCARD_PATH:-auto}"
+
+if [ "${1:-}" != "" ]; then
+    echo "usage: $0" >&2
+    exit 1
+fi
+
+if [ -n "${ADB_SERIAL:-}" ]; then
+    serial="$ADB_SERIAL"
+else
+    serial="$(adb devices | awk 'NR>1 && $2=="device" {print $1; exit}')"
+fi
+[ -n "${serial:-}" ] || {
+    echo "No online adb device found." >&2
+    exit 1
+}
+ADB=(adb -s "$serial")
+
+remote_sd="$(
+    PLATFORM_ID="$PLATFORM_ID" \
+    REMOTE_SDCARD_PATH="$REQUESTED_REMOTE_SDCARD_PATH" \
+    ADB_SERIAL="$serial" \
+        "$ROOT_DIR/scripts/adb-resolve-umrk-sd.sh"
+)"
+remote_system="${REMOTE_SYSTEM_PATH:-$remote_sd/.system/leaf}"
+remote_platform="${REMOTE_PLATFORM_PATH:-$remote_system/platforms/$PLATFORM_ID}"
+remote_bundle="$remote_platform/assets"
+remote_user_assets="${UMRK_RETROARCH_USER_ASSETS_DIR:-$remote_sd/.umrk/$PLATFORM_ID/retroarch/.config/retroarch/assets}"
+
+"${ADB[@]}" shell sh -s -- "$remote_bundle" "$remote_user_assets" <<'REMOTE_SH'
+set -eu
+
+bundle_root="$1"
+user_root="$2"
+
+sync_namespace() {
+    namespace="$1"
+    src="$bundle_root/$namespace"
+    dst="$user_root/$namespace"
+    tmp="$dst.tmp.$$"
+    previous="$dst.previous.$$"
+    [ -d "$src" ] || {
+        echo "missing Leaf asset namespace: $src" >&2
+        exit 1
+    }
+    mkdir -p "$(dirname "$dst")" || {
+        echo "failed to create asset namespace parent for: $namespace" >&2
+        exit 1
+    }
+    rm -rf "$tmp" "$previous" 2>/dev/null || true
+    cp -R "$src" "$tmp"
+    if [ -e "$dst" ]; then
+        mv "$dst" "$previous"
+    fi
+    if ! mv "$tmp" "$dst"; then
+        [ ! -e "$previous" ] || mv "$previous" "$dst" 2>/dev/null || true
+        echo "failed to promote Leaf asset namespace: $namespace" >&2
+        exit 1
+    fi
+    rm -rf "$previous" 2>/dev/null || true
+}
+
+mkdir -p "$user_root"
+sync_namespace ozone
+sync_namespace xmb/monochrome
+sync_namespace pkg
+echo "Synchronized Leaf menu asset namespaces at $user_root"
+REMOTE_SH

--- a/scripts/make-sd-release-zip.sh
+++ b/scripts/make-sd-release-zip.sh
@@ -32,6 +32,8 @@ MLP1_RETROARCH_BIN="${MLP1_RETROARCH_BIN:-$RETROARCH_BUILDS_DIR/output/mlp1/bin/
 MLP1_RETROARCH_MANIFEST="${MLP1_RETROARCH_MANIFEST:-$RETROARCH_BUILDS_DIR/output/mlp1/build-manifest.json}"
 MLP1_SHADERS_DIR="${MLP1_SHADERS_DIR:-$RETROARCH_BUILDS_DIR/output/mlp1/shaders}"
 MLP1_SHADER_TOOL="${MLP1_SHADER_TOOL:-$RETROARCH_BUILDS_DIR/scripts/mlp1_shader_bundle.py}"
+MLP1_ASSETS_DIR="${MLP1_ASSETS_DIR:-$RETROARCH_BUILDS_DIR/output/mlp1/assets}"
+MLP1_ASSET_TOOL="${MLP1_ASSET_TOOL:-$RETROARCH_BUILDS_DIR/scripts/mlp1_asset_bundle.py}"
 MLP1_CORES_DIR="${MLP1_CORES_DIR:-$CORES_SPRUCE_DIR/output/mlp1/cores}"
 MLP1_CORES_REPORT="${MLP1_CORES_REPORT:-$CORES_SPRUCE_DIR/output/mlp1/build-report.json}"
 MLP1_PPSSPP_PACKAGE="${MLP1_PPSSPP_PACKAGE:-$PPSSPP_SPRUCE_DIR/output/mlp1/ppsspp}"
@@ -470,6 +472,15 @@ validate_retroarch_contract() {
         || die "RetroArch runtime metadata contract validation failed"
 }
 
+validate_asset_bundle() {
+    local platform_dir="$1"
+    local license_root="$2"
+    python3 "$MLP1_ASSET_TOOL" validate --output "$platform_dir/assets" ||
+        die "MLP1 menu asset bundle release validation failed"
+    [ -f "$license_root/ASSETS.md" ] ||
+        die "missing asset license notice: $license_root/ASSETS.md"
+}
+
 validate_shader_bundle() {
     local platform_dir="$1"
     local license_root="$2"
@@ -600,6 +611,11 @@ build_missing_platform_bits() {
         MLP1_SHADER_OUTPUT="$MLP1_SHADERS_DIR"
     python3 "$MLP1_SHADER_TOOL" validate --output "$MLP1_SHADERS_DIR" ||
         die "MLP1 shader bundle validation failed"
+
+    make -C "$RETROARCH_BUILDS_DIR" assets-mlp1 \
+        MLP1_ASSET_OUTPUT="$MLP1_ASSETS_DIR"
+    python3 "$MLP1_ASSET_TOOL" validate --output "$MLP1_ASSETS_DIR" ||
+        die "MLP1 menu asset bundle validation failed"
 
     REBUILD_CORES="${REBUILD_CORES:-0}" \
     CORES_SPRUCE_DIR="$CORES_SPRUCE_DIR" \
@@ -854,6 +870,7 @@ build_install_zip() {
         MLP1_RETROARCH_BIN="$MLP1_RETROARCH_BIN" \
         MLP1_RETROARCH_MANIFEST="$MLP1_RETROARCH_MANIFEST" \
         MLP1_SHADERS_DIR="$MLP1_SHADERS_DIR" \
+        MLP1_ASSETS_DIR="$MLP1_ASSETS_DIR" \
         MLP1_CORES_DIR="$MLP1_CORES_DIR" \
         MLP1_CORES_REPORT="$MLP1_CORES_REPORT" \
         assemble-jawaka
@@ -887,6 +904,7 @@ build_install_zip() {
     validate_packaged_cores "$RELEASE_ROOT"
     validate_retroarch_contract "$RELEASE_ROOT/platforms/mlp1"
     validate_shader_bundle "$RELEASE_ROOT/platforms/mlp1" "$RELEASE_ROOT/licenses"
+    validate_asset_bundle "$RELEASE_ROOT/platforms/mlp1" "$RELEASE_ROOT/licenses"
 
     for app in $STAGE_APPS; do
         package_app "$app"

--- a/stage/licenses/ASSETS.md
+++ b/stage/licenses/ASSETS.md
@@ -11,6 +11,12 @@ https://leaf.game/credits.
 | Default system icons (libretro Systematic pack) | libretro team and contributors | CC BY-SA 4.0 |
 | UI fonts (Space Grotesk, Inter, Rounded M+, Nunito, Baloo 2, Fredoka, Lexend, IBM Plex Sans, Noto Sans, Source Han Sans) | respective type designers | SIL OFL 1.1 |
 | Keyboard glyph icons (Nerd Fonts) | Nerd Fonts contributors | MIT |
+| RetroArch menu artwork (`platforms/mlp1/assets/`, Ozone and XMB Monochrome) | libretro team and contributors | CC BY 4.0 |
+| RetroArch menu font (Inter UI, in `assets/ozone/`) | The Inter UI project authors | SIL OFL 1.1 |
+| RetroArch icon-theme font (M+ 1p, in `assets/xmb/monochrome/`) | M+ FONTS PROJECT | M+ Free License |
+| RetroArch Chinese fallback font (Droid Sans Fallback) | Ascender Corporation / Google | Apache 2.0 |
+| RetroArch Korean fallback font (Spoqa Han Sans) | Spoqa | SIL OFL 1.1 |
+| RetroArch Arabic/Persian, Thai and OSD fonts (DejaVu Sans, Waree, DejaVu Sans Mono) | Bitstream, Inc.; DejaVu and TLWG contributors | Bitstream Vera license; project changes public domain |
 
 **Cover Flow console art** - photographs of video game hardware released to the
 public domain by Evan Amos (https://commons.wikimedia.org/wiki/User:Evan-Amos).
@@ -23,5 +29,19 @@ short codes for the theme; full-resolution originals are kept in the UMRK
 (https://github.com/libretro/retroarch-assets, `xmb/systematic/png/`), CC BY-SA
 4.0. Per-file note ships in `res/system_icons/LICENSE-ASSETS.md`.
 
-**Fonts** are distributed under the SIL Open Font License 1.1. The Nerd Fonts
-glyphs used for on-screen keyboard key icons are MIT-licensed.
+**RetroArch menu assets** - RetroArch resolves every icon and font its menu
+drivers draw under a single assets directory. Leaf assembles that tree directly
+from https://github.com/libretro/retroarch-assets at a pinned commit, pruned to
+the subtrees our binary actually reads (`ozone/`, `xmb/monochrome/`, and the
+`pkg/` fallback fonts). The artwork is covered by that repository's own
+`COPYING`, Creative Commons Attribution 4.0 International; the fonts carry
+their own separate licenses, listed above and read from each font's name table
+rather than assumed. Per-file provenance - upstream commit, source path,
+SHA-256 and license classification for all 929 files - ships in the bundle
+itself as `platforms/mlp1/assets/manifest.json`, with a human-readable summary
+in `platforms/mlp1/assets/NOTICE.md`.
+
+**Fonts** used by Leaf's own launcher UI are distributed under the SIL Open
+Font License 1.1. The Nerd Fonts glyphs used for on-screen keyboard key icons
+are MIT-licensed. The RetroArch fallback fonts above are separate works with
+their own terms and are not OFL.

--- a/stage/mlp1.mk
+++ b/stage/mlp1.mk
@@ -15,6 +15,8 @@ MLP1_RETROARCH_BIN ?= $(RETROARCH_BUILDS_DIR)/output/mlp1/bin/retroarch
 MLP1_RETROARCH_MANIFEST ?= $(RETROARCH_BUILDS_DIR)/output/mlp1/build-manifest.json
 MLP1_SHADERS_DIR    ?= $(RETROARCH_BUILDS_DIR)/output/mlp1/shaders
 MLP1_SHADER_TOOL    ?= $(RETROARCH_BUILDS_DIR)/scripts/mlp1_shader_bundle.py
+MLP1_ASSETS_DIR     ?= $(RETROARCH_BUILDS_DIR)/output/mlp1/assets
+MLP1_ASSET_TOOL     ?= $(RETROARCH_BUILDS_DIR)/scripts/mlp1_asset_bundle.py
 MLP1_CORES_DIR     ?= $(CORES_SPRUCE_DIR)/output/mlp1/cores
 MLP1_CORES_REPORT  ?= $(CORES_SPRUCE_DIR)/output/mlp1/build-report.json
 MLP1_INFO_DIR      ?= $(CORES_SPRUCE_DIR)/output/mlp1/info
@@ -164,6 +166,13 @@ assemble-jawaka: jawaka-build shader-bundle-mlp1
 	@mkdir -p "$(PLATFORM_PAYLOAD_DIR)/shaders"
 	@cp -Rf "$(MLP1_SHADERS_DIR)/." "$(PLATFORM_PAYLOAD_DIR)/shaders/"
 	@python3 "$(MLP1_SHADER_TOOL)" validate --output "$(PLATFORM_PAYLOAD_DIR)/shaders"
+	@# RetroArch menu assets. Ozone reads every icon and font it draws from
+	@# assets_directory, which jawaka-retroarch-runner points here; without this
+	@# tree Ozone has no icons and falls back to a bitmap font that cannot draw CJK.
+	@test -d "$(MLP1_ASSETS_DIR)" || { echo "missing MLP1 asset bundle: $(MLP1_ASSETS_DIR)" >&2; exit 1; }
+	@mkdir -p "$(PLATFORM_PAYLOAD_DIR)/assets"
+	@cp -Rf "$(MLP1_ASSETS_DIR)/." "$(PLATFORM_PAYLOAD_DIR)/assets/"
+	@python3 "$(MLP1_ASSET_TOOL)" validate --output "$(PLATFORM_PAYLOAD_DIR)/assets"
 	@test -f "$(PLATFORM_PAYLOAD_DIR)/cores/build-report.json" || { echo "missing MLP1 core build report: $(PLATFORM_PAYLOAD_DIR)/cores/build-report.json" >&2; exit 1; }
 	@python3 "$(UMRK_WORKSPACE_DIR)/scripts/retroarch_validate_package.py" \
 		--metadata-dir "$(MLP1_METADATA_DIR)" \
@@ -202,6 +211,8 @@ stage-retroarch:
 	@test -d "$(MLP1_CORES_DIR)" || { echo "missing cores dir: $(MLP1_CORES_DIR)" >&2; exit 1; }
 	@$(MAKE) -C "$(RETROARCH_BUILDS_DIR)" shaders-mlp1 MLP1_SHADER_OUTPUT="$(MLP1_SHADERS_DIR)"
 	@python3 "$(MLP1_SHADER_TOOL)" validate --output "$(MLP1_SHADERS_DIR)"
+	@$(MAKE) -C "$(RETROARCH_BUILDS_DIR)" assets-mlp1 MLP1_ASSET_OUTPUT="$(MLP1_ASSETS_DIR)"
+	@python3 "$(MLP1_ASSET_TOOL)" validate --output "$(MLP1_ASSETS_DIR)"
 	@if ! python3 "$(MLP1_CORE_REPORT_TOOL)" verify \
 			--report "$(MLP1_CORES_REPORT)" \
 			--cores-dir "$(MLP1_CORES_DIR)"; then \
@@ -239,7 +250,7 @@ stage-retroarch:
 		REMOTE_SYSTEM_PATH="$$remote_system" \
 		REMOTE_PLATFORM_PATH="$$remote_platform" \
 		"$(LEAF_ROOT)/scripts/adb-sync-shader-namespaces.sh" --migrate-only; \
-	"$${ADB[@]}" shell "mkdir -p '$$remote_platform' && rm -rf '$$remote_platform/bin' '$$remote_platform/cores' '$$remote_platform/info' '$$remote_platform/shaders' && mkdir -p '$$remote_platform/bin' '$$remote_platform/cores' '$$remote_platform/info' '$$remote_platform/shaders'"; \
+	"$${ADB[@]}" shell "mkdir -p '$$remote_platform' && rm -rf '$$remote_platform/bin' '$$remote_platform/cores' '$$remote_platform/info' '$$remote_platform/shaders' '$$remote_platform/assets' && mkdir -p '$$remote_platform/bin' '$$remote_platform/cores' '$$remote_platform/info' '$$remote_platform/shaders' '$$remote_platform/assets'"; \
 	"$${ADB[@]}" push "$(MLP1_RETROARCH_BIN)" "$$remote_platform/bin/retroarch" >/dev/null; \
 	if [ -f "$(MLP1_RETROARCH_MANIFEST)" ]; then \
 		"$${ADB[@]}" push "$(MLP1_RETROARCH_MANIFEST)" "$$remote_platform/bin/retroarch.build-manifest.json" >/dev/null; \
@@ -252,11 +263,17 @@ stage-retroarch:
 		"$${ADB[@]}" push "$(MLP1_INFO_DIR)/." "$$remote_platform/info/" >/dev/null; \
 	fi; \
 	"$${ADB[@]}" push "$(MLP1_SHADERS_DIR)/." "$$remote_platform/shaders/" >/dev/null; \
+	"$${ADB[@]}" push "$(MLP1_ASSETS_DIR)/." "$$remote_platform/assets/" >/dev/null; \
 	ADB_SERIAL="$$serial" PLATFORM_ID="mlp1" \
 		REMOTE_SDCARD_PATH="$$remote_sd" \
 		REMOTE_SYSTEM_PATH="$$remote_system" \
 		REMOTE_PLATFORM_PATH="$$remote_platform" \
 		"$(LEAF_ROOT)/scripts/adb-sync-shader-namespaces.sh" --sync-only; \
+	ADB_SERIAL="$$serial" PLATFORM_ID="mlp1" \
+		REMOTE_SDCARD_PATH="$$remote_sd" \
+		REMOTE_SYSTEM_PATH="$$remote_system" \
+		REMOTE_PLATFORM_PATH="$$remote_platform" \
+		"$(LEAF_ROOT)/scripts/adb-sync-asset-namespaces.sh"; \
 	"$${ADB[@]}" shell "chmod 755 '$$remote_platform/bin/retroarch' '$$remote_platform/cores/'*_libretro.so 2>/dev/null || true"; \
 	"$${ADB[@]}" shell sync; \
 	echo "RetroArch platform payload staged."


### PR DESCRIPTION
## Why

A Chinese user reported that Leaf's default RetroArch menu (RGUI) reads badly in Chinese, so Chinese players switch to Ozone — and that Ozone "has some issues as well." Ozone was broken because **Leaf shipped no RetroArch asset bundle at all**: `assets/` on the device was an empty directory, so Ozone had no icons and RetroArch fell back to its built-in 8×8 ASCII bitmap font, which has no CJK glyphs.

Reproduced on the MLP1 test device, then fixed and re-captured — same device, same config, only the assets differ:

| Before | After |
|---|---|
| Every Chinese string `?????`, every icon a black square | Full Chinese UI, all icons, scaled TTF text |

## What this does

Assembles [retroarch-builds' new asset bundle](https://github.com/Utility-Muffin-Research-Kitchen/retroarch-builds/pull/6) into the MLP1 platform payload, validates it at assemble and release time next to the shader bundle, and syncs it into the durable user assets tree.

## The one design decision worth reviewing

The obvious wiring is to point `assets_directory` at the release-managed platform tree, next to `cores` and `info`. **I didn't, because Leaf deliberately does the opposite for shaders** — `paths.c:1717` says so outright: *"so RetroArch's online updater cannot mutate the release-managed, manifest-validated bundle."*

That reasoning applies at least as strongly to assets. The Online Updater is enabled on our devices (`menu_show_online_updater = "true"`, verified on the test device) and its **"Update Assets"** action writes straight into `assets_directory`; `.system` is replaced wholesale on every Leaf update.

So assets follow the shader model. Usefully, **no config change was needed at all**: RetroArch already resolves `assets_directory` to `~/.config/retroarch/assets` → `.umrk/<platform>/retroarch/.config/retroarch/assets`, which *is* the durable user tree. The files just had to arrive there, so `paths.c` is untouched by this PR.

Only the three subtrees Leaf ships (`ozone`, `xmb/monochrome`, `pkg`) are replaced, so anything the updater adds beside them survives — the same containment the shader namespaces have. `xmb/monochrome` is nested, hence the `mkdir -p` on the namespace parent that the shader version doesn't need.

## Licensing

`stage/licenses/ASSETS.md` extended. Licenses were read from each font's own name table rather than assumed, which mattered: `chinese-fallback-font.ttf` is Droid Sans Fallback under **Apache 2.0**, not OFL like Leaf's other bundled faces. Artwork is CC BY 4.0 per the upstream `COPYING`; Inter UI is OFL-1.1; M+ 1p is the M+ Free License; DejaVu/Waree are Bitstream Vera. Per-file provenance ships in the bundle's own `manifest.json`.

⚠️ Separately: the **pre-existing** row for the Systematic icon pack claims CC BY-SA 4.0, while that repo's `COPYING` says plain CC BY 4.0. Untouched here — flagged for a follow-up, not part of this change.

## Testing

- Shell syntax clean on all three touched scripts; `stage/mlp1.mk` parses and exposes the new vars.
- On device: bundle staged, synced to the user tree, two spot-check SHA-256s match the manifest exactly.
- Screenshots captured via `weston-screenshooter` with RetroArch running under `jawaka-retroarch-runner --menu`. Device config restored afterwards (`rgui`, English, `network_cmd_enable` off).

**Not run:** a full `make stage DEVICE=mlp1` (needs ADB; the device was reached over SSH) or a full release-zip build. Worth a look from someone with ADB to hand before merge.

## Related

- retroarch-builds#6 — the bundle itself
- miniloong-launcher-switcher (same branch name) — SD installer promotion + sync, so real users get it
- umrk-workspace `plans/retroarch-user-language.md` — the remaining i18n gap

Note for whoever picks up the release: 929 small files on a 32 KB-cluster FAT32 card occupy ~74 MB allocated against 17.3 MB of content.