### PR TITLE
Add Pak Rat content storefront lane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ help:
 	@echo "  make benchmark-ppsspp ROM=/path CORE=vulkan PRESET=balanced TRACE=scripts/ppsspp-input-traces/example.json"
 
 bootstrap:
-	@LEAF_WORKSPACE_DIR="$(WORKSPACE_DIR)" scripts/bootstrap.sh $(REQUIRED_REPOS) --optional $(OPTIONAL_PRIVATE_REPOS)
+	@LEAF_WORKSPACE_DIR="$(WORKSPACE_DIR)" scripts/bootstrap.sh $(REQUIRED_REPOS) --optional $(OPTIONAL_PRIVATE_REPOS) $(OPTIONAL_EXAMPLE_REPOS)
 
 flycast-release-policy-smoke:
 	@python3 scripts/validate-flycast-standalone-release-test.py

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ help:
 	@echo "  make stage-app APP=VideoFromHell DEVICE=mlp1 explicitly stage the optional Video From Hell app"
 	@echo "  make stage-app APP=Nimbus DEVICE=mlp1       explicitly stage the optional Nimbus app"
 	@echo "  make stage-app APP=PortMaster-mlp1 DEVICE=mlp1 explicitly stage the optional PortMaster app"
+	@echo "  make stage-app APP=ScummVM-pak DEVICE=mlp1 explicitly stage the reference content pak"
 	@echo "  make release-zips DEVICE=mlp1             build end-user install + recovery ZIPs"
 	@echo "    REBUILD_CORES=1                         explicitly permit compiling missing/stale cores"
 	@echo "    FORCE_REBUILD_CORES=1                   with REBUILD_CORES=1, bypass every valid cache hit"

--- a/scripts/adb-package-quiesce.sh
+++ b/scripts/adb-package-quiesce.sh
@@ -52,7 +52,8 @@ esac
 
 request_type="package-quiesce-$action"
 request="{\"type\":\"$request_type\",\"operation_id\":\"$operation_id\"}"
-reply="$("${ADB[@]}" shell "
+send_request() {
+    "${ADB[@]}" shell "
 set -eu
 env_file='$remote_sd/.system/leaf/platforms/$PLATFORM_ID/launcher/env.sh'
 [ -f \"\$env_file\" ] || { echo 'Leaf runtime env is missing' >&2; exit 1; }
@@ -60,8 +61,11 @@ env_file='$remote_sd/.system/leaf/platforms/$PLATFORM_ID/launcher/env.sh'
 ctl=\"\$UMRK_LAUNCHER_PATH/bin/jawaka-platformctl\"
 [ -x \"\$ctl\" ] || { echo 'jawaka-platformctl is missing' >&2; exit 1; }
 [ -S \"\$UMRK_DAEMON_SOCKET\" ] || { echo 'jawakad socket is unavailable' >&2; exit 1; }
-\"\$ctl\" --socket \"\$UMRK_DAEMON_SOCKET\" request '$request'
-")"
+\"\$ctl\" --socket \"\$UMRK_DAEMON_SOCKET\" request '$1'
+"
+}
+
+reply="$(send_request "$request")"
 reply="${reply//$'\r'/}"
 printf '%s\n' "$reply"
 case "$reply" in
@@ -71,3 +75,16 @@ case "$reply" in
         exit 1
         ;;
 esac
+
+if [ "$action" = "end" ]; then
+    scan_reply="$(send_request '{"type":"scan-library"}')"
+    scan_reply="${scan_reply//$'\r'/}"
+    printf '%s\n' "$scan_reply"
+    case "$scan_reply" in
+        *'"type":"ok"'*) ;;
+        *)
+            echo "Jawaka rejected the post-stage library scan." >&2
+            exit 1
+            ;;
+    esac
+fi

--- a/scripts/adb-stage-app-package-smoke.sh
+++ b/scripts/adb-stage-app-package-smoke.sh
@@ -24,6 +24,13 @@ case "$*" in
     *package-quiesce-end*)
         printf '%s\n' '{"type":"ok","action":"package-quiesce-end"}'
         ;;
+    *scan-library*)
+        if [ "${FAKE_ADB_SCAN_ERROR:-0}" -eq 1 ]; then
+            printf '%s\n' '{"type":"error","message":"scan-failed"}'
+        else
+            printf '%s\n' '{"type":"ok","action":"scan-library started"}'
+        fi
+        ;;
     *' push '*)
         if [ "${FAKE_ADB_PUSH_ERROR:-0}" -eq 1 ]; then exit 1; fi
         ;;
@@ -52,9 +59,11 @@ begin_line="$(line_for package-quiesce-begin)"
 remove_line="$(line_for "$remote_remove_marker")"
 push_line="$(line_for ' push ')"
 end_line="$(line_for package-quiesce-end)"
+scan_line="$(line_for scan-library)"
 [ "$begin_line" -lt "$remove_line" ]
 [ "$remove_line" -lt "$push_line" ]
 [ "$push_line" -lt "$end_line" ]
+[ "$end_line" -lt "$scan_line" ]
 
 : >"$FAKE_ADB_LOG"
 if FAKE_ADB_PUSH_ERROR=1 \
@@ -66,6 +75,17 @@ fi
 grep -Fq package-quiesce-begin "$FAKE_ADB_LOG"
 grep -Fq ' push ' "$FAKE_ADB_LOG"
 grep -Fq package-quiesce-end "$FAKE_ADB_LOG"
+grep -Fq scan-library "$FAKE_ADB_LOG"
+
+: >"$FAKE_ADB_LOG"
+if FAKE_ADB_SCAN_ERROR=1 \
+    "$ROOT_DIR/scripts/adb-stage-app-package.sh" "$fixture/local" "$remote_dir" \
+        >/dev/null 2>&1; then
+    echo "expected a rejected library scan to fail staging" >&2
+    exit 1
+fi
+grep -Fq package-quiesce-end "$FAKE_ADB_LOG"
+grep -Fq scan-library "$FAKE_ADB_LOG"
 
 : >"$FAKE_ADB_LOG"
 if FAKE_ADB_BEGIN_ERROR=1 \

--- a/scripts/app-package-policy-smoke.sh
+++ b/scripts/app-package-policy-smoke.sh
@@ -31,6 +31,7 @@ assert_policy DiscoBoy DiscoBoy.pak pakrat
 assert_policy VideoFromHell VideoFromHell.pak pakrat
 assert_policy Nimbus Nimbus.pak pakrat
 assert_policy PortMaster-mlp1 PortMaster.pak pakrat
+assert_policy ScummVM-pak ScummVM.pak pakrat
 assert_policy ssh-server SSHServer.pak release
 
 # The audits below derive their patterns from leaf_pakrat_owned_repos, so this

--- a/scripts/app-package-policy.sh
+++ b/scripts/app-package-policy.sh
@@ -128,6 +128,14 @@ leaf_app_policy() {
             supported_devices="mlp1"
             distribution="pakrat"
             ;;
+        ScummVM-pak)
+            package_target="package-mlp1"
+            package_dir="$workspace_dir/ScummVM-pak/build/package/ScummVM.pak"
+            package_name="ScummVM.pak"
+            destination_platform="mlp1"
+            supported_devices="mlp1"
+            distribution="pakrat"
+            ;;
         ssh-server)
             package_target="package-platform"
             package_platform="mlp1"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -26,6 +26,8 @@ url_for() {
         mlp1-toolchain)              echo "https://github.com/Utility-Muffin-Research-Kitchen/mlp1-toolchain.git" ;;
         miniloong-launcher-switcher) echo "https://github.com/Helaas/miniloong-launcher-switcher.git" ;;
         miniloong-adb-keeper)        echo "https://github.com/Helaas/miniloong-adb-keeper.git" ;;
+        leaf-contracts)              echo "https://github.com/Utility-Muffin-Research-Kitchen/leaf-contracts.git" ;;
+        ScummVM-pak)                 echo "https://github.com/Utility-Muffin-Research-Kitchen/ScummVM-pak.git" ;;
         *) echo "" ;;
     esac
 }

--- a/scripts/pakrat-local-feed-test.py
+++ b/scripts/pakrat-local-feed-test.py
@@ -41,6 +41,9 @@ class LocalFeedTest(unittest.TestCase):
         version: str = "1.0.0",
         min_leaf_version: str | None = None,
         runtime_min_leaf_version: str | None | object = MATCH_METADATA,
+        kind: str | None = None,
+        provides: dict | None = None,
+        platform: str = "mlp1",
     ) -> Path:
         app_dir = self.apps_root / directory
         package_dir = app_dir / "build" / "mlp1" / "package" / install_name
@@ -58,6 +61,8 @@ class LocalFeedTest(unittest.TestCase):
         )
         if runtime_minimum is not None:
             runtime["min_leaf_version"] = runtime_minimum
+        if provides is not None:
+            runtime["provides"] = provides
         (package_dir / "pak.json").write_text(
             json.dumps(runtime) + "\n", encoding="utf-8"
         )
@@ -74,7 +79,7 @@ class LocalFeedTest(unittest.TestCase):
             "leaf": {
                 "packages": [
                     {
-                        "platform": "mlp1",
+                        "platform": platform,
                         "version": version,
                         "artifact_name": artifact_name,
                         "install_name": install_name,
@@ -87,6 +92,8 @@ class LocalFeedTest(unittest.TestCase):
         }
         if min_leaf_version is not None:
             metadata["leaf"]["packages"][0]["min_leaf_version"] = min_leaf_version
+        if kind is not None:
+            metadata["kind"] = kind
         (app_dir / "pakrat.json").write_text(
             json.dumps(metadata, indent=2) + "\n", encoding="utf-8"
         )
@@ -161,6 +168,202 @@ class LocalFeedTest(unittest.TestCase):
                 encoding="utf-8"
             )
         )
+
+    # ---- STORE-CONTENT-1: the content[] lane -------------------------------
+
+    SCUMMVM_PROVIDES = {
+        "schema": 1,
+        "systems": [
+            {
+                "id": "SCUMMVM",
+                "name": "ScummVM",
+                "patterns": ["SCUMMVM"],
+                "extensions": ["scummvm"],
+                "rom_root": "Roms/SCUMMVM",
+                "image_root": "Images/SCUMMVM",
+                "default_core": "scummvm",
+                "icon_flat": "art/SCUMMVM.png",
+            }
+        ],
+        "cores": [],
+        "system_extensions": [],
+    }
+
+    def test_content_package_publishes_with_no_ungated_floor(self) -> None:
+        """The case that forced a separate lane: every version is gated, so
+        there is no ungated safe floor and the apps[] rule could never be
+        satisfied."""
+        app = self.write_app(
+            "ScummVM",
+            "org.umrk.scummvm",
+            "ScummVM.pak",
+            "ScummVM.mlp1.pak.zip",
+            min_leaf_version="0.11.0",
+            kind="content",
+            provides=self.SCUMMVM_PROVIDES,
+        )
+        self.run_feed([app])
+        catalog = self.catalog()
+        self.assertEqual(catalog["apps"], [])
+        self.assertEqual(len(catalog["content"]), 1)
+        entry = catalog["content"][0]
+        self.assertEqual(entry["id"], "org.umrk.scummvm")
+        package = entry["packages"][0]
+        self.assertEqual(package["min_leaf_version"], "0.11.0")
+        self.assertTrue(
+            all("min_leaf_version" in v for v in package["versions"]),
+            "a content package needs no ungated floor",
+        )
+
+    def test_gate_unaware_client_sees_only_apps(self) -> None:
+        """A client that predates this contract parses apps[], ignores the
+        unknown content key, and never learns a content pak exists."""
+        plain = self.write_app(
+            "Plain", "org.umrk.plain", "Plain.pak", "Plain.mlp1.pak.zip"
+        )
+        content = self.write_app(
+            "ScummVM",
+            "org.umrk.scummvm",
+            "ScummVM.pak",
+            "ScummVM.mlp1.pak.zip",
+            min_leaf_version="0.11.0",
+            kind="content",
+            provides=self.SCUMMVM_PROVIDES,
+        )
+        self.run_feed([plain, content])
+        catalog = self.catalog()
+        self.assertEqual([a["id"] for a in catalog["apps"]], ["org.umrk.plain"])
+        self.assertEqual(
+            [a["id"] for a in catalog["content"]], ["org.umrk.scummvm"]
+        )
+        self.assertEqual(catalog["schema"], 1, "the schema must not bump")
+
+    def test_content_key_is_absent_when_no_content_package_exists(self) -> None:
+        """Every storefront published before this contract stays byte-shaped
+        exactly as it was."""
+        app = self.write_app(
+            "Plain", "org.umrk.plain", "Plain.pak", "Plain.mlp1.pak.zip"
+        )
+        self.run_feed([app])
+        self.assertNotIn("content", self.catalog())
+
+    def test_content_artifact_without_provides_is_rejected(self) -> None:
+        """The lane is a claim; the built .pak is the fact."""
+        app = self.write_app(
+            "ScummVM",
+            "org.umrk.scummvm",
+            "ScummVM.pak",
+            "ScummVM.mlp1.pak.zip",
+            min_leaf_version="0.11.0",
+            kind="content",
+        )
+        result = self.run_feed([app], expected_ok=False)
+        self.assertIn("declares no `provides`", result.stderr)
+
+    def test_ungated_content_package_is_rejected(self) -> None:
+        app = self.write_app(
+            "ScummVM",
+            "org.umrk.scummvm",
+            "ScummVM.pak",
+            "ScummVM.mlp1.pak.zip",
+            kind="content",
+            provides=self.SCUMMVM_PROVIDES,
+        )
+        result = self.run_feed([app], expected_ok=False)
+        self.assertIn("every content version must declare min_leaf_version",
+                      result.stderr)
+
+    def test_provides_artifact_in_apps_lane_is_rejected(self) -> None:
+        """The mirror rule: a provides pak is gated on this contract by
+        construction, so the gate-unaware lane is the wrong home for it."""
+        app = self.write_app(
+            "ScummVM",
+            "org.umrk.scummvm",
+            "ScummVM.pak",
+            "ScummVM.mlp1.pak.zip",
+            provides=self.SCUMMVM_PROVIDES,
+        )
+        result = self.run_feed([app], expected_ok=False)
+        self.assertIn("belongs in the content lane", result.stderr)
+
+    def test_shared_platform_content_package_is_rejected(self) -> None:
+        """D16: cores and standalone emulators are platform-specific."""
+        app = self.write_app(
+            "ScummVM",
+            "org.umrk.scummvm",
+            "ScummVM.pak",
+            "ScummVM.mlp1.pak.zip",
+            min_leaf_version="0.11.0",
+            kind="content",
+            provides=self.SCUMMVM_PROVIDES,
+            platform="shared",
+        )
+        result = self.run_feed([app], expected_ok=False)
+        self.assertIn("shared", result.stderr)
+
+    def test_id_cannot_appear_in_both_lanes(self) -> None:
+        """S-3: both lanes resolve to the same install_path."""
+        app = self.write_app(
+            "Plain", "org.umrk.dual", "Plain.pak", "Plain.mlp1.pak.zip"
+        )
+        twin = self.write_app(
+            "Twin",
+            "org.umrk.dual",
+            "Twin.pak",
+            "Twin.mlp1.pak.zip",
+            min_leaf_version="0.11.0",
+            kind="content",
+            provides=self.SCUMMVM_PROVIDES,
+        )
+        result = self.run_feed([app, twin], expected_ok=False)
+        self.assertIn("duplicate app id", result.stderr)
+
+    def test_content_history_stays_immutable_and_append_only(self) -> None:
+        """The safe-floor exemption is the ONE rule content[] relaxes."""
+        app = self.write_app(
+            "ScummVM",
+            "org.umrk.scummvm",
+            "ScummVM.pak",
+            "ScummVM.mlp1.pak.zip",
+            min_leaf_version="0.11.0",
+            kind="content",
+            provides=self.SCUMMVM_PROVIDES,
+        )
+        self.run_feed([app])
+        first = self.catalog()["content"][0]["packages"][0]["versions"][0]
+
+        self.update_app(app, "1.1.0", "0.11.0")
+        self.run_feed([app])
+        versions = self.catalog()["content"][0]["packages"][0]["versions"]
+        self.assertEqual([v["version"] for v in versions], ["1.1.0", "1.0.0"])
+        self.assertEqual(
+            versions[1], first, "a published content version is frozen"
+        )
+        # The legacy fields mirror the NEWEST entry, gate included, because in
+        # this lane there is no ungated floor for them to mirror instead.
+        package = self.catalog()["content"][0]["packages"][0]
+        self.assertEqual(package["version"], "1.1.0")
+        self.assertEqual(package["min_leaf_version"], "0.11.0")
+
+    def test_package_cannot_change_lanes_once_published(self) -> None:
+        app = self.write_app(
+            "ScummVM",
+            "org.umrk.scummvm",
+            "ScummVM.pak",
+            "ScummVM.mlp1.pak.zip",
+            min_leaf_version="0.11.0",
+            kind="content",
+            provides=self.SCUMMVM_PROVIDES,
+        )
+        self.run_feed([app])
+        metadata_path = app / "pakrat.json"
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        metadata.pop("kind")
+        metadata_path.write_text(json.dumps(metadata, indent=2) + "\n",
+                                 encoding="utf-8")
+        result = self.run_feed([app], expected_ok=False)
+        self.assertIn("belongs in the content lane", result.stderr)
+
 
     def test_multiple_explicit_apps(self) -> None:
         first = self.write_app(

--- a/scripts/pakrat-local-feed.py
+++ b/scripts/pakrat-local-feed.py
@@ -265,7 +265,9 @@ def version_entry(entry: object, source: Path) -> dict:
     return result
 
 
-def normalized_history_package(app: dict, package: object, source: Path) -> dict:
+def normalized_history_package(
+    app: dict, package: object, source: Path, is_content: bool = False
+) -> dict:
     if not isinstance(package, dict):
         die(f"{source}: package must be an object")
     platform = require_metadata_string(package, "platform", source)
@@ -281,7 +283,7 @@ def normalized_history_package(app: dict, package: object, source: Path) -> dict
         die(f"{source}: runtime_manifest_path must be a non-empty string")
 
     legacy = version_entry(package, source)
-    if "min_leaf_version" in legacy:
+    if "min_leaf_version" in legacy and not is_content:
         die(f"{source}: legacy package version must be an ungated safe floor")
     versions_value = package.get("versions")
     legacy_import = versions_value is None
@@ -303,16 +305,32 @@ def normalized_history_package(app: dict, package: object, source: Path) -> dict
     by_version = {value["version"]: value for value in versions}
     if len(by_version) != len(versions):
         die(f"{source}: duplicate package version")
-    floors = [value for value in versions if "min_leaf_version" not in value]
-    if not floors:
-        die(f"{source}: package history has no ungated safe floor")
-    floor = max(floors, key=lambda value: version_key(value["version"]))
-    if (
-        legacy["version"] != floor["version"]
-        or legacy["artifact"] != floor["artifact"]
-        or app.get("version") != floor["version"]
-    ):
-        die(f"{source}: legacy app/package fields do not match the safe floor")
+    if is_content:
+        # Every content package gates on the contract that defines it, so it
+        # has no ungated floor and needs none: gate-unaware clients never
+        # parse this lane. The legacy fields still mirror something real --
+        # the newest entry rather than the newest ungated one.
+        if any("min_leaf_version" not in value for value in versions):
+            die(f"{source}: every content version must declare min_leaf_version")
+        floor = max(versions, key=lambda value: version_key(value["version"]))
+        if (
+            legacy["version"] != floor["version"]
+            or legacy["artifact"] != floor["artifact"]
+            or legacy.get("min_leaf_version") != floor.get("min_leaf_version")
+            or app.get("version") != floor["version"]
+        ):
+            die(f"{source}: legacy app/package fields do not match the newest version")
+    else:
+        floors = [value for value in versions if "min_leaf_version" not in value]
+        if not floors:
+            die(f"{source}: package history has no ungated safe floor")
+        floor = max(floors, key=lambda value: version_key(value["version"]))
+        if (
+            legacy["version"] != floor["version"]
+            or legacy["artifact"] != floor["artifact"]
+            or app.get("version") != floor["version"]
+        ):
+            die(f"{source}: legacy app/package fields do not match the safe floor")
 
     return {
         "platform": platform,
@@ -333,29 +351,38 @@ def load_history_index(path: Path | None) -> dict[tuple[str, str, str], dict]:
     apps = catalog.get("apps")
     if not isinstance(apps, list):
         die(f"{path}: history apps must be an array")
+    content = catalog.get("content", [])
+    if not isinstance(content, list):
+        die(f"{path}: history content must be an array")
     result: dict[tuple[str, str, str], dict] = {}
     seen_ids: set[str] = set()
-    for app in apps:
-        if not isinstance(app, dict):
-            die(f"{path}: history app must be an object")
-        app_id = require_metadata_string(app, "id", path)
-        if app_id in seen_ids:
-            die(f"{path}: duplicate history app id: {app_id}")
-        seen_ids.add(app_id)
-        packages = app.get("packages")
-        if not isinstance(packages, list) or not packages:
-            die(f"{path}: history app packages must be a non-empty array")
-        for package in packages:
-            normalized = normalized_history_package(app, package, path)
-            key = (
-                app_id,
-                normalized["platform"],
-                normalized["install_name"].casefold(),
-            )
-            if key in result:
-                die(f"{path}: duplicate history package for {app_id}")
-            normalized["source_path"] = path
-            result[key] = normalized
+    for entries, is_content in ((apps, False), (content, True)):
+        for app in entries:
+            if not isinstance(app, dict):
+                die(f"{path}: history app must be an object")
+            app_id = require_metadata_string(app, "id", path)
+            # S-3, enforced against published history too: an id that has
+            # appeared in both lanes cannot be resolved to one install_path.
+            if app_id in seen_ids:
+                die(f"{path}: duplicate history app id: {app_id}")
+            seen_ids.add(app_id)
+            packages = app.get("packages")
+            if not isinstance(packages, list) or not packages:
+                die(f"{path}: history app packages must be a non-empty array")
+            for package in packages:
+                normalized = normalized_history_package(
+                    app, package, path, is_content
+                )
+                key = (
+                    app_id,
+                    normalized["platform"],
+                    normalized["install_name"].casefold(),
+                )
+                if key in result:
+                    die(f"{path}: duplicate history package for {app_id}")
+                normalized["source_path"] = path
+                normalized["is_content"] = is_content
+                result[key] = normalized
     return result
 
 
@@ -419,6 +446,7 @@ def merge_package_history(
     artifacts_root: Path,
     base_url: str,
     source: Path,
+    is_content: bool = False,
 ) -> tuple[list[dict], dict]:
     if history is None:
         versions: list[dict] = []
@@ -455,6 +483,14 @@ def merge_package_history(
             f"{source}: versions exceeds the "
             f"{MAX_VERSIONS_PER_PACKAGE}-entry client limit"
         )
+    if is_content:
+        # STORE-CONTENT-1: there is no ungated safe floor in content[], but
+        # every entry still has a gate. Immutability and append-only history
+        # above apply unchanged.
+        if any("min_leaf_version" not in value for value in versions):
+            die(f"{source}: every content version must declare min_leaf_version")
+        floor = max(versions, key=lambda value: version_key(value["version"]))
+        return versions, floor
     floors = [value for value in versions if "min_leaf_version" not in value]
     if not floors:
         die(
@@ -524,6 +560,7 @@ def build_storefront(args: argparse.Namespace) -> Path:
     artifact_overrides = parse_artifact_overrides(args.artifact)
     base_url = ensure_base_url(args.base_url)
     apps: list[dict] = []
+    content: list[dict] = []
     seen_ids: set[str] = set()
     seen_install_names: set[str] = set()
     used_history_keys: set[tuple[str, str, str]] = set()
@@ -535,13 +572,30 @@ def build_storefront(args: argparse.Namespace) -> Path:
             die(f"{metadata_path}: schema must be 1")
         app_id = require_metadata_string(meta, "id", metadata_path)
         require_path_segment(app_id, "app id", metadata_path)
+        # S-3: one lane per id. Both lanes resolve to the same install_path,
+        # so an id in both is a duplicate-identity bug, not two audiences.
         if app_id in seen_ids:
             die(f"duplicate app id: {app_id}")
         seen_ids.add(app_id)
+        kind = meta.get("kind", "app")
+        if kind not in ("app", "content"):
+            die(f"{metadata_path}: kind must be \"app\" or \"content\"")
+        is_content = kind == "content"
 
         packages = meta.get("leaf", {}).get("packages", [])
         if not isinstance(packages, list) or not packages:
             die(f"{metadata_path}: leaf.packages must be a non-empty array")
+        if is_content:
+            # D16: cores and standalone emulator binaries are
+            # platform-specific, so there is nothing a shared content pak
+            # could correctly ship. Refused explicitly rather than left to
+            # fail later as "no MLP1 package", which would hide the reason.
+            for pkg in packages:
+                if isinstance(pkg, dict) and pkg.get("platform") == "shared":
+                    die(
+                        f"{metadata_path}: content packages must name a "
+                        "concrete platform; \"shared\" is refused"
+                    )
         selected = [pkg for pkg in packages if pkg.get("platform") == "mlp1"]
         if not selected:
             die(f"{metadata_path}: no MLP1 Leaf package")
@@ -572,6 +626,11 @@ def build_storefront(args: argparse.Namespace) -> Path:
                 pkg.get("version"), "package version", metadata_path
             )
             minimum = optional_min_leaf_version(pkg, metadata_path)
+            if is_content and minimum is None:
+                die(
+                    f"{metadata_path}: every content version must declare "
+                    "min_leaf_version"
+                )
 
             install_key = install_name.casefold()
             if install_key in seen_install_names:
@@ -620,6 +679,22 @@ def build_storefront(args: argparse.Namespace) -> Path:
             runtime, installed_size = inspect_zip_artifact(
                 candidate_path, install_name, runtime_manifest_path
             )
+            # The lane is a claim; the built .pak is the fact. A package in
+            # content[] whose artifact declares no `provides` would install
+            # and then contribute nothing, and a `provides` pak in apps[]
+            # would be offered to gate-unaware clients that cannot use it.
+            artifact_provides = isinstance(runtime.get("provides"), dict)
+            if is_content and not artifact_provides:
+                die(
+                    f"{candidate_path}: kind is content but the runtime "
+                    "manifest declares no `provides` block"
+                )
+            if not is_content and artifact_provides:
+                die(
+                    f"{candidate_path}: runtime manifest declares `provides`, "
+                    "so this package belongs in the content lane "
+                    "(set \"kind\": \"content\" in pakrat.json)"
+                )
             if version != runtime.get("pak_version"):
                 die(
                     f"{candidate_path}: runtime pak_version "
@@ -661,6 +736,11 @@ def build_storefront(args: argparse.Namespace) -> Path:
                 die(f"{metadata_path}: package identity disagrees with history")
             if history is not None:
                 used_history_keys.add(history_key)
+            if history is not None and history.get("is_content", False) != is_content:
+                die(
+                    f"{metadata_path}: {app_id} changed lanes; published "
+                    "history cannot move between apps[] and content[]"
+                )
             versions, floor = merge_package_history(
                 history,
                 current,
@@ -669,22 +749,28 @@ def build_storefront(args: argparse.Namespace) -> Path:
                 artifacts_root,
                 base_url,
                 metadata_path,
+                is_content,
             )
             candidate_path.replace(artifact_path)
 
             current_versions.add(version)
             app_floor_versions.add(floor["version"])
-            app_packages.append(
-                {
-                    "platform": "mlp1",
-                    "runtime": "leaf",
-                    "version": floor["version"],
-                    "install_name": install_name,
-                    "runtime_manifest_path": runtime_manifest_path,
-                    "artifact": copy.deepcopy(floor["artifact"]),
-                    "versions": versions,
-                }
-            )
+            emitted = {
+                "platform": "mlp1",
+                "runtime": "leaf",
+                "version": floor["version"],
+                "install_name": install_name,
+                "runtime_manifest_path": runtime_manifest_path,
+                "artifact": copy.deepcopy(floor["artifact"]),
+                "versions": versions,
+            }
+            # In apps[] the legacy fields ARE the ungated safe floor, so they
+            # never carry a gate. In content[] they mirror the newest entry,
+            # which has one -- and omitting it would leave the legacy fields
+            # claiming an install that no gated client would accept.
+            if is_content and "min_leaf_version" in floor:
+                emitted["min_leaf_version"] = floor["min_leaf_version"]
+            app_packages.append(emitted)
 
         if len(current_versions) != 1:
             die(f"{metadata_path}: all MLP1 packages must use one app version")
@@ -696,7 +782,7 @@ def build_storefront(args: argparse.Namespace) -> Path:
             isinstance(value, str) and value for value in categories
         ):
             die(f"{metadata_path}: categories must be a string array")
-        apps.append(
+        (content if is_content else apps).append(
             {
                 "id": app_id,
                 "name": require_metadata_string(meta, "name", metadata_path),
@@ -729,6 +815,12 @@ def build_storefront(args: argparse.Namespace) -> Path:
         "generated_at": generated_at,
         "apps": apps,
     }
+    # `schema` stays 1 and the key is only emitted when it has entries: a
+    # gate-unaware client parses apps[], ignores an unknown `content` key, and
+    # never learns a content pak exists. That is the whole reason this is a
+    # new lane rather than a flag on an existing one.
+    if content:
+        storefront["content"] = content
 
     storefront_partial = storefront_path.with_suffix(".json.partial")
     storefront_partial.write_text(
@@ -736,7 +828,7 @@ def build_storefront(args: argparse.Namespace) -> Path:
     )
     storefront_partial.replace(storefront_path)
     print(f"Wrote {storefront_path}")
-    for app in apps:
+    for app in apps + content:
         for pkg in app["packages"]:
             artifact = pkg["versions"][0]["artifact"]
             print(

--- a/stage/common.mk
+++ b/stage/common.mk
@@ -38,3 +38,9 @@ REQUIRED_REPOS := Catastrophe Jawaka Thing-File ssh-server CentralScrutinizer Fu
 # Private maintainer-only repos. Bootstrap probes these and silently skips them
 # when credentials are unavailable.
 OPTIONAL_PRIVATE_REPOS := umrk-workspace
+
+# Example paks. Deliberately NOT required: each one builds from a clean clone
+# with no sibling checkout, which is the property that makes it usable as a
+# template by someone outside this workspace. Nothing in Leaf's build or
+# staging depends on them.
+OPTIONAL_EXAMPLE_REPOS := ScummVM-pak


### PR DESCRIPTION
## Summary
- generate and merge content storefront entries separately from apps
- require a Leaf gate for every content version and preserve immutable history
- register the public leaf-contracts and ScummVM-pak repositories for bootstrap and staging
- route ScummVM-pak through the generic `stage-app` policy

## Validation
- 23 pakrat local-feed tests
- app package policy smoke test
- staged the updated launcher and ScummVM pak on MLP1