### PR TITLE
Gate np2kai and Flycast arcade support in releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ help:
 	@echo "  make refresh-jawaka DEVICE=mlp1           refresh helper (reboot advised with init hook)"
 	@echo "  make stage-jawaka DEVICE=mlp1             launcher payload only"
 	@echo "  make stage-retroarch DEVICE=mlp1          RetroArch binary + cores + info + shaders"
+	@echo "  make stage-core-test CORE=np2kai DEVICE=mlp1  testing only: stage one checksum-verified core"
 	@echo "  make stage-emulator EMULATOR=ppsspp DEVICE=mlp1 stage a standalone emulator"
 	@echo "  make stage-emulator EMULATOR=drastic DEVICE=mlp1 stage DraStic"
 	@echo "  make stage-emulator EMULATOR=mupen64plus DEVICE=mlp1 stage standalone N64"

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ make stage-refresh DEVICE=mlp1              # full stage, then restart Jawaka GU
 make refresh-jawaka DEVICE=mlp1             # restart Jawaka/Loong GUI stack only
 make stage-jawaka DEVICE=mlp1               # launcher payload only
 make stage-retroarch DEVICE=mlp1            # RetroArch binary + cores + info + shaders
+make stage-core-test CORE=np2kai DEVICE=mlp1 # testing only: one targeted, verified core
 make stage-emulator EMULATOR=drastic DEVICE=mlp1
 make stage-emulator EMULATOR=mupen64plus DEVICE=mlp1
 make stage-emulator EMULATOR=flycast DEVICE=mlp1
@@ -94,6 +95,11 @@ make release-zips DEVICE=mlp1               # build end-user install + recovery 
 make release-sd-zip DEVICE=mlp1             # build end-user install ZIP only
 make release-recovery-zip DEVICE=mlp1       # build end-user recovery ZIP only
 ```
+
+`stage-core-test` is the fast device-iteration path after a targeted
+`Cores-spruce/build-mlp1.sh <core>` build. It stages only the named core and
+matching info file from a checksum-bound report. Full staging and release ZIPs
+still require the complete stock-parity report.
 
 On MLP1, `stage-app` uses Jawaka's `package-quiesce-v1` barrier before it
 removes or pushes any package bytes. Close foreground apps first. A missing

--- a/scripts/validate-flycast-standalone-release-test.py
+++ b/scripts/validate-flycast-standalone-release-test.py
@@ -93,10 +93,11 @@ def fixture(root: Path) -> Path:
     systems = {
         "systems": [
             {
-                "id": "DC",
+                "id": system_id,
                 "default_core": "flycast_standalone",
-                "alternate_cores": ["flycast"],
+                "alternate_cores": ["flycast", "km_flycast_xtreme"],
             }
+            for system_id in ("DC", "ATOMISWAVE", "NAOMI")
         ]
     }
     (platform / "defaults/cores.json").write_text(
@@ -195,6 +196,14 @@ def main() -> None:
         path.write_text(json.dumps(data), encoding="utf-8")
 
     run_case("retroarch-default", restore_retroarch_default, False)
+
+    def remove_naomi_fallback(platform: Path) -> None:
+        path = platform / "defaults/systems.json"
+        data = json.loads(path.read_text(encoding="utf-8"))
+        data["systems"][2]["alternate_cores"] = ["km_flycast_xtreme"]
+        path.write_text(json.dumps(data), encoding="utf-8")
+
+    run_case("naomi-missing-retroarch-fallback", remove_naomi_fallback, False)
     print("Flycast standalone release policy checks passed")
 
 

--- a/scripts/validate-flycast-standalone-release.py
+++ b/scripts/validate-flycast-standalone-release.py
@@ -14,6 +14,7 @@ from pathlib import Path, PurePosixPath
 CORE_ID = "flycast_standalone"
 CORE_PATH = "emulators/flycast/launch.sh"
 PACKAGE_REL = Path("emulators/flycast")
+FLYCAST_SYSTEM_IDS = ("DC", "ATOMISWAVE", "NAOMI")
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 REQUIRED_LICENSES = {
@@ -103,17 +104,20 @@ def validate(platform_dir: Path) -> None:
     systems = rows(load_json(systems_path), "systems", systems_path)
     cores = rows(load_json(cores_path), "cores", cores_path)
 
-    dc_rows = [row for row in systems if row.get("id") == "DC"]
-    if len(dc_rows) != 1:
-        fail("systems.json must contain exactly one DC system")
-    dc = dc_rows[0]
-    alternates = dc.get("alternate_cores")
-    if not isinstance(alternates, list):
-        fail("DC alternate_cores must be an array")
-    if dc.get("default_core") != CORE_ID:
-        fail("DC must default to flycast_standalone")
-    if "flycast" not in alternates:
-        fail("DC must retain the RetroArch Flycast core as a fallback")
+    for system_id in FLYCAST_SYSTEM_IDS:
+        system_rows = [row for row in systems if row.get("id") == system_id]
+        if len(system_rows) != 1:
+            fail(f"systems.json must contain exactly one {system_id} system")
+        system = system_rows[0]
+        alternates = system.get("alternate_cores")
+        if not isinstance(alternates, list):
+            fail(f"{system_id} alternate_cores must be an array")
+        if system.get("default_core") != CORE_ID:
+            fail(f"{system_id} must default to flycast_standalone")
+        if "flycast" not in alternates:
+            fail(
+                f"{system_id} must retain the RetroArch Flycast core as a fallback"
+            )
 
     core_rows = [row for row in cores if row.get("id") == CORE_ID]
     if len(core_rows) != 1:

--- a/stage/licenses/CORES.md
+++ b/stage/licenses/CORES.md
@@ -42,6 +42,7 @@ from the named upstream release asset.
 | mgba | MPL-2.0 | https://github.com/libretro/mgba |
 | mupen64plus_standalone (standalone) | GPL-2.0 / MIT / bundled third-party notices | https://github.com/josegonzalez/minui-n64-pak |
 | mupen64plus_next | GPL-2.0 | https://github.com/libretro/mupen64plus-libretro-nx |
+| np2kai | MIT | https://github.com/libretro/NP2kai |
 | pcsx_rearmed | GPL-2.0 | https://github.com/libretro/pcsx_rearmed |
 | picodrive | PicoDrive (non-commercial) | https://github.com/libretro/picodrive |
 | ppsspp (standalone) | GPL-2.0+ | https://github.com/hrydgard/ppsspp |

--- a/stage/licenses/cores/np2kai.txt
+++ b/stage/licenses/cores/np2kai.txt
@@ -1,0 +1,26 @@
+Neko Project II kai (PC-98)
+https://github.com/libretro/NP2kai
+
+Copyright (c) various contributors
+
+Licensed under the MIT License
+
+---
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/stage/licenses/cores/np2kai.txt
+++ b/stage/licenses/cores/np2kai.txt
@@ -1,11 +1,6 @@
-Neko Project II kai (PC-98)
-https://github.com/libretro/NP2kai
+MIT License
 
-Copyright (c) various contributors
-
-Licensed under the MIT License
-
----
+Copyright (c) 2017 AZO
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/stage/mlp1.mk
+++ b/stage/mlp1.mk
@@ -58,7 +58,7 @@ override LEAF_BETA_TAG_INPUT := $(value TAG)
 unexport TAG
 export LEAF_BETA_TAG_INPUT
 
-.PHONY: stage stage-app stage-emulator stage-emulators stage-public-root stage-retroarch stage-refresh refresh-jawaka jawaka-build shader-bundle-mlp1 assemble-jawaka stage-jawaka release-zips release-sd-zip release-recovery-zip beta-zips verify-beta-zips stable-zips verify-stable-zips
+.PHONY: stage stage-app stage-core-test stage-emulator stage-emulators stage-public-root stage-retroarch stage-refresh refresh-jawaka jawaka-build shader-bundle-mlp1 assemble-jawaka stage-jawaka release-zips release-sd-zip release-recovery-zip beta-zips verify-beta-zips stable-zips verify-stable-zips
 
 # Build the Jawaka MLP1 binaries (cross-compile via its own Docker target).
 jawaka-build:
@@ -299,6 +299,53 @@ stage-retroarch:
 	"$${ADB[@]}" shell "chmod 755 '$$remote_platform/bin/retroarch' '$$remote_platform/cores/'*_libretro.so 2>/dev/null || true"; \
 	"$${ADB[@]}" shell sync; \
 	echo "RetroArch platform payload staged."
+
+# Testing-only fast path for a targeted core build. It never replaces the
+# device's full build report or any sibling core; release staging remains gated
+# by stage-retroarch's complete stock-parity report.
+stage-core-test:
+	@set -euo pipefail; \
+	core="$(CORE)"; \
+	case "$$core" in ''|*[!a-z0-9_]*) echo "usage: make stage-core-test CORE=<core-id> DEVICE=mlp1" >&2; exit 2;; esac; \
+	if ! python3 "$(MLP1_CORE_REPORT_TOOL)" verify \
+			--report "$(MLP1_CORES_REPORT)" \
+			--cores-dir "$(MLP1_CORES_DIR)" >/dev/null 2>&1; then \
+		echo "Probing targeted MLP1 build report on the selected device"; \
+		ADB_SERIAL="$${ADB_SERIAL:-}" "$(MLP1_CORE_PROBE_RUNNER)" \
+			--report "$(MLP1_CORES_REPORT)" \
+			--cores-dir "$(MLP1_CORES_DIR)"; \
+	fi; \
+	python3 "$(MLP1_CORE_REPORT_TOOL)" verify \
+		--report "$(MLP1_CORES_REPORT)" \
+		--cores-dir "$(MLP1_CORES_DIR)"; \
+	row="$$(python3 "$(MLP1_CORE_REPORT_TOOL)" manifest \
+		--report "$(MLP1_CORES_REPORT)" \
+		--cores-dir "$(MLP1_CORES_DIR)" | awk -F '\t' -v wanted="$$core" '$$1 == wanted { print; exit }')"; \
+	[ -n "$$row" ] || { echo "error: targeted report does not contain core: $$core" >&2; exit 2; }; \
+	IFS=$$'\t' read -r _ core_file expected_sha256 <<<"$$row"; \
+	info_file="$${core_file%.so}.info"; \
+	core_path="$(MLP1_CORES_DIR)/$$core_file"; \
+	info_path="$(MLP1_INFO_DIR)/$$info_file"; \
+	[ -f "$$info_path" ] || { echo "error: missing matching info file: $$info_path" >&2; exit 2; }; \
+	if [ -n "$${ADB_SERIAL:-}" ]; then serial="$$ADB_SERIAL"; else serial="$$(adb devices | awk 'NR>1 && $$2=="device" {print $$1; exit}')"; fi; \
+	[ -n "$$serial" ] || { echo "No online adb device found." >&2; exit 1; }; \
+	ADB=(adb -s "$$serial"); \
+	if "$${ADB[@]}" shell 'pidof retroarch >/dev/null'; then \
+		echo "error: exit the running RetroArch game before replacing $$core_file" >&2; \
+		exit 2; \
+	fi; \
+	remote_sd="$$(PLATFORM_ID="mlp1" REMOTE_SDCARD_PATH="$(REMOTE_SDCARD_PATH)" ADB_SERIAL="$$serial" "$(LEAF_ROOT)/scripts/adb-resolve-umrk-sd.sh")"; \
+	remote_system="$(REMOTE_SYSTEM_PATH)"; \
+	if [ -z "$$remote_system" ]; then remote_system="$$remote_sd/.system/leaf"; fi; \
+	remote_platform="$(REMOTE_PLATFORM_PATH)"; \
+	if [ -z "$$remote_platform" ]; then remote_platform="$$remote_system/platforms/mlp1"; fi; \
+	"$${ADB[@]}" shell "mkdir -p '$$remote_platform/cores' '$$remote_platform/info'"; \
+	"$${ADB[@]}" push "$$core_path" "$$remote_platform/cores/$$core_file" >/dev/null; \
+	"$${ADB[@]}" push "$$info_path" "$$remote_platform/info/$$info_file" >/dev/null; \
+	"$${ADB[@]}" shell "chmod 755 '$$remote_platform/cores/$$core_file' && sync"; \
+	actual_sha256="$$("$${ADB[@]}" shell "sha256sum '$$remote_platform/cores/$$core_file'" | awk '{print $$1}')"; \
+	[ "$$actual_sha256" = "$$expected_sha256" ] || { echo "error: device checksum mismatch for $$core_file" >&2; exit 1; }; \
+	echo "Testing core staged: $$core ($$expected_sha256)"
 
 # Create the public SD folders Leaf exposes to users. Internal runtime files live
 # under .system/leaf; these directories stay at the card root for content.


### PR DESCRIPTION
Adds the upstream np2kai license/inventory entry and extends standalone Flycast release policy to Dreamcast, Atomiswave, and Naomi while preserving one Flycast package.

Host evidence:
- np2kai notice is byte-identical to upstream, including Copyright (c) 2017 AZO
- Flycast validator policy smoke passed
- 23 release-policy tests passed
- 10 release-identity tests passed
- host launcher assembly passed
- full local MLP1 install ZIP and release-candidate gate passed
- actual Flycast gate passed: 33 checksummed files
- np2kai binary, info, checksum-bound report, and license present in assembled release
- 34 packaged catalog entries passed binary/path plus license validation

Physical staging/gameplay remains pending ADB reconnection and legal BIOS/content. Keep draft and unmerged; no release tag or published artifact.