### PR TITLE
mlp1: gate releases on a full, fresh core build report

### DIFF
--- a/scripts/make-sd-release-zip.sh
+++ b/scripts/make-sd-release-zip.sh
@@ -464,11 +464,21 @@ EOF
 validate_retroarch_contract() {
     local platform_dir="$1"
     local report="$platform_dir/cores/build-report.json"
+    local builder="$CORES_SPRUCE_DIR/build-mlp1.sh"
     [ -f "$report" ] || die "missing MLP1 core build report: $report"
+    [ -f "$builder" ] || die "missing Cores-spruce builder: $builder"
+    # A release is gated harder than a dev stage. --require-full-build-report
+    # was previously only applied when staging, so a release could be cut from
+    # a partial report; --require-fresh-build-report additionally rejects a
+    # report produced by a different build-mlp1.sh, which is how a stale core
+    # artifact reaches a release while every other check still passes.
     python3 "$UMRK_WORKSPACE_DIR/scripts/retroarch_validate_package.py" \
         --metadata-dir "$UMRK_WORKSPACE_DIR/plans/retroarch/generated/mlp1" \
         --build-report "$report" \
         --package-root "$platform_dir" \
+        --builder-script "$builder" \
+        --require-full-build-report \
+        --require-fresh-build-report \
         || die "RetroArch runtime metadata contract validation failed"
 }
 

--- a/stage/mlp1.mk
+++ b/stage/mlp1.mk
@@ -193,7 +193,8 @@ assemble-jawaka: jawaka-build shader-bundle-mlp1
 	@python3 "$(UMRK_WORKSPACE_DIR)/scripts/retroarch_validate_package.py" \
 		--metadata-dir "$(MLP1_METADATA_DIR)" \
 		--build-report "$(PLATFORM_PAYLOAD_DIR)/cores/build-report.json" \
-		--package-root "$(PLATFORM_PAYLOAD_DIR)"
+		--package-root "$(PLATFORM_PAYLOAD_DIR)" \
+		--builder-script "$(CORES_SPRUCE_DIR)/build-mlp1.sh"
 	@# Jawaka owns which controllers an emulator may see. A wrapper that
 	@# overwrites the published roster, or code that opens an event node
 	@# directly, fails silently at runtime -- the player just gets the wrong
@@ -249,7 +250,8 @@ stage-retroarch:
 	@python3 "$(UMRK_WORKSPACE_DIR)/scripts/retroarch_validate_package.py" \
 		--metadata-dir "$(MLP1_METADATA_DIR)" \
 		--build-report "$(MLP1_CORES_REPORT)" \
-		--require-full-build-report
+		--require-full-build-report \
+		--builder-script "$(CORES_SPRUCE_DIR)/build-mlp1.sh"
 	@set -euo pipefail; \
 	if [ -n "$${ADB_SERIAL:-}" ]; then \
 		serial="$$ADB_SERIAL"; \


### PR DESCRIPTION
## Why

Two independent gaps let a stale mGBA core ship in `v0.10.0-beta.4`.

**The release path was gated more weakly than staging.** `validate_retroarch_contract()` in `make-sd-release-zip.sh` called the validator without `--require-full-build-report`, which the staging path already passed. A release could therefore be cut from a partial or targeted build report while `make stage-retroarch` on the same tree would refuse it.

**Nothing tied the report to the builder that produced it.** The stale mGBA row was accurate — matching sha256, core present, coverage complete — so every existing check passed. What made it stale was that it predated the `build-mlp1.sh` in the tree, which no check could see.

## What this does

Adds `--builder-script` to the staging and release validator calls, and `--require-full-build-report` plus `--require-fresh-build-report` to the release path.

| Path | Full report | Builder identity |
| --- | --- | --- |
| `stage-retroarch` (payload + pre-stage) | pre-stage only, unchanged | **warning** |
| `release-zips` / beta zips | **error** (new) | **error** (new) |

Severity is deliberate: a developer staging to a device to try something gets a warning and carries on; a release stops. That keeps the gate from becoming something people learn to bypass.

## Depends on

- Cores-spruce PR #4 — emits `builder_script_sha256`
- umrk-workspace `3fe1b4c` — adds the validator flags

**Landing order matters.** The Cores-spruce emitter must ship *and a build must have run* before this merges. The freshness gate rejects reports that predate identity recording, so merging this first would block releases until the next full rebuild.

## Verification

Validator behaviour is covered by eight new unit tests in umrk-workspace. `bash -n` clean on `make-sd-release-zip.sh`. Confirmed against the real `v0.10.0-beta.4` report: with both flags it fails with `build report has no builder_script_sha256; it predates builder identity recording` — i.e. this gate would have stopped that beta.
