### PR TITLE
Compile and stage the UI translations into the platform payload

### DIFF
--- a/stage/mlp1.mk
+++ b/stage/mlp1.mk
@@ -110,6 +110,22 @@ assemble-jawaka: jawaka-build shader-bundle-mlp1
 	@cp -Rf "$(DEVICE_OVERLAY)/." "$(PLATFORM_PAYLOAD_DIR)/"
 	@test -f "$(PLATFORM_PAYLOAD_DIR)/defaults/systems.json" || { echo "missing platform defaults: $(PLATFORM_PAYLOAD_DIR)/defaults/systems.json" >&2; exit 1; }
 	@test -f "$(PLATFORM_PAYLOAD_DIR)/defaults/cores.json" || { echo "missing platform defaults: $(PLATFORM_PAYLOAD_DIR)/defaults/cores.json" >&2; exit 1; }
+	@# Compiled UI translations. The launcher reads $$UMRK_PLATFORM_PATH/i18n;
+	@# the compiler drops fuzzy entries (unreviewed strings never ship), and a
+	@# table that would ship zero entries is skipped entirely -- shipping it
+	@# would make the Settings language picker offer a language that translates
+	@# nothing. The hand-editable .tsv override in .umrk still outranks this at
+	@# runtime, so a translator can keep iterating on top of a release.
+	@mkdir -p "$(PLATFORM_PAYLOAD_DIR)/i18n"
+	@for po in "$(JAWAKA_DIR)"/i18n/*.po; do \
+		[ -f "$$po" ] || continue; \
+		code=$$(basename "$$po" .po); \
+		out="$(PLATFORM_PAYLOAD_DIR)/i18n/$$code.jwi"; \
+		python3 "$(JAWAKA_DIR)/tools/i18n-compile.py" "$$po" -o "$$out" || exit 1; \
+		if [ "$$(wc -c < "$$out")" -le 25 ]; then \
+			echo "skipping $$code: no reviewed entries to ship"; rm -f "$$out"; \
+		fi; \
+	done
 	@mkdir -p "$(PLATFORM_PAYLOAD_DIR)/platform.d"
 	@if [ -d "$(JAWAKA_DIR)/platform/mlp1/platform.d" ]; then \
 		cp -Rf "$(JAWAKA_DIR)/platform/mlp1/platform.d/." "$(PLATFORM_PAYLOAD_DIR)/platform.d/"; \


### PR DESCRIPTION
Companion to https://github.com/Utility-Muffin-Research-Kitchen/Jawaka/pull/55 — the last piece of the Simplified Chinese work's plumbing. The machinery, the reviewed `.po` and the CI all live in Jawaka; this makes a release actually carry the result.

`assemble-jawaka` now compiles every `Jawaka/i18n/*.po` into `platforms/mlp1/i18n/<code>.jwi` via `tools/i18n-compile.py`, host-side (staging already shells python3 for the shader and RetroArch validators).

Two properties worth reviewing:

- **Fuzzy entries never ship.** The compiler drops them, so a machine-seeded or unreviewed string falls back to English on device. Today that means zh_CN ships 275 native-reviewed entries and holds back the 9 still awaiting the reviewer's device pass.
- **A zero-entry table is skipped, not staged.** The Settings language picker offers a language when its table file exists, so staging an empty `.jwi` would offer a language that translates nothing.

The hand-editable `.tsv` override in `.umrk` still outranks the compiled table at runtime — the translator iteration loop survives a release unchanged.

Verified: the recipe logic run standalone ships the real `.po` (275 entries) and skips an all-fuzzy fixture; the compiled table itself was pushed to the device's platform i18n directory and loads (pending one last on-device confirmation with the override removed).

Merge order: after Jawaka #55 (which brings `i18n/` and the tools this rule invokes). Building this branch against a Jawaka checkout without #55 finds no `i18n/*.po` and stages nothing — the loop is a no-op, not an error.