### PR TITLE
Guard stage-app against Pak Rat-owned targets

### DIFF
--- a/scripts/adb-stage-app-package-smoke.sh
+++ b/scripts/adb-stage-app-package-smoke.sh
@@ -14,6 +14,11 @@ cat >"$fixture/bin/adb" <<'EOF'
 set -u
 printf '%s\n' "$*" >>"$FAKE_ADB_LOG"
 case "$*" in
+    *'SELECT store_id'*)
+        if [ "${FAKE_ADB_OWNED:-0}" -eq 1 ]; then
+            printf 'org.umrk.fixture\tmlp1/Joe'"'"'s Calibrage.pak\n'
+        fi
+        ;;
     *package-quiesce-begin*)
         if [ "${FAKE_ADB_BEGIN_ERROR:-0}" -eq 1 ]; then
             printf '%s\n' '{"type":"error","message":"stale-generation"}'
@@ -51,6 +56,24 @@ remote_remove_marker="rm -rf -- \"\$1\""
 line_for() {
     grep -F -n -m1 -- "$1" "$FAKE_ADB_LOG" | cut -d: -f1
 }
+
+: >"$FAKE_ADB_LOG"
+owned_error="$fixture/owned.err"
+if FAKE_ADB_OWNED=1 \
+    "$ROOT_DIR/scripts/adb-stage-app-package.sh" "$fixture/local" "$remote_dir" \
+        >/dev/null 2>"$owned_error"; then
+    echo "expected Pak Rat ownership to block direct staging" >&2
+    exit 1
+fi
+grep -Fq "refusing to overwrite Pak Rat-owned package org.umrk.fixture" \
+    "$owned_error"
+grep -Fq 'SELECT store_id' "$FAKE_ADB_LOG"
+if grep -Fq package-quiesce-begin "$FAKE_ADB_LOG" ||
+   grep -Fq "$remote_remove_marker" "$FAKE_ADB_LOG" ||
+   grep -Fq ' push ' "$FAKE_ADB_LOG"; then
+    echo "Pak Rat-owned package reached the staging mutation path" >&2
+    exit 1
+fi
 
 : >"$FAKE_ADB_LOG"
 "$ROOT_DIR/scripts/adb-stage-app-package.sh" "$fixture/local" "$remote_dir" \

--- a/scripts/adb-stage-app-package.sh
+++ b/scripts/adb-stage-app-package.sh
@@ -41,6 +41,24 @@ fi
 ADB=(adb -s "$serial")
 operation_id="stage-app-$$"
 quiesced=0
+platform_id="${PLATFORM_ID:-${DEVICE:-mlp1}}"
+remote_sd="$(
+    PLATFORM_ID="$platform_id" \
+    REMOTE_SDCARD_PATH="${REMOTE_SDCARD_PATH:-auto}" \
+    ADB_SERIAL="$serial" \
+        "$ROOT_DIR/scripts/adb-resolve-umrk-sd.sh"
+)"
+install_path="${remote_dir#*/Apps/}"
+printf -v db_path_arg '%q' "$remote_sd/.umrk/$platform_id/library.db"
+pakrat_installs="$("${ADB[@]}" shell \
+    "sh -c '[ ! -f \"\$1\" ] || sqlite3 \"\$1\" \"SELECT store_id || char(9) || install_path FROM pakrat_installs;\"' sh $db_path_arg")"
+pakrat_installs="${pakrat_installs//$'\r'/}"
+while IFS=$'\t' read -r store_id owned_path; do
+    if [ "$owned_path" = "$install_path" ]; then
+        echo "refusing to overwrite Pak Rat-owned package $store_id at Apps/$install_path; uninstall it in Pak Rat before using stage-app" >&2
+        exit 1
+    fi
+done <<<"$pakrat_installs"
 
 # adb joins the remote command into one shell string. Quote the validated path
 # as one remote-shell argument, then let the inner sh script use it only as $1.
@@ -50,8 +68,8 @@ printf -v remote_dir_arg '%q' "$remote_dir"
 
 release_quiesce() {
     ADB_SERIAL="$serial" \
-    PLATFORM_ID="${PLATFORM_ID:-${DEVICE:-mlp1}}" \
-    REMOTE_SDCARD_PATH="${REMOTE_SDCARD_PATH:-auto}" \
+    PLATFORM_ID="$platform_id" \
+    REMOTE_SDCARD_PATH="$remote_sd" \
         "$ROOT_DIR/scripts/adb-package-quiesce.sh" end "$operation_id"
 }
 
@@ -67,8 +85,8 @@ on_exit() {
 trap on_exit EXIT
 
 if ! ADB_SERIAL="$serial" \
-    PLATFORM_ID="${PLATFORM_ID:-${DEVICE:-mlp1}}" \
-    REMOTE_SDCARD_PATH="${REMOTE_SDCARD_PATH:-auto}" \
+    PLATFORM_ID="$platform_id" \
+    REMOTE_SDCARD_PATH="$remote_sd" \
         "$ROOT_DIR/scripts/adb-package-quiesce.sh" begin "$operation_id"; then
     # A preflight refusal never latched the barrier; an unverified stop did.
     # A matching release is therefore a harmless best-effort cleanup in the


### PR DESCRIPTION
## Summary

- resolve the active Leaf SD before staging
- read Pak Rat ownership without mutating its database
- refuse before quiesce/delete/push when the target install path is Pak Rat-owned
- tell developers to uninstall the package in Pak Rat before direct staging

This prevents `stage-app` from replacing a token-bearing Pak Rat install with an untracked tree and leaving startup recovery permanently inconsistent.

## Tests

- `bash scripts/app-package-policy-smoke.sh`
- `make package-quiesce-smoke`
- `shellcheck scripts/adb-stage-app-package.sh scripts/adb-stage-app-package-smoke.sh`