### PR TITLE
Gate MLP1 payloads on the paired-controller input contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ LARGE_LIBRARY_FIXTURE_ENV = \
 	REMOTE_SDCARD_PATH="$(REMOTE_SDCARD_PATH)"
 
 .DEFAULT_GOAL := help
-.PHONY: help bootstrap doctor status status-internal pakrat-local-feed-test leaf-release-policy-test shader-bundle-release-policy-test flycast-release-policy-smoke core-rebuild-gate-test package-quiesce-smoke adb-enable-marker adb-disable-marker adb-tail-logs adb-large-library-create adb-large-library-clean adb-large-library-status adb-install-wrapper adb-uninstall-wrapper benchmark-ppsspp
+.PHONY: help bootstrap doctor status status-internal pakrat-local-feed-test leaf-release-policy-test shader-bundle-release-policy-test input-roster-policy-test flycast-release-policy-smoke core-rebuild-gate-test package-quiesce-smoke adb-enable-marker adb-disable-marker adb-tail-logs adb-large-library-create adb-large-library-clean adb-large-library-status adb-install-wrapper adb-uninstall-wrapper benchmark-ppsspp
 
 help:
 	@echo "Leaf workspace commands (DEVICE=$(DEVICE), WORKSPACE_DIR=$(WORKSPACE_DIR)):"
@@ -55,6 +55,7 @@ help:
 	@echo "  make pakrat-local-feed-test               test multi-app and exact-artifact local feeds"
 	@echo "  make leaf-release-policy-test             test release identity, artifacts, provenance, and gates"
 	@echo "  make shader-bundle-release-policy-test    test shader bundle integrity release gates"
+	@echo "  make input-roster-policy-test             test the MLP1 paired-controller input gates"
 	@echo "  make flycast-release-policy-smoke         test standalone Flycast release gates"
 	@echo "  make core-rebuild-gate-test               test explicit long core-rebuild authorization"
 	@echo "  make package-quiesce-smoke                test fail-closed stage-app service barrier"
@@ -112,6 +113,9 @@ leaf-release-policy-test:
 
 shader-bundle-release-policy-test:
 	python3 scripts/validate-shader-bundle-release-test.py
+
+input-roster-policy-test:
+	python3 scripts/validate-input-roster-policy-test.py
 
 core-rebuild-gate-test:
 	bash scripts/ensure-mlp1-cores-test.sh

--- a/scripts/adb-stage-sd-bundle.sh
+++ b/scripts/adb-stage-sd-bundle.sh
@@ -66,6 +66,7 @@ REMOTE_PLATFORM_PATH="${REMOTE_PLATFORM_PATH:-$REMOTE_PLATFORM_ROOT/$PLATFORM_ID
 REMOTE_LAUNCHER_PATH="${REMOTE_LAUNCHER_PATH:-${REMOTE_BUNDLE:-$REMOTE_PLATFORM_PATH/launcher}}"
 MARKER="${UMRK_MARKER_PATH:-$REMOTE_PLATFORM_PATH/enabled}"
 SHADER_PAYLOAD="$PLATFORM_DIR/shaders"
+ASSET_PAYLOAD="$PLATFORM_DIR/assets"
 
 if [ "$PLATFORM_ID" = "mlp1" ] &&
    [ -d "$SHADER_PAYLOAD/leaf-bundled" ] &&
@@ -87,7 +88,7 @@ if [ -d "$PLATFORM_DIR" ]; then
     echo "Deploying platform payload to $REMOTE_PLATFORM_PATH ($PLATFORM_MODE)"
     "${ADB[@]}" shell "mkdir -p '$REMOTE_PLATFORM_PATH'"
     if [ "$PLATFORM_MODE" = "replace" ]; then
-        for name in bin cores info defaults platform.d autoconfig boot-animation shaders manifest.json; do
+        for name in bin cores info defaults platform.d autoconfig boot-animation shaders assets manifest.json; do
             "${ADB[@]}" shell "rm -rf '$REMOTE_PLATFORM_PATH/$name'"
         done
     fi
@@ -118,6 +119,15 @@ if [ "$PLATFORM_ID" = "mlp1" ] &&
     REMOTE_SYSTEM_PATH="$REMOTE_SYSTEM_PATH" \
     REMOTE_PLATFORM_PATH="$REMOTE_PLATFORM_PATH" \
         "$ROOT_DIR/scripts/adb-sync-shader-namespaces.sh" --sync-only
+fi
+
+if [ "$PLATFORM_ID" = "mlp1" ] && [ -d "$ASSET_PAYLOAD/ozone" ]; then
+    ADB_SERIAL="$serial" \
+    PLATFORM_ID="$PLATFORM_ID" \
+    REMOTE_SDCARD_PATH="$REMOTE_SDCARD_PATH" \
+    REMOTE_SYSTEM_PATH="$REMOTE_SYSTEM_PATH" \
+    REMOTE_PLATFORM_PATH="$REMOTE_PLATFORM_PATH" \
+        "$ROOT_DIR/scripts/adb-sync-asset-namespaces.sh"
 fi
 
 case "$MARKER_MODE" in

--- a/scripts/adb-sync-asset-namespaces.sh
+++ b/scripts/adb-sync-asset-namespaces.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Copy the release-managed RetroArch menu asset bundle into the durable user
+# assets tree RetroArch actually reads.
+#
+# RetroArch resolves assets_directory to ~/.config/retroarch/assets, which for
+# Leaf is $SDCARD/.umrk/<platform>/retroarch/.config/retroarch/assets. That is
+# deliberately NOT the release-managed platform tree: RetroArch's Online Updater
+# has an "Update Assets" action that writes into assets_directory, and .system is
+# replaced wholesale on every Leaf update. Same split, same reasoning as
+# adb-sync-shader-namespaces.sh.
+#
+# Only the subtrees Leaf ships are replaced, so anything the updater adds
+# alongside them (xmb/automatic, rgui, sounds, ...) is left alone.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLATFORM_ID="${PLATFORM_ID:-mlp1}"
+REQUESTED_REMOTE_SDCARD_PATH="${REMOTE_SDCARD_PATH:-auto}"
+
+if [ "${1:-}" != "" ]; then
+    echo "usage: $0" >&2
+    exit 1
+fi
+
+if [ -n "${ADB_SERIAL:-}" ]; then
+    serial="$ADB_SERIAL"
+else
+    serial="$(adb devices | awk 'NR>1 && $2=="device" {print $1; exit}')"
+fi
+[ -n "${serial:-}" ] || {
+    echo "No online adb device found." >&2
+    exit 1
+}
+ADB=(adb -s "$serial")
+
+remote_sd="$(
+    PLATFORM_ID="$PLATFORM_ID" \
+    REMOTE_SDCARD_PATH="$REQUESTED_REMOTE_SDCARD_PATH" \
+    ADB_SERIAL="$serial" \
+        "$ROOT_DIR/scripts/adb-resolve-umrk-sd.sh"
+)"
+remote_system="${REMOTE_SYSTEM_PATH:-$remote_sd/.system/leaf}"
+remote_platform="${REMOTE_PLATFORM_PATH:-$remote_system/platforms/$PLATFORM_ID}"
+remote_bundle="$remote_platform/assets"
+remote_user_assets="${UMRK_RETROARCH_USER_ASSETS_DIR:-$remote_sd/.umrk/$PLATFORM_ID/retroarch/.config/retroarch/assets}"
+
+"${ADB[@]}" shell sh -s -- "$remote_bundle" "$remote_user_assets" <<'REMOTE_SH'
+set -eu
+
+bundle_root="$1"
+user_root="$2"
+
+sync_namespace() {
+    namespace="$1"
+    src="$bundle_root/$namespace"
+    dst="$user_root/$namespace"
+    tmp="$dst.tmp.$$"
+    previous="$dst.previous.$$"
+    [ -d "$src" ] || {
+        echo "missing Leaf asset namespace: $src" >&2
+        exit 1
+    }
+    mkdir -p "$(dirname "$dst")" || {
+        echo "failed to create asset namespace parent for: $namespace" >&2
+        exit 1
+    }
+    rm -rf "$tmp" "$previous" 2>/dev/null || true
+    cp -R "$src" "$tmp"
+    if [ -e "$dst" ]; then
+        mv "$dst" "$previous"
+    fi
+    if ! mv "$tmp" "$dst"; then
+        [ ! -e "$previous" ] || mv "$previous" "$dst" 2>/dev/null || true
+        echo "failed to promote Leaf asset namespace: $namespace" >&2
+        exit 1
+    fi
+    rm -rf "$previous" 2>/dev/null || true
+}
+
+mkdir -p "$user_root"
+sync_namespace ozone
+sync_namespace xmb/monochrome
+sync_namespace pkg
+echo "Synchronized Leaf menu asset namespaces at $user_root"
+REMOTE_SH

--- a/scripts/make-sd-release-zip.sh
+++ b/scripts/make-sd-release-zip.sh
@@ -32,6 +32,8 @@ MLP1_RETROARCH_BIN="${MLP1_RETROARCH_BIN:-$RETROARCH_BUILDS_DIR/output/mlp1/bin/
 MLP1_RETROARCH_MANIFEST="${MLP1_RETROARCH_MANIFEST:-$RETROARCH_BUILDS_DIR/output/mlp1/build-manifest.json}"
 MLP1_SHADERS_DIR="${MLP1_SHADERS_DIR:-$RETROARCH_BUILDS_DIR/output/mlp1/shaders}"
 MLP1_SHADER_TOOL="${MLP1_SHADER_TOOL:-$RETROARCH_BUILDS_DIR/scripts/mlp1_shader_bundle.py}"
+MLP1_ASSETS_DIR="${MLP1_ASSETS_DIR:-$RETROARCH_BUILDS_DIR/output/mlp1/assets}"
+MLP1_ASSET_TOOL="${MLP1_ASSET_TOOL:-$RETROARCH_BUILDS_DIR/scripts/mlp1_asset_bundle.py}"
 MLP1_CORES_DIR="${MLP1_CORES_DIR:-$CORES_SPRUCE_DIR/output/mlp1/cores}"
 MLP1_CORES_REPORT="${MLP1_CORES_REPORT:-$CORES_SPRUCE_DIR/output/mlp1/build-report.json}"
 MLP1_PPSSPP_PACKAGE="${MLP1_PPSSPP_PACKAGE:-$PPSSPP_SPRUCE_DIR/output/mlp1/ppsspp}"
@@ -470,6 +472,15 @@ validate_retroarch_contract() {
         || die "RetroArch runtime metadata contract validation failed"
 }
 
+validate_asset_bundle() {
+    local platform_dir="$1"
+    local license_root="$2"
+    python3 "$MLP1_ASSET_TOOL" validate --output "$platform_dir/assets" ||
+        die "MLP1 menu asset bundle release validation failed"
+    [ -f "$license_root/ASSETS.md" ] ||
+        die "missing asset license notice: $license_root/ASSETS.md"
+}
+
 validate_shader_bundle() {
     local platform_dir="$1"
     local license_root="$2"
@@ -600,6 +611,11 @@ build_missing_platform_bits() {
         MLP1_SHADER_OUTPUT="$MLP1_SHADERS_DIR"
     python3 "$MLP1_SHADER_TOOL" validate --output "$MLP1_SHADERS_DIR" ||
         die "MLP1 shader bundle validation failed"
+
+    make -C "$RETROARCH_BUILDS_DIR" assets-mlp1 \
+        MLP1_ASSET_OUTPUT="$MLP1_ASSETS_DIR"
+    python3 "$MLP1_ASSET_TOOL" validate --output "$MLP1_ASSETS_DIR" ||
+        die "MLP1 menu asset bundle validation failed"
 
     REBUILD_CORES="${REBUILD_CORES:-0}" \
     CORES_SPRUCE_DIR="$CORES_SPRUCE_DIR" \
@@ -854,6 +870,7 @@ build_install_zip() {
         MLP1_RETROARCH_BIN="$MLP1_RETROARCH_BIN" \
         MLP1_RETROARCH_MANIFEST="$MLP1_RETROARCH_MANIFEST" \
         MLP1_SHADERS_DIR="$MLP1_SHADERS_DIR" \
+        MLP1_ASSETS_DIR="$MLP1_ASSETS_DIR" \
         MLP1_CORES_DIR="$MLP1_CORES_DIR" \
         MLP1_CORES_REPORT="$MLP1_CORES_REPORT" \
         assemble-jawaka
@@ -887,6 +904,7 @@ build_install_zip() {
     validate_packaged_cores "$RELEASE_ROOT"
     validate_retroarch_contract "$RELEASE_ROOT/platforms/mlp1"
     validate_shader_bundle "$RELEASE_ROOT/platforms/mlp1" "$RELEASE_ROOT/licenses"
+    validate_asset_bundle "$RELEASE_ROOT/platforms/mlp1" "$RELEASE_ROOT/licenses"
 
     for app in $STAGE_APPS; do
         package_app "$app"

--- a/scripts/validate-input-roster-policy-test.py
+++ b/scripts/validate-input-roster-policy-test.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Smoke-test Leaf's MLP1 input-roster policy gate.
+
+Each rejection case is a shape that actually shipped at some point, so the
+accept cases matter just as much: a gate that fails the current wrappers is
+worse than no gate, because the next person turns it off.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+LEAF_ROOT = Path(__file__).resolve().parents[1]
+WORKSPACE_ROOT = LEAF_ROOT.parent
+TOOL = LEAF_ROOT / "scripts" / "validate-input-roster-policy.py"
+
+FAILURES: list[str] = []
+
+
+def run(target: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["python3", str(TOOL), str(target)],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def expect_reject(name: str, code: str, files: dict[str, str]) -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        for relative, body in files.items():
+            path = root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(body, encoding="utf-8")
+        result = run(root)
+        if result.returncode == 0:
+            FAILURES.append(f"{name}: expected rejection, got success")
+        elif code not in result.stderr:
+            FAILURES.append(
+                f"{name}: expected {code}, got:\n{result.stderr.strip()}"
+            )
+
+
+def expect_accept(name: str, files: dict[str, str]) -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        for relative, body in files.items():
+            path = root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(body, encoding="utf-8")
+        result = run(root)
+        if result.returncode != 0:
+            FAILURES.append(f"{name}: expected success, got:\n{result.stderr.strip()}")
+
+
+# ROSTER001 -- the PPSSPP wrapper shipped exactly this, which discarded every
+# paired controller and left only the built-in pad.
+expect_reject(
+    "unguarded SDL_JOYSTICK_DEVICE overwrite",
+    "ROSTER001",
+    {
+        "launch.sh": (
+            "#!/bin/sh\n"
+            'if [ -n "${JAWAKA_INPUT_VIRTUAL_EVENT:-}" ]; then\n'
+            '    export SDL_JOYSTICK_DEVICE="$JAWAKA_INPUT_VIRTUAL_EVENT"\n'
+            "fi\n"
+        )
+    },
+)
+
+expect_accept(
+    "guarded fallback preserves an inherited roster",
+    {
+        "launch.sh": (
+            "#!/bin/sh\n"
+            'if [ -z "${SDL_JOYSTICK_DEVICE:-}" ] && '
+            '[ -n "${JAWAKA_INPUT_VIRTUAL_EVENT:-}" ]; then\n'
+            '    export SDL_JOYSTICK_DEVICE="$JAWAKA_INPUT_VIRTUAL_EVENT"\n'
+            "fi\n"
+        )
+    },
+)
+
+expect_accept(
+    "self-referencing default preserves an inherited roster",
+    {
+        "launch.sh": (
+            "#!/bin/sh\n"
+            'export SDL_JOYSTICK_DEVICE="${SDL_JOYSTICK_DEVICE:-$fallback}"\n'
+        )
+    },
+)
+
+# ROSTER002 -- DraStic's MLP1 backend opened this node directly.
+expect_reject(
+    "hardcoded physical event node in a wrapper",
+    "ROSTER002",
+    {"launch.sh": "#!/bin/sh\nINPUT_DEV=/dev/input/event4\n"},
+)
+
+expect_accept(
+    "enumerating event nodes with a format string",
+    {"launch.sh": '#!/bin/sh\nprintf "/dev/input/event%d\\n" "$i"\n'},
+)
+
+# ROSTER003 -- "-1 for unused players" was in the plan until RetroArch was
+# observed faulting on it two seconds into every launch.
+expect_reject(
+    "negative joypad index as an unused-player marker",
+    "ROSTER003",
+    {"retroarch.cfg": 'input_max_users = "4"\ninput_player4_joypad_index = "-1"\n'},
+)
+
+expect_reject(
+    "more players enabled than a roster can hold",
+    "ROSTER003",
+    {"retroarch.cfg": 'input_max_users = "8"\n'},
+)
+
+expect_reject(
+    "controller bound past the last roster slot",
+    "ROSTER003",
+    {"emu.cfg": "maple_sdl_joystick_0=5\n"},
+)
+
+expect_accept(
+    "a four-player roster config",
+    {
+        "retroarch.cfg": (
+            'input_max_users = "4"\n'
+            'input_player1_joypad_index = "0"\n'
+            'input_player4_joypad_index = "3"\n'
+            # Players beyond the roster keep RetroArch's stock identity indices;
+            # they are not enabled ports and must not trip the gate.
+            'input_player5_joypad_index = "4"\n'
+            'input_player16_joypad_index = "15"\n'
+        ),
+        "emu.cfg": "maple_sdl_joystick_0=0\nmaple_sdl_joystick_3=3\n",
+    },
+)
+
+# ROSTER004 -- both Loong pads report the same name.
+expect_reject(
+    "resolving a Loong pad by display name alone",
+    "ROSTER004",
+    {
+        "launch.sh": (
+            "#!/bin/sh\n"
+            "awk '/^N: Name=\"Loong Gamepad\"/ { found = 1 }' "
+            "/proc/bus/input/devices\n"
+        )
+    },
+)
+
+expect_accept(
+    "name plus virtual sysfs path disambiguates the uinput clone",
+    {
+        "launch.sh": (
+            "#!/bin/sh\n"
+            "awk '\n"
+            '/^N: Name="Loong Gamepad"/ { name = 1 }\n'
+            "/^S: Sysfs=\\/devices\\/virtual\\/input\\// { virtual = 1 }\n"
+            "' /proc/bus/input/devices\n"
+        )
+    },
+)
+
+expect_reject(
+    "documented fallback to direct physical input",
+    "ROSTER004",
+    {
+        "launch.sh": (
+            "#!/bin/sh\n"
+            'echo "virtual unavailable; falling back to direct SDL input"\n'
+        )
+    },
+)
+
+
+def check_binary_case() -> None:
+    """A hardcoded node hides in an emulator's shipped library, not just its
+    wrapper, so the scan has to reach into non-UTF-8 files too."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        blob = root / "lib" / "libexample.so"
+        blob.parent.mkdir(parents=True, exist_ok=True)
+        blob.write_bytes(b"\x7fELF\x02\x01\x01\x00" + b"/dev/input/event4\x00\xff\xfe")
+        result = run(root)
+        if result.returncode == 0:
+            FAILURES.append("binary scan: expected rejection, got success")
+        elif "ROSTER002" not in result.stderr:
+            FAILURES.append(
+                f"binary scan: expected ROSTER002, got:\n{result.stderr.strip()}"
+            )
+
+
+def check_shipped_wrappers() -> None:
+    """The gate must pass the wrappers currently shipped for MLP1. If this
+    fails, the gate is wrong -- not the wrappers."""
+    wrappers = [
+        WORKSPACE_ROOT / "PPSSPP-spruce" / "package-mlp1.sh",
+        WORKSPACE_ROOT / "Flycast-standalone" / "config" / "mlp1" / "launch.sh",
+        WORKSPACE_ROOT / "N64-standalone" / "config" / "mlp1" / "launch.sh",
+    ]
+    for wrapper in wrappers:
+        if not wrapper.exists():
+            print(f"skip (not checked out): {wrapper}")
+            continue
+        result = run(wrapper)
+        if result.returncode != 0:
+            FAILURES.append(
+                f"shipped wrapper rejected: {wrapper}\n{result.stderr.strip()}"
+            )
+
+
+check_binary_case()
+check_shipped_wrappers()
+
+if FAILURES:
+    for failure in FAILURES:
+        print(f"FAIL {failure}")
+    raise SystemExit(1)
+
+print("validate-input-roster-policy-test: ok")

--- a/scripts/validate-input-roster-policy.py
+++ b/scripts/validate-input-roster-policy.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Reject MLP1 payloads that break the paired-controller input contract.
+
+plans/paired-wireless-controllers-mlp1.md makes Jawaka the single authority on
+which controllers an emulator may see: it freezes a roster for each launch,
+publishes it in SDL_JOYSTICK_DEVICE in player order, and backs that with a
+private /dev/input containing exactly those devices.
+
+Four things quietly defeat that contract, and none of them fails loudly at
+runtime -- the emulator simply plays with the wrong device, with none at all,
+or hands a player slot to the uncalibrated physical pad:
+
+  ROSTER001  a wrapper overwriting an inherited SDL_JOYSTICK_DEVICE
+  ROSTER002  emulator code hardcoding a physical /dev/input/eventN path
+  ROSTER003  a configuration enabling more player ports than a roster holds
+  ROSTER004  a launch path resolving the Loong pads by display name alone
+
+Each of these has already shipped at least once, which is why they are gated
+here rather than left to review.
+
+Point this at an assembled MLP1 payload or a built emulator package -- not at a
+multi-platform source tree. ROSTER002 cannot tell which arm of an #if a literal
+belongs to, so a shared backend carrying every handheld's event node reports one
+violation per platform. A compiled MLP1 artifact only contains the branch that
+survived the preprocessor, which is the thing actually shipping.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+# Shipped wrappers are shell; emulator payloads also carry binaries whose
+# embedded strings are the only place a hardcoded device path shows up.
+SHELL_SUFFIXES = {".sh", ".bash"}
+CONFIG_SUFFIXES = {".ini", ".cfg", ".conf"}
+SKIP_DIR_NAMES = {".git", "node_modules", "__pycache__"}
+
+# event%d and event* are how code enumerates; a trailing digit is a decision
+# about one specific node, which is exactly what the roster exists to make.
+HARDCODED_EVENT_RE = re.compile(r"/dev/input/event\d+")
+
+ASSIGN_RE = re.compile(r"^\s*(?:export\s+)?SDL_JOYSTICK_DEVICE=")
+# Preserving the inherited value looks like `[ -z "${SDL_JOYSTICK_DEVICE:-}" ]`.
+GUARD_RE = re.compile(r"-z\s+\"?\$\{?SDL_JOYSTICK_DEVICE")
+GUARD_WINDOW = 12
+
+MAX_USERS_RE = re.compile(r"input_max_users\s*=\s*\"?(\d+)\"?")
+JOYPAD_INDEX_RE = re.compile(r"input_player(\d+)_joypad_index\s*=\s*\"?(-?\d+)\"?")
+MAPLE_PORT_RE = re.compile(r"maple_sdl_joystick_(\d+)\s*=\s*(-?\d+)")
+
+LOONG_NAME = "Loong Gamepad"
+DEVICE_LIST_PATH = "/proc/bus/input/devices"
+# The only honest way to tell the two identically named pads apart in
+# /proc/bus/input/devices is the uinput clone's virtual sysfs path.
+VIRTUAL_SYSFS = "/devices/virtual/input"
+DIRECT_FALLBACK_RE = re.compile(
+    r"fall(?:ing|s|back)?[ -]?back to direct|direct SDL input", re.IGNORECASE
+)
+
+ROSTER_MAX_CONTROLLERS = 4
+
+
+class Finding:
+    def __init__(self, code: str, path: Path, line: int, message: str) -> None:
+        self.code = code
+        self.path = path
+        self.line = line
+        self.message = message
+
+    def render(self, root: Path) -> str:
+        try:
+            shown = self.path.relative_to(root)
+        except ValueError:
+            shown = self.path
+        where = f"{shown}:{self.line}" if self.line else str(shown)
+        return f"{self.code} {where}: {self.message}"
+
+
+def read_file(path: Path) -> tuple[str, bool]:
+    """Return (text, is_text). Binaries decode as latin-1 so embedded strings
+    stay searchable without pulling in a strings(1) dependency."""
+    data = path.read_bytes()
+    try:
+        return data.decode("utf-8"), True
+    except UnicodeDecodeError:
+        return data.decode("latin-1"), False
+
+
+def iter_files(root: Path):
+    if root.is_file():
+        yield root
+        return
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.is_symlink():
+            continue
+        if any(part in SKIP_DIR_NAMES for part in path.parts):
+            continue
+        yield path
+
+
+def check_roster_overwrite(path: Path, lines: list[str]) -> list[Finding]:
+    """ROSTER001: a wrapper may seed SDL_JOYSTICK_DEVICE for direct invocation,
+    but never replace a value Jawaka already set -- that discards every paired
+    controller and leaves the built-in pad alone in the roster."""
+    findings = []
+    for number, line in enumerate(lines, start=1):
+        if not ASSIGN_RE.match(line):
+            continue
+        # Reusing the variable on the right-hand side preserves it, e.g.
+        # SDL_JOYSTICK_DEVICE="${SDL_JOYSTICK_DEVICE:-$fallback}".
+        _, _, rhs = line.partition("=")
+        if "SDL_JOYSTICK_DEVICE" in rhs:
+            continue
+        window = lines[max(0, number - 1 - GUARD_WINDOW):number - 1]
+        if any(GUARD_RE.search(previous) for previous in window):
+            continue
+        findings.append(
+            Finding(
+                "ROSTER001",
+                path,
+                number,
+                "assigns SDL_JOYSTICK_DEVICE without first checking it is unset; "
+                "an inherited roster must win over any wrapper default",
+            )
+        )
+    return findings
+
+
+def check_hardcoded_event(path: Path, text: str, is_text: bool) -> list[Finding]:
+    """ROSTER002: the physical and virtual Loong pads share a name and differ
+    only by node, and their numbering is incidental kernel ordering. Any
+    literal event node is a guess that the roster already answers."""
+    findings = []
+    if is_text:
+        for number, line in enumerate(text.splitlines(), start=1):
+            match = HARDCODED_EVENT_RE.search(line)
+            if match:
+                findings.append(
+                    Finding(
+                        "ROSTER002",
+                        path,
+                        number,
+                        f"hardcodes {match.group(0)}; resolve the device from "
+                        "SDL_JOYSTICK_DEVICE instead",
+                    )
+                )
+        return findings
+
+    seen = sorted(set(HARDCODED_EVENT_RE.findall(text)))
+    if seen:
+        findings.append(
+            Finding(
+                "ROSTER002",
+                path,
+                0,
+                "embeds hardcoded input node(s) "
+                + ", ".join(seen)
+                + "; resolve the device from SDL_JOYSTICK_DEVICE instead",
+            )
+        )
+    return findings
+
+
+def check_player_ports(path: Path, lines: list[str]) -> list[Finding]:
+    """ROSTER003: a roster holds at most four controllers, so a config must not
+    open more ports than that -- and must never use -1 as an "unused player"
+    marker, which RetroArch reads into an unsigned index and faults on."""
+    findings = []
+    for number, line in enumerate(lines, start=1):
+        match = MAX_USERS_RE.search(line)
+        if match and int(match.group(1)) > ROSTER_MAX_CONTROLLERS:
+            findings.append(
+                Finding(
+                    "ROSTER003",
+                    path,
+                    number,
+                    f"enables {match.group(1)} players; a launch roster holds at "
+                    f"most {ROSTER_MAX_CONTROLLERS}",
+                )
+            )
+
+        match = JOYPAD_INDEX_RE.search(line)
+        if match and int(match.group(2)) < 0:
+            findings.append(
+                Finding(
+                    "ROSTER003",
+                    path,
+                    number,
+                    "uses a negative joypad index as an unused-player marker; "
+                    "RetroArch reads it into an unsigned index and faults on the "
+                    "first poll -- omit the key instead",
+                )
+            )
+
+        match = MAPLE_PORT_RE.search(line)
+        if match and int(match.group(2)) >= ROSTER_MAX_CONTROLLERS:
+            findings.append(
+                Finding(
+                    "ROSTER003",
+                    path,
+                    number,
+                    f"binds a controller to port {match.group(2)}; a launch "
+                    f"roster holds at most {ROSTER_MAX_CONTROLLERS}",
+                )
+            )
+    return findings
+
+
+def check_direct_fallback(path: Path, text: str, lines: list[str]) -> list[Finding]:
+    """ROSTER004: both Loong pads report the name "Loong Gamepad", so matching
+    on the name alone can hand an emulator the grabbed, uncalibrated physical
+    device. Pairing it with the uinput clone's virtual sysfs path is the
+    accepted way to disambiguate."""
+    findings = []
+    # awk and sed programs escape the separators (\/devices\/virtual\/input\/),
+    # so compare against a backslash-stripped copy or every correct wrapper
+    # trips this rule.
+    unescaped = text.replace("\\", "")
+    scans_device_list = DEVICE_LIST_PATH in unescaped and LOONG_NAME in unescaped
+    if scans_device_list and VIRTUAL_SYSFS not in unescaped:
+        for number, line in enumerate(lines, start=1):
+            if LOONG_NAME in line:
+                findings.append(
+                    Finding(
+                        "ROSTER004",
+                        path,
+                        number,
+                        "identifies a Loong pad by display name alone; the "
+                        "physical and virtual devices share that name, so also "
+                        f"require {VIRTUAL_SYSFS} or use the roster",
+                    )
+                )
+                break
+
+    for number, line in enumerate(lines, start=1):
+        if DIRECT_FALLBACK_RE.search(line):
+            findings.append(
+                Finding(
+                    "ROSTER004",
+                    path,
+                    number,
+                    "describes a fallback to direct physical input; a roster or "
+                    "namespace failure must block the launch instead",
+                )
+            )
+    return findings
+
+
+def scan(root: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in iter_files(root):
+        try:
+            text, is_text = read_file(path)
+        except OSError as exc:
+            raise SystemExit(f"error: cannot read {path}: {exc}") from exc
+
+        findings.extend(check_hardcoded_event(path, text, is_text))
+        if not is_text:
+            continue
+
+        lines = text.splitlines()
+        suffix = path.suffix.lower()
+        shell_like = suffix in SHELL_SUFFIXES or (
+            lines and lines[0].startswith("#!") and "sh" in lines[0]
+        )
+        if shell_like:
+            findings.extend(check_roster_overwrite(path, lines))
+            findings.extend(check_direct_fallback(path, text, lines))
+        if shell_like or suffix in CONFIG_SUFFIXES:
+            findings.extend(check_player_ports(path, lines))
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        type=Path,
+        help="assembled platform payload(s) or source tree(s) to check",
+    )
+    args = parser.parse_args()
+
+    findings: list[Finding] = []
+    for target in args.paths:
+        if not target.exists():
+            raise SystemExit(f"error: no such path: {target}")
+        findings.extend(scan(target))
+
+    if findings:
+        root = Path.cwd()
+        for finding in findings:
+            print(finding.render(root), file=sys.stderr)
+        print(
+            f"\n{len(findings)} input-roster policy violation(s); see "
+            "plans/paired-wireless-controllers-mlp1.md",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("input-roster policy: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/stage/licenses/ASSETS.md
+++ b/stage/licenses/ASSETS.md
@@ -11,6 +11,12 @@ https://leaf.game/credits.
 | Default system icons (libretro Systematic pack) | libretro team and contributors | CC BY-SA 4.0 |
 | UI fonts (Space Grotesk, Inter, Rounded M+, Nunito, Baloo 2, Fredoka, Lexend, IBM Plex Sans, Noto Sans, Source Han Sans) | respective type designers | SIL OFL 1.1 |
 | Keyboard glyph icons (Nerd Fonts) | Nerd Fonts contributors | MIT |
+| RetroArch menu artwork (`platforms/mlp1/assets/`, Ozone and XMB Monochrome) | libretro team and contributors | CC BY 4.0 |
+| RetroArch menu font (Inter UI, in `assets/ozone/`) | The Inter UI project authors | SIL OFL 1.1 |
+| RetroArch icon-theme font (M+ 1p, in `assets/xmb/monochrome/`) | M+ FONTS PROJECT | M+ Free License |
+| RetroArch Chinese fallback font (Droid Sans Fallback) | Ascender Corporation / Google | Apache 2.0 |
+| RetroArch Korean fallback font (Spoqa Han Sans) | Spoqa | SIL OFL 1.1 |
+| RetroArch Arabic/Persian, Thai and OSD fonts (DejaVu Sans, Waree, DejaVu Sans Mono) | Bitstream, Inc.; DejaVu and TLWG contributors | Bitstream Vera license; project changes public domain |
 
 **Cover Flow console art** - photographs of video game hardware released to the
 public domain by Evan Amos (https://commons.wikimedia.org/wiki/User:Evan-Amos).
@@ -23,5 +29,19 @@ short codes for the theme; full-resolution originals are kept in the UMRK
 (https://github.com/libretro/retroarch-assets, `xmb/systematic/png/`), CC BY-SA
 4.0. Per-file note ships in `res/system_icons/LICENSE-ASSETS.md`.
 
-**Fonts** are distributed under the SIL Open Font License 1.1. The Nerd Fonts
-glyphs used for on-screen keyboard key icons are MIT-licensed.
+**RetroArch menu assets** - RetroArch resolves every icon and font its menu
+drivers draw under a single assets directory. Leaf assembles that tree directly
+from https://github.com/libretro/retroarch-assets at a pinned commit, pruned to
+the subtrees our binary actually reads (`ozone/`, `xmb/monochrome/`, and the
+`pkg/` fallback fonts). The artwork is covered by that repository's own
+`COPYING`, Creative Commons Attribution 4.0 International; the fonts carry
+their own separate licenses, listed above and read from each font's name table
+rather than assumed. Per-file provenance - upstream commit, source path,
+SHA-256 and license classification for all 929 files - ships in the bundle
+itself as `platforms/mlp1/assets/manifest.json`, with a human-readable summary
+in `platforms/mlp1/assets/NOTICE.md`.
+
+**Fonts** used by Leaf's own launcher UI are distributed under the SIL Open
+Font License 1.1. The Nerd Fonts glyphs used for on-screen keyboard key icons
+are MIT-licensed. The RetroArch fallback fonts above are separate works with
+their own terms and are not OFL.

--- a/stage/mlp1.mk
+++ b/stage/mlp1.mk
@@ -15,6 +15,8 @@ MLP1_RETROARCH_BIN ?= $(RETROARCH_BUILDS_DIR)/output/mlp1/bin/retroarch
 MLP1_RETROARCH_MANIFEST ?= $(RETROARCH_BUILDS_DIR)/output/mlp1/build-manifest.json
 MLP1_SHADERS_DIR    ?= $(RETROARCH_BUILDS_DIR)/output/mlp1/shaders
 MLP1_SHADER_TOOL    ?= $(RETROARCH_BUILDS_DIR)/scripts/mlp1_shader_bundle.py
+MLP1_ASSETS_DIR     ?= $(RETROARCH_BUILDS_DIR)/output/mlp1/assets
+MLP1_ASSET_TOOL     ?= $(RETROARCH_BUILDS_DIR)/scripts/mlp1_asset_bundle.py
 MLP1_CORES_DIR     ?= $(CORES_SPRUCE_DIR)/output/mlp1/cores
 MLP1_CORES_REPORT  ?= $(CORES_SPRUCE_DIR)/output/mlp1/build-report.json
 MLP1_INFO_DIR      ?= $(CORES_SPRUCE_DIR)/output/mlp1/info
@@ -164,6 +166,13 @@ assemble-jawaka: jawaka-build shader-bundle-mlp1
 	@mkdir -p "$(PLATFORM_PAYLOAD_DIR)/shaders"
 	@cp -Rf "$(MLP1_SHADERS_DIR)/." "$(PLATFORM_PAYLOAD_DIR)/shaders/"
 	@python3 "$(MLP1_SHADER_TOOL)" validate --output "$(PLATFORM_PAYLOAD_DIR)/shaders"
+	@# RetroArch menu assets. Ozone reads every icon and font it draws from
+	@# assets_directory, which jawaka-retroarch-runner points here; without this
+	@# tree Ozone has no icons and falls back to a bitmap font that cannot draw CJK.
+	@test -d "$(MLP1_ASSETS_DIR)" || { echo "missing MLP1 asset bundle: $(MLP1_ASSETS_DIR)" >&2; exit 1; }
+	@mkdir -p "$(PLATFORM_PAYLOAD_DIR)/assets"
+	@cp -Rf "$(MLP1_ASSETS_DIR)/." "$(PLATFORM_PAYLOAD_DIR)/assets/"
+	@python3 "$(MLP1_ASSET_TOOL)" validate --output "$(PLATFORM_PAYLOAD_DIR)/assets"
 	@test -f "$(PLATFORM_PAYLOAD_DIR)/cores/build-report.json" || { echo "missing MLP1 core build report: $(PLATFORM_PAYLOAD_DIR)/cores/build-report.json" >&2; exit 1; }
 	@python3 "$(UMRK_WORKSPACE_DIR)/scripts/retroarch_validate_package.py" \
 		--metadata-dir "$(MLP1_METADATA_DIR)" \
@@ -202,6 +211,8 @@ stage-retroarch:
 	@test -d "$(MLP1_CORES_DIR)" || { echo "missing cores dir: $(MLP1_CORES_DIR)" >&2; exit 1; }
 	@$(MAKE) -C "$(RETROARCH_BUILDS_DIR)" shaders-mlp1 MLP1_SHADER_OUTPUT="$(MLP1_SHADERS_DIR)"
 	@python3 "$(MLP1_SHADER_TOOL)" validate --output "$(MLP1_SHADERS_DIR)"
+	@$(MAKE) -C "$(RETROARCH_BUILDS_DIR)" assets-mlp1 MLP1_ASSET_OUTPUT="$(MLP1_ASSETS_DIR)"
+	@python3 "$(MLP1_ASSET_TOOL)" validate --output "$(MLP1_ASSETS_DIR)"
 	@if ! python3 "$(MLP1_CORE_REPORT_TOOL)" verify \
 			--report "$(MLP1_CORES_REPORT)" \
 			--cores-dir "$(MLP1_CORES_DIR)"; then \
@@ -239,7 +250,7 @@ stage-retroarch:
 		REMOTE_SYSTEM_PATH="$$remote_system" \
 		REMOTE_PLATFORM_PATH="$$remote_platform" \
 		"$(LEAF_ROOT)/scripts/adb-sync-shader-namespaces.sh" --migrate-only; \
-	"$${ADB[@]}" shell "mkdir -p '$$remote_platform' && rm -rf '$$remote_platform/bin' '$$remote_platform/cores' '$$remote_platform/info' '$$remote_platform/shaders' && mkdir -p '$$remote_platform/bin' '$$remote_platform/cores' '$$remote_platform/info' '$$remote_platform/shaders'"; \
+	"$${ADB[@]}" shell "mkdir -p '$$remote_platform' && rm -rf '$$remote_platform/bin' '$$remote_platform/cores' '$$remote_platform/info' '$$remote_platform/shaders' '$$remote_platform/assets' && mkdir -p '$$remote_platform/bin' '$$remote_platform/cores' '$$remote_platform/info' '$$remote_platform/shaders' '$$remote_platform/assets'"; \
 	"$${ADB[@]}" push "$(MLP1_RETROARCH_BIN)" "$$remote_platform/bin/retroarch" >/dev/null; \
 	if [ -f "$(MLP1_RETROARCH_MANIFEST)" ]; then \
 		"$${ADB[@]}" push "$(MLP1_RETROARCH_MANIFEST)" "$$remote_platform/bin/retroarch.build-manifest.json" >/dev/null; \
@@ -252,11 +263,17 @@ stage-retroarch:
 		"$${ADB[@]}" push "$(MLP1_INFO_DIR)/." "$$remote_platform/info/" >/dev/null; \
 	fi; \
 	"$${ADB[@]}" push "$(MLP1_SHADERS_DIR)/." "$$remote_platform/shaders/" >/dev/null; \
+	"$${ADB[@]}" push "$(MLP1_ASSETS_DIR)/." "$$remote_platform/assets/" >/dev/null; \
 	ADB_SERIAL="$$serial" PLATFORM_ID="mlp1" \
 		REMOTE_SDCARD_PATH="$$remote_sd" \
 		REMOTE_SYSTEM_PATH="$$remote_system" \
 		REMOTE_PLATFORM_PATH="$$remote_platform" \
 		"$(LEAF_ROOT)/scripts/adb-sync-shader-namespaces.sh" --sync-only; \
+	ADB_SERIAL="$$serial" PLATFORM_ID="mlp1" \
+		REMOTE_SDCARD_PATH="$$remote_sd" \
+		REMOTE_SYSTEM_PATH="$$remote_system" \
+		REMOTE_PLATFORM_PATH="$$remote_platform" \
+		"$(LEAF_ROOT)/scripts/adb-sync-asset-namespaces.sh"; \
 	"$${ADB[@]}" shell "chmod 755 '$$remote_platform/bin/retroarch' '$$remote_platform/cores/'*_libretro.so 2>/dev/null || true"; \
 	"$${ADB[@]}" shell sync; \
 	echo "RetroArch platform payload staged."

--- a/stage/mlp1.mk
+++ b/stage/mlp1.mk
@@ -178,6 +178,12 @@ assemble-jawaka: jawaka-build shader-bundle-mlp1
 		--metadata-dir "$(MLP1_METADATA_DIR)" \
 		--build-report "$(PLATFORM_PAYLOAD_DIR)/cores/build-report.json" \
 		--package-root "$(PLATFORM_PAYLOAD_DIR)"
+	@# Jawaka owns which controllers an emulator may see. A wrapper that
+	@# overwrites the published roster, or code that opens an event node
+	@# directly, fails silently at runtime -- the player just gets the wrong
+	@# pad -- so it is gated here instead.
+	@python3 "$(LEAF_ROOT)/scripts/validate-input-roster-policy.py" \
+		"$(PLATFORM_PAYLOAD_DIR)"
 	@printf 'Jawaka MLP1 launcher bundle\n' > "$(PAYLOAD_DIR)/README.txt"
 	@echo "Assembled payload at $(PAYLOAD_ROOT)"
 	@find "$(PAYLOAD_ROOT)" -type f | sort
@@ -367,6 +373,7 @@ stage-emulator:
 		"$${ADB[@]}" shell "rm -rf \"$$remote_vulkan\" && mkdir -p \"$$remote_vulkan\""; \
 		"$${ADB[@]}" push "$$vulkan_runtime/." "$$remote_vulkan/" >/dev/null; \
 	fi; \
+	python3 "$(LEAF_ROOT)/scripts/validate-input-roster-policy.py" "$$package_dir"; \
 	remote_dir="$$remote_platform/emulators/$$remote_name"; \
 	echo "Deploying $(EMULATOR) emulator to $$remote_dir"; \
 	"$${ADB[@]}" shell "rm -rf \"$$remote_dir\" && mkdir -p \"$$remote_dir\""; \


### PR DESCRIPTION
Implements Phase 5 of `plans/paired-wireless-controllers-mlp1.md`.

## Why

Jawaka owns which controllers an emulator may see: it freezes a roster per launch, publishes it in `SDL_JOYSTICK_DEVICE` in player order, and backs that with a private `/dev/input`. Four things defeat that contract, and **none of them fails loudly** — the emulator just plays with the wrong device, with none at all, or hands a player slot to the uncalibrated physical pad.

| Code | Rejects |
|---|---|
| `ROSTER001` | a wrapper overwriting an inherited `SDL_JOYSTICK_DEVICE` |
| `ROSTER002` | emulator code hardcoding a physical `/dev/input/eventN` |
| `ROSTER003` | a config enabling more player ports than a roster holds, or the `-1` sentinel that faults RetroArch |
| `ROSTER004` | resolving the Loong pads by display name alone, or a documented direct-input fallback |

Every one of these has shipped at least once during this work.

## Wiring

Two gates, so a package cannot reach a device without passing: MLP1 payload assembly, and `stage-emulator`. Plus `make input-roster-policy-test`.

Both call sites feed it **compiled MLP1 artifacts** rather than source. That is deliberate: `ROSTER002` cannot tell which arm of an `#if` a literal belongs to, so a shared backend carrying every handheld's event node would report one violation per platform. A compiled artifact contains only the branch that survived the preprocessor — the thing actually shipping. This boundary is documented in the tool.

## Verification

Run against the **pre-fix** tree it flags the real regressions: `ROSTER001` on the PPSSPP wrapper at the exact line that was wrong, and `ROSTER002` on DraStic's hardcoded node.

It passes the full 738MB assembled payload and all four built emulator packages with zero false positives, and catches a node planted at the end of an 80MB binary in 0.08s.

## One thing worth reading in the test

The accept cases matter as much as the rejects. My first cut of `ROSTER004` **failed the N64 wrapper** — which is correct code: it disambiguates the two identically-named Loong pads by `Sysfs=/devices/virtual/input/`, but escapes the slashes for awk, so a literal check missed it. A gate that rejects correct code gets switched off, so the test asserts the real shipped wrappers pass, and the rule now compares against an unescaped copy.