### PR TITLE
Accept PPSSPP roster controller mappings

### DIFF
--- a/scripts/validate-ppsspp-vulkan-release.py
+++ b/scripts/validate-ppsspp-vulkan-release.py
@@ -99,11 +99,11 @@ def validate(platform: Path) -> None:
         key, separator, value = line.partition("=")
         if separator:
             controls[key.strip()] = value.strip()
-    if controls.get("Square") != "1-29,10-188":
+    if controls.get("Square") != "1-29,10-188,11-188,12-188,13-188":
         raise SystemExit("error: PPSSPP Square mapping is not the MLP1 mapping")
-    if controls.get("Triangle") != "1-47,10-191":
+    if controls.get("Triangle") != "1-47,10-191,11-191,12-191,13-191":
         raise SystemExit("error: PPSSPP Triangle mapping is not the MLP1 mapping")
-    if controls.get("An.Up") != "1-37,10-4003":
+    if controls.get("An.Up") != "1-37,10-4003,11-4003,12-4003,13-4003":
         raise SystemExit("error: PPSSPP analog up is not SDL Y-axis negative")
 
     cores = load_json(platform / "defaults/cores.json").get("cores")


### PR DESCRIPTION
## What changed

- Update the PPSSPP release validator to require the current four-slot MLP1 roster mappings for Square, Triangle, and analog up.

## Root cause and impact

PPSSPP now binds single-player PSP controls across roster device IDs 10–13 so a paired controller can occupy player 1 while the calibrated built-in pad moves later in the launch roster. Leaf's release gate still expected the earlier slot-10-only strings, causing an otherwise valid `v0.10.0-beta.1` assembly to fail at the final validator.

## Validation

- Current assembled PPSSPP/Vulkan payload passes `validate-ppsspp-vulkan-release.py`.
- `make leaf-release-policy-test`
- `python3 scripts/validate-input-roster-policy-test.py`
- Python bytecode compilation and `git diff --check`
