### PR TITLE
Gate releases on MLP1 recording payload

### DIFF
--- a/scripts/validate-leaf-release-test.py
+++ b/scripts/validate-leaf-release-test.py
@@ -253,6 +253,26 @@ class CandidateTests(unittest.TestCase):
         defaults.parent.mkdir(parents=True, exist_ok=True)
         defaults.write_text('input_player1_l3_btn = "7"\n', encoding="utf-8")
 
+        platform = root / "platforms" / "mlp1"
+        write_executable(platform / "bin" / "retroarch", b"\x7fELF RetroArch\n")
+        write_executable(platform / "bin" / "ffmpeg", b"\x7fELF FFmpeg\n")
+        write_executable(
+            platform / "bin" / "leaf-record-convert.sh",
+            b"#!/bin/sh\n",
+        )
+        (platform / "defaults" / "retroarch-record.cfg").write_text(
+            "vcodec = h264_rkmpp\n",
+            encoding="utf-8",
+        )
+        (platform / "bin" / "retroarch.build-manifest.json").write_text(
+            json.dumps({"configure_flags": ["--enable-ffmpeg"]}),
+            encoding="utf-8",
+        )
+        recording_libs = platform / "lib" / "ffmpeg"
+        recording_libs.mkdir(parents=True)
+        for name in MODULE.REQUIRED_RECORDING_LIBRARIES:
+            (recording_libs / name).write_bytes(b"\x7fELF library\n")
+
         provenance = {
             "schema": 1,
             "product": "leaf",
@@ -314,6 +334,30 @@ class CandidateTests(unittest.TestCase):
             )
             daemon.write_bytes(b"\x7fELF no feature\n")
             with self.assertRaisesRegex(MODULE.PolicyError, "relocate-games-v1"):
+                MODULE.validate_candidate(args)
+
+    def test_candidate_rejects_missing_recording_payload(self):
+        with tempfile.TemporaryDirectory() as raw:
+            args = self.make_candidate(Path(raw))
+            (args.release_root / "platforms" / "mlp1" / "bin" / "ffmpeg").unlink()
+            with self.assertRaisesRegex(MODULE.PolicyError, "MLP1 FFmpeg"):
+                MODULE.validate_candidate(args)
+
+    def test_candidate_rejects_retroarch_without_recording_support(self):
+        with tempfile.TemporaryDirectory() as raw:
+            args = self.make_candidate(Path(raw))
+            manifest = (
+                args.release_root
+                / "platforms"
+                / "mlp1"
+                / "bin"
+                / "retroarch.build-manifest.json"
+            )
+            manifest.write_text(
+                json.dumps({"configure_flags": ["--disable-ffmpeg"]}),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(MODULE.PolicyError, "recording support"):
                 MODULE.validate_candidate(args)
 
     def test_candidate_rejects_missing_source_paths_capability(self):

--- a/scripts/validate-leaf-release.py
+++ b/scripts/validate-leaf-release.py
@@ -63,6 +63,17 @@ REQUIRED_PRIMARY_PATHS = {
     # SDCARD_PATHS-aligned source list.
     "RECORDINGS_PATH": "/mnt/sdcard/Recordings",
 }
+REQUIRED_RECORDING_LIBRARIES = (
+    "libavcodec.so.60",
+    "libavdevice.so.60",
+    "libavfilter.so.9",
+    "libavformat.so.60",
+    "libavutil.so.58",
+    "libpostproc.so.57",
+    "librockchip_mpp.so.1",
+    "libswresample.so.4",
+    "libswscale.so.7",
+)
 
 
 class PolicyError(Exception):
@@ -291,6 +302,38 @@ def validate_mlp1_retroarch_input_profile(platform: Path) -> None:
             )
 
 
+def validate_mlp1_recording_payload(platform: Path) -> None:
+    binary_dir = platform / "bin"
+    require_file(binary_dir / "retroarch", "MLP1 RetroArch", executable=True)
+    require_file(binary_dir / "ffmpeg", "MLP1 FFmpeg", executable=True)
+    require_file(
+        binary_dir / "leaf-record-convert.sh",
+        "MLP1 recording conversion helper",
+        executable=True,
+    )
+    require_file(
+        platform / "defaults" / "retroarch-record.cfg",
+        "MLP1 recording preset",
+    )
+    for name in REQUIRED_RECORDING_LIBRARIES:
+        require_file(
+            platform / "lib" / "ffmpeg" / name,
+            f"MLP1 recording library {name}",
+        )
+
+    manifest = read_json(
+        binary_dir / "retroarch.build-manifest.json",
+        "MLP1 RetroArch build manifest",
+    )
+    flags = manifest.get("configure_flags") if isinstance(manifest, dict) else None
+    if (
+        not isinstance(flags, list)
+        or "--enable-ffmpeg" not in flags
+        or "--disable-ffmpeg" in flags
+    ):
+        raise PolicyError("MLP1 RetroArch was not built with FFmpeg recording support")
+
+
 def read_staged_environment(env_path: Path) -> dict[str, str]:
     result = subprocess.run(
         [
@@ -332,6 +375,7 @@ def validate_candidate(args: argparse.Namespace) -> None:
     require_file(inhibit, "launcher inhibit helper", executable=True)
     require_file(env_path, "runtime environment")
     validate_mlp1_retroarch_input_profile(platform)
+    validate_mlp1_recording_payload(platform)
     if b"relocate-games-v1" not in daemon.read_bytes():
         raise PolicyError("launcher daemon does not advertise relocate-games-v1")
     if b"source-paths-v2" not in daemon.read_bytes():


### PR DESCRIPTION
## What changed

- Require release candidates to contain the executable FFmpeg CLI, recording conversion helper, recording preset, and the complete FFmpeg 6.1/Rockchip MPP runtime library set.
- Require the packaged RetroArch build manifest to prove RetroArch was configured with `--enable-ffmpeg` and not `--disable-ffmpeg`.
- Add release-policy fixtures and regression tests for a missing FFmpeg payload and a recording-disabled RetroArch build.

## Why

`stage/mlp1.mk` intentionally treats FFmpeg as optional for developer launcher staging, but the final release candidate gate did not distinguish that convenience from a publishable build. A release could therefore ship without `bin/ffmpeg`, its runtime libraries, or even with RetroArch compiled without FFmpeg support, silently making game recording unavailable.

## Impact

Developer staging keeps its current warning-only behavior. Install ZIP generation now fails at the existing candidate gate unless the assembled MLP1 release has a complete, usable recording stack.

## Validation

- `make leaf-release-policy-test` (23 release candidate/provenance tests and 10 artifact identity tests)
- `git diff --check`
