### PR TITLE
Add uipad, a synthetic gamepad for driving app UIs over adb

### DIFF
--- a/scripts/adb-uipad.sh
+++ b/scripts/adb-uipad.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Drive a Leaf app's UI on the MLP1 with a synthetic gamepad, over adb.
+#
+#   scripts/adb-uipad.sh install         cross-compile and push the pad
+#   scripts/adb-uipad.sh start           create the pad and keep it alive
+#   scripts/adb-uipad.sh send A          press buttons (repeatable, in order)
+#   scripts/adb-uipad.sh send LEFT LEFT A
+#   scripts/adb-uipad.sh stop            destroy the pad and clean up
+#
+# Order matters: `start` must run BEFORE the app under test launches. SDL
+# enumerates joysticks once at init, so a pad created afterwards is invisible to
+# that process and the presses go to the launcher instead. See devtools/uipad.c.
+#
+# The launcher is a live Wayland client that also consumes pad input; when
+# driving an app directly, suspend it first:
+#
+#   adb shell pkill -STOP -x loong_pangu     # ... run the test ...
+#   adb shell pkill -CONT  -x loong_pangu
+#
+# Note loong_pangu is also the daemon, so jawakad IPC will not answer while it
+# is stopped. For device IPC use the on-device jawaka-platformctl instead of
+# rolling a client:
+#
+#   jawaka-platformctl --socket /tmp/jawaka-runtime/jawakad.sock request JSON
+#
+# and for reboot use scripts/adb-restart-loong.sh (`adb reboot` is a no-op here).
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LEAF_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKSPACE_DIR="${LEAF_WORKSPACE_DIR:-$(cd "$LEAF_DIR/.." && pwd)}"
+TOOLCHAIN_IMAGE="${TOOLCHAIN_IMAGE:-ghcr.io/utility-muffin-research-kitchen/mlp1-toolchain:latest}"
+
+REMOTE_BIN=/tmp/uipad
+REMOTE_FIFO=/tmp/uipad.fifo
+REMOTE_LOG=/tmp/uipad.log
+
+if [ -n "${ADB_SERIAL:-}" ]; then
+    serial="$ADB_SERIAL"
+else
+    serial="$(adb devices | awk 'NR>1 && $2=="device" {print $1; exit}')"
+    if [ -z "${serial:-}" ]; then
+        echo "No online adb device found." >&2
+        exit 1
+    fi
+fi
+ADB=(adb -s "$serial")
+
+cmd="${1:-}"
+shift || true
+
+case "$cmd" in
+install)
+    out="$LEAF_DIR/build/uipad"
+    mkdir -p "$LEAF_DIR/build"
+    # The container sees the workspace at /workspace, matching the other lanes.
+    docker run --rm -v "$WORKSPACE_DIR":/workspace -w /workspace "$TOOLCHAIN_IMAGE" \
+        /opt/mlp1-toolchain/bin/aarch64-buildroot-linux-gnu-gcc \
+        -std=gnu11 -Wall -Wextra -O2 -static \
+        -o /workspace/Leaf/build/uipad \
+        /workspace/Leaf/scripts/devtools/uipad.c
+    "${ADB[@]}" push "$out" "$REMOTE_BIN" >/dev/null
+    "${ADB[@]}" shell "chmod +x $REMOTE_BIN"
+    rm -f "$out"
+    echo "Installed $REMOTE_BIN on $serial"
+    ;;
+
+start)
+    # pkill -x matches the process NAME. Do not use pkill -f with the binary
+    # path: the adb shell's own command line contains that path, so -f kills
+    # this shell before the rest of the line runs.
+    "${ADB[@]}" shell "pkill -x uipad" >/dev/null 2>&1 || true
+    "${ADB[@]}" shell "rm -f $REMOTE_FIFO $REMOTE_LOG && mkfifo $REMOTE_FIFO && test -p $REMOTE_FIFO" \
+        || { echo "Could not create $REMOTE_FIFO on the device." >&2; exit 1; }
+    # serve opens the fifo O_RDWR itself, so no holder process is needed.
+    "${ADB[@]}" shell "setsid sh -c '$REMOTE_BIN --serve $REMOTE_FIFO > $REMOTE_LOG 2>&1' \
+                       </dev/null >/dev/null 2>&1 & exit 0" >/dev/null 2>&1
+    sleep 3
+    if "${ADB[@]}" shell "cat $REMOTE_LOG 2>/dev/null" | tr -d '\r' | grep -q ready; then
+        echo "Pad ready. Launch the app under test now."
+    else
+        echo "Pad did not come up; check $REMOTE_LOG on the device." >&2
+        exit 1
+    fi
+    ;;
+
+send)
+    if [ "$#" -eq 0 ]; then
+        echo "usage: $0 send BUTTON [BUTTON ...]" >&2
+        exit 1
+    fi
+    "${ADB[@]}" shell "echo '$*' > $REMOTE_FIFO"
+    ;;
+
+stop)
+    "${ADB[@]}" shell "echo quit > $REMOTE_FIFO 2>/dev/null" >/dev/null 2>&1 || true
+    sleep 1
+    "${ADB[@]}" shell "pkill -x uipad; rm -f $REMOTE_FIFO $REMOTE_LOG" >/dev/null 2>&1 || true
+    echo "Pad stopped."
+    ;;
+
+*)
+    sed -n '3,28p' "$0" | sed 's/^# \{0,1\}//'
+    exit 1
+    ;;
+esac

--- a/scripts/devtools/uipad.c
+++ b/scripts/devtools/uipad.c
@@ -1,0 +1,201 @@
+/*
+ * uipad — synthetic gamepad for driving Leaf app UIs on the MLP1 over adb.
+ *
+ * Build and push with scripts/adb-uipad.sh; it runs on the device, not here.
+ *
+ * Two constraints are not optional, and both are silent when violated:
+ *
+ * 1. The device must exist BEFORE the app under test starts. SDL enumerates
+ *    joysticks at init and does not pick up one that appears later, so a pad
+ *    created afterwards is invisible to that process and the presses land in
+ *    whatever else is running (usually the launcher, which then raises itself
+ *    over the app). Hence --serve: create the pad once, keep it alive, feed it
+ *    commands. Check the app log: "tracked (joystick)" is right.
+ *
+ * 2. It must clone the real Loong Gamepad identity (bus 0x0019, vendor 0x9903,
+ *    product 0x9913, version 0x0102, name "Loong Gamepad"). SDL derives its
+ *    GUID from those; with any other identity it opens the device as a mapped
+ *    game controller instead of a raw joystick and renames the face buttons --
+ *    "A" arrives as "B". The app log says "tracked (gamecontroller+joystick)"
+ *    when this has happened. jawakad's own virtual pad clones the same identity
+ *    for the same reason (Jawaka/internal/platform/input_proxy_mlp1.c).
+ *
+ * The 12 button codes below are exactly those the real pad declares, in
+ * ascending order, which is the order SDL assigns button indices and therefore
+ * matches Catastrophe's CAT__MLP1_BTN_* table.
+ *
+ *   uipad A                 press and release A
+ *   uipad LEFT LEFT A       a sequence, in order
+ *   uipad --hold 300 A      press, hold 300ms, release
+ *   uipad --serve PATH      read space-separated buttons from a fifo until "quit"
+ *
+ * Buttons: A B X Y L1 R1 L2 R2 SELECT START MENU STICK UP DOWN LEFT RIGHT
+ */
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <linux/input.h>
+#include <linux/uinput.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <stdbool.h>
+
+/* Ascending keycode order == SDL button index order. */
+static const int keys[] = {
+    BTN_SOUTH,  /* 0  B */
+    BTN_EAST,   /* 1  A */
+    BTN_NORTH,  /* 2  X */
+    BTN_WEST,   /* 3  Y */
+    BTN_TL,     /* 4  L1 */
+    BTN_TR,     /* 5  R1 */
+    BTN_TL2,    /* 6  L2 */
+    BTN_TR2,    /* 7  R2 */
+    BTN_SELECT, /* 8  */
+    BTN_START,  /* 9  */
+    BTN_MODE,   /* 10 MENU */
+    BTN_THUMBL, /* 11 STICK */
+};
+#define NKEYS ((int)(sizeof(keys) / sizeof(keys[0])))
+
+static struct { const char *name; int code; } named[] = {
+    { "B", BTN_SOUTH }, { "A", BTN_EAST }, { "X", BTN_NORTH }, { "Y", BTN_WEST },
+    { "L1", BTN_TL }, { "R1", BTN_TR }, { "L2", BTN_TL2 }, { "R2", BTN_TR2 },
+    { "SELECT", BTN_SELECT }, { "START", BTN_START }, { "MENU", BTN_MODE },
+    { "STICK", BTN_THUMBL },
+};
+
+static int fd;
+
+static void emit(int type, int code, int val)
+{
+    struct input_event ev;
+    memset(&ev, 0, sizeof(ev));
+    ev.type = type; ev.code = code; ev.value = val;
+    if (write(fd, &ev, sizeof(ev)) != (ssize_t)sizeof(ev))
+        fprintf(stderr, "uipad: write failed\n");
+}
+
+static void syn(void) { emit(EV_SYN, SYN_REPORT, 0); }
+
+static void msleep(int ms)
+{
+    struct timespec ts = { ms / 1000, (long)(ms % 1000) * 1000000L };
+    nanosleep(&ts, NULL);
+}
+
+static void do_action(const char *a, int hold, int gap)
+{
+    if (!strcmp(a, "LEFT") || !strcmp(a, "RIGHT")) {
+        int v = a[0] == 'L' ? -1 : 1;
+        emit(EV_ABS, ABS_HAT0X, v); syn(); msleep(hold);
+        emit(EV_ABS, ABS_HAT0X, 0); syn();
+    } else if (!strcmp(a, "UP") || !strcmp(a, "DOWN")) {
+        int v = a[0] == 'U' ? -1 : 1;
+        emit(EV_ABS, ABS_HAT0Y, v); syn(); msleep(hold);
+        emit(EV_ABS, ABS_HAT0Y, 0); syn();
+    } else {
+        int code = -1;
+        for (int k = 0; k < (int)(sizeof(named) / sizeof(named[0])); k++)
+            if (!strcmp(a, named[k].name)) { code = named[k].code; break; }
+        if (code < 0) { fprintf(stderr, "uipad: unknown button %s\n", a); return; }
+        emit(EV_KEY, code, 1); syn(); msleep(hold);
+        emit(EV_KEY, code, 0); syn();
+    }
+    msleep(gap);
+}
+
+int main(int argc, char **argv)
+{
+    int hold = 60, settle = 700, gap = 220;
+
+    fd = open("/dev/uinput", O_WRONLY | O_NONBLOCK);
+    if (fd < 0) { perror("open /dev/uinput"); return 1; }
+
+    ioctl(fd, UI_SET_EVBIT, EV_KEY);
+    for (int i = 0; i < NKEYS; i++) ioctl(fd, UI_SET_KEYBIT, keys[i]);
+    ioctl(fd, UI_SET_EVBIT, EV_ABS);
+    ioctl(fd, UI_SET_ABSBIT, ABS_X);
+    ioctl(fd, UI_SET_ABSBIT, ABS_Y);
+    ioctl(fd, UI_SET_ABSBIT, ABS_HAT0X);
+    ioctl(fd, UI_SET_ABSBIT, ABS_HAT0Y);
+
+    /* Mirror the Loong Gamepad exactly. The GUID SDL derives from
+       bus/vendor/product/version decides whether it opens the device as a raw
+       joystick or as a mapped game controller, and a mapped controller renames
+       the face buttons -- which is how "A" arrived as "B" and quit the app.
+       jawakad's own virtual pad clones the same identity. */
+    struct uinput_setup us;
+    memset(&us, 0, sizeof(us));
+    us.id.bustype = 0x0019;   /* BUS_HOST, as the real pad reports */
+    us.id.vendor  = 0x9903;
+    us.id.product = 0x9913;
+    us.id.version = 0x0102;
+    snprintf(us.name, sizeof(us.name), "Loong Gamepad");
+    ioctl(fd, UI_DEV_SETUP, &us);
+
+    struct uinput_abs_setup abs;
+    memset(&abs, 0, sizeof(abs));
+    abs.absinfo.minimum = -1;
+    abs.absinfo.maximum = 1;
+    abs.code = ABS_HAT0X; ioctl(fd, UI_ABS_SETUP, &abs);
+    abs.code = ABS_HAT0Y; ioctl(fd, UI_ABS_SETUP, &abs);
+    abs.absinfo.minimum = -128; abs.absinfo.maximum = 127; abs.absinfo.flat = 15;
+    abs.code = ABS_X; ioctl(fd, UI_ABS_SETUP, &abs);
+    abs.code = ABS_Y; ioctl(fd, UI_ABS_SETUP, &abs);
+
+    if (ioctl(fd, UI_DEV_CREATE) < 0) { perror("UI_DEV_CREATE"); return 1; }
+
+    const char *serve_path = NULL;
+    for (int i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "--settle") && i + 1 < argc) settle = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--hold") && i + 1 < argc) hold = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--gap") && i + 1 < argc) gap = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--serve") && i + 1 < argc) serve_path = argv[++i];
+    }
+    msleep(settle);
+
+    /* Serve mode: the device must already exist when the app under test starts,
+       because SDL enumerates joysticks once at init and never sees a pad that
+       appears later. Create it first, launch the app, then feed it commands. */
+    if (serve_path) {
+        /* O_RDWR, not O_RDONLY: as a reader-only the fifo returns EOF every time
+           the last writer closes, which is after every single send. Holding a
+           write end ourselves keeps the stream open for the whole session and
+           removes the need for a separate holder process. */
+        int ffd = open(serve_path, O_RDWR);
+        if (ffd < 0) { perror("open fifo"); return 1; }
+        FILE *in = fdopen(ffd, "r");
+        if (!in) { perror("fdopen"); return 1; }
+
+        printf("ready\n");
+        fflush(stdout);
+        char line[256];
+        while (fgets(line, sizeof(line), in)) {
+            char *nl = strchr(line, '\n');
+            if (nl) *nl = '\0';
+            if (!line[0]) continue;
+            if (!strcmp(line, "quit")) break;
+            for (char *tok = strtok(line, " \t"); tok; tok = strtok(NULL, " \t"))
+                do_action(tok, hold, gap);
+        }
+        msleep(200);
+        ioctl(fd, UI_DEV_DESTROY);
+        close(fd);
+        return 0;
+    }
+
+    for (int i = 1; i < argc; i++) {
+        const char *a = argv[i];
+        if (!strcmp(a, "--settle") || !strcmp(a, "--hold") || !strcmp(a, "--gap") ||
+            !strcmp(a, "--serve")) { i++; continue; }
+        if (!strcmp(a, "--sleep")) { msleep(atoi(argv[++i])); continue; }
+        do_action(a, hold, gap);
+    }
+
+    msleep(200);
+    ioctl(fd, UI_DEV_DESTROY);
+    close(fd);
+    return 0;
+}


### PR DESCRIPTION
Device UI verification had no input tool, so app-level device tests could not be
automated. `uipad` creates a uinput pad and feeds it button sequences over adb.

```bash
scripts/adb-uipad.sh install    # cross-compile and push
scripts/adb-uipad.sh start      # create the pad — BEFORE launching the app
scripts/adb-uipad.sh send A
scripts/adb-uipad.sh stop
```

## Two constraints are baked in

Both fail *silently* when violated, and both cost a debugging pass to find:

1. **The pad must exist before the app under test starts.** SDL enumerates
   joysticks once at init and never picks up one that appears later, so a pad
   created afterwards is invisible to that process and the presses land in the
   launcher, which then raises itself over the app. Hence `--serve`: create once,
   keep alive, feed commands. The app log tells you which happened —
   `tracked (joystick)` is right.
2. **It must clone the Loong Gamepad identity** (bus `0x0019`, vendor `0x9903`,
   product `0x9913`, version `0x0102`). SDL derives its GUID from those; with any
   other identity it opens the device as a mapped *game controller* and renames
   the face buttons, so `A` arrives as `B` — which quit the app under test
   instead of confirming. `jawakad`'s own virtual pad clones the same identity
   for the same reason.

`--serve` opens the fifo `O_RDWR` itself, so no holder process is needed: a
read-only opener sees EOF every time a writer closes, which is after every send.

## Notes

The script points at `adb-restart-loong.sh` and the on-device
`jawaka-platformctl` for IPC rather than reinventing them — `adb reboot` is a
no-op on this device.

Used to run the Fugazi ownership device matrix (12 cases, 24/24 checks).
`shellcheck` clean.