### PR TITLE
Require TLS-enabled MLP1 RetroArch artifacts

### DIFF
--- a/scripts/validate-leaf-release-test.py
+++ b/scripts/validate-leaf-release-test.py
@@ -265,7 +265,7 @@ class CandidateTests(unittest.TestCase):
             encoding="utf-8",
         )
         (platform / "bin" / "retroarch.build-manifest.json").write_text(
-            json.dumps({"configure_flags": ["--enable-ffmpeg"]}),
+            json.dumps({"configure_flags": ["--enable-ffmpeg", "--enable-ssl"]}),
             encoding="utf-8",
         )
         recording_libs = platform / "lib" / "ffmpeg"
@@ -358,6 +358,25 @@ class CandidateTests(unittest.TestCase):
                 encoding="utf-8",
             )
             with self.assertRaisesRegex(MODULE.PolicyError, "recording support"):
+                MODULE.validate_candidate(args)
+
+    def test_candidate_rejects_retroarch_without_tls_support(self):
+        with tempfile.TemporaryDirectory() as raw:
+            args = self.make_candidate(Path(raw))
+            manifest = (
+                args.release_root
+                / "platforms"
+                / "mlp1"
+                / "bin"
+                / "retroarch.build-manifest.json"
+            )
+            manifest.write_text(
+                json.dumps(
+                    {"configure_flags": ["--enable-ffmpeg", "--disable-ssl"]}
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(MODULE.PolicyError, "TLS support"):
                 MODULE.validate_candidate(args)
 
     def test_candidate_rejects_missing_source_paths_capability(self):

--- a/scripts/validate-leaf-release.py
+++ b/scripts/validate-leaf-release.py
@@ -332,6 +332,8 @@ def validate_mlp1_recording_payload(platform: Path) -> None:
         or "--disable-ffmpeg" in flags
     ):
         raise PolicyError("MLP1 RetroArch was not built with FFmpeg recording support")
+    if "--enable-ssl" not in flags or "--disable-ssl" in flags:
+        raise PolicyError("MLP1 RetroArch was not built with TLS support")
 
 
 def read_staged_environment(env_path: Path) -> dict[str, str]:

--- a/scripts/validate-mlp1-retroarch-build.py
+++ b/scripts/validate-mlp1-retroarch-build.py
@@ -59,6 +59,14 @@ def main() -> None:
     if not isinstance(manifest, dict):
         fail(f"build manifest is not a JSON object: {args.manifest}")
 
+    flags = manifest.get("configure_flags")
+    if (
+        not isinstance(flags, list)
+        or "--enable-ssl" not in flags
+        or "--disable-ssl" in flags
+    ):
+        fail("RetroArch was not built with TLS support")
+
     controls = manifest.get("patch_controls")
     if not isinstance(controls, dict) or "MLP1_PATCH_SET" not in controls:
         fail("build manifest does not record patch_controls.MLP1_PATCH_SET")


### PR DESCRIPTION
## Summary

- reject reused MLP1 RetroArch artifacts that were built without TLS
- reject release candidates whose RetroArch manifest lacks `--enable-ssl`
- cover the release policy with a focused regression test

## Why

The build fix for #51 lives in the owning `retroarch-builds` repository. These checks prevent Leaf staging or a later release from silently reusing an older non-TLS artifact and reintroducing the hardcore RetroAchievements badge failure (and plaintext direct API traffic).

Depends on Utility-Muffin-Research-Kitchen/retroarch-builds#9.

## Verification

- `python3 scripts/validate-leaf-release-test.py` (24 tests)
- Python byte-compilation of all changed validators
- confirmed the validator rejects the previous non-TLS manifest
- confirmed it accepts the new cross-built manifest
- `make stage-retroarch DEVICE=mlp1`
- attached-device direct hardcore Gambatte launch of the issue's Game Boy Darkwing Duck case
- downloaded the correct game and achievement badge images, with the proper badges confirmed on screen
- clean exit back to Jawaka

Fixes #51.
