### PR TITLE
Gate assembled shader recommendation coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ LARGE_LIBRARY_FIXTURE_ENV = \
 	REMOTE_SDCARD_PATH="$(REMOTE_SDCARD_PATH)"
 
 .DEFAULT_GOAL := help
-.PHONY: help bootstrap doctor status status-internal pakrat-local-feed-test leaf-release-policy-test shader-bundle-release-policy-test input-roster-policy-test flycast-release-policy-smoke yabasanshiro-release-policy-smoke yabasanshiro-stage-policy-smoke core-rebuild-gate-test package-quiesce-smoke adb-enable-marker adb-disable-marker adb-tail-logs adb-large-library-create adb-large-library-clean adb-large-library-status adb-install-wrapper adb-uninstall-wrapper benchmark-ppsspp
+.PHONY: help bootstrap doctor status status-internal pakrat-local-feed-test leaf-release-policy-test shader-bundle-release-policy-test shader-coverage-policy-test input-roster-policy-test flycast-release-policy-smoke yabasanshiro-release-policy-smoke yabasanshiro-stage-policy-smoke core-rebuild-gate-test package-quiesce-smoke adb-enable-marker adb-disable-marker adb-tail-logs adb-large-library-create adb-large-library-clean adb-large-library-status adb-install-wrapper adb-uninstall-wrapper benchmark-ppsspp
 
 help:
 	@echo "Leaf workspace commands (DEVICE=$(DEVICE), WORKSPACE_DIR=$(WORKSPACE_DIR)):"
@@ -61,6 +61,7 @@ help:
 	@echo "  make pakrat-local-feed-test               test multi-app and exact-artifact local feeds"
 	@echo "  make leaf-release-policy-test             test release identity, artifacts, provenance, and gates"
 	@echo "  make shader-bundle-release-policy-test    test shader bundle integrity release gates"
+	@echo "  make shader-coverage-policy-test          test assembled shader coverage gates"
 	@echo "  make input-roster-policy-test             test the MLP1 paired-controller input gates"
 	@echo "  make flycast-release-policy-smoke         test standalone Flycast release gates"
 	@echo "  make yabasanshiro-release-policy-smoke    test standalone Saturn release gates"
@@ -127,6 +128,9 @@ leaf-release-policy-test:
 
 shader-bundle-release-policy-test:
 	python3 scripts/validate-shader-bundle-release-test.py
+
+shader-coverage-policy-test:
+	python3 scripts/validate-shader-coverage-test.py
 
 input-roster-policy-test:
 	python3 scripts/validate-input-roster-policy-test.py

--- a/config/mlp1-shader-coverage-exclusions.json
+++ b/config/mlp1-shader-coverage-exclusions.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": 1,
+  "exclusions": []
+}

--- a/scripts/make-sd-release-zip.sh
+++ b/scripts/make-sd-release-zip.sh
@@ -33,6 +33,8 @@ MLP1_RETROARCH_BIN="${MLP1_RETROARCH_BIN:-$RETROARCH_BUILDS_DIR/output/mlp1/bin/
 MLP1_RETROARCH_MANIFEST="${MLP1_RETROARCH_MANIFEST:-$RETROARCH_BUILDS_DIR/output/mlp1/build-manifest.json}"
 MLP1_SHADERS_DIR="${MLP1_SHADERS_DIR:-$RETROARCH_BUILDS_DIR/output/mlp1/shaders}"
 MLP1_SHADER_TOOL="${MLP1_SHADER_TOOL:-$RETROARCH_BUILDS_DIR/scripts/mlp1_shader_bundle.py}"
+MLP1_SHADER_COVERAGE_TOOL="${MLP1_SHADER_COVERAGE_TOOL:-$LEAF_ROOT/scripts/validate-shader-coverage.py}"
+MLP1_SHADER_COVERAGE_EXCLUSIONS="${MLP1_SHADER_COVERAGE_EXCLUSIONS:-$LEAF_ROOT/config/mlp1-shader-coverage-exclusions.json}"
 MLP1_ASSETS_DIR="${MLP1_ASSETS_DIR:-$RETROARCH_BUILDS_DIR/output/mlp1/assets}"
 MLP1_ASSET_TOOL="${MLP1_ASSET_TOOL:-$RETROARCH_BUILDS_DIR/scripts/mlp1_asset_bundle.py}"
 MLP1_CORES_DIR="${MLP1_CORES_DIR:-$CORES_SPRUCE_DIR/output/mlp1/cores}"
@@ -521,6 +523,11 @@ validate_shader_bundle() {
     local license_root="$2"
     python3 "$MLP1_SHADER_TOOL" validate --output "$platform_dir/shaders" ||
         die "MLP1 shader bundle release validation failed"
+    python3 "$MLP1_SHADER_COVERAGE_TOOL" \
+        --platform-dir "$platform_dir" \
+        --exclusions "$MLP1_SHADER_COVERAGE_EXCLUSIONS" \
+        --report-root "$UMRK_WORKSPACE_DIR" ||
+        die "MLP1 shader coverage release validation failed"
     [ -f "$license_root/SHADERS.md" ] ||
         die "missing shader license notice: $license_root/SHADERS.md"
 }

--- a/scripts/validate-shader-coverage-test.py
+++ b/scripts/validate-shader-coverage-test.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Mutation fixtures for the assembled shader-coverage gate."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+LEAF_ROOT = Path(__file__).resolve().parents[1]
+TOOL = Path(
+    os.environ.get(
+        "SHADER_COVERAGE_TOOL",
+        LEAF_ROOT / "scripts" / "validate-shader-coverage.py",
+    )
+)
+
+
+def write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def make_fixture(root: Path) -> tuple[Path, Path, Path]:
+    platform = root / "platform"
+    exclusions = root / "exclusions.json"
+    reports = root / "reports"
+    write_json(
+        platform / "defaults" / "systems.json",
+        {
+            "systems": [
+                {"id": "A", "default_core": "retro"},
+                {"id": "B", "default_core": "standalone"},
+                {"id": "C", "default_core": "missing"},
+            ]
+        },
+    )
+    write_json(
+        platform / "defaults" / "cores.json",
+        {
+            "cores": [
+                {
+                    "id": "retro",
+                    "type": "retroarch",
+                    "status": "packaged",
+                    "supports_menu": True,
+                },
+                {
+                    "id": "standalone",
+                    "type": "path",
+                    "status": "packaged",
+                    "supports_menu": False,
+                },
+                {
+                    "id": "missing",
+                    "type": "retroarch",
+                    "status": "missing",
+                    "supports_menu": True,
+                },
+            ]
+        },
+    )
+    write_json(
+        platform / "shaders" / "manifest.json",
+        {
+            "presets": [
+                {
+                    "path": "leaf-recommended/one.glslp",
+                    "qualification": "recommended",
+                    "intended_systems": ["A"],
+                },
+                {
+                    "path": "leaf-recommended/two.glslp",
+                    "qualification": "recommended",
+                    "intended_systems": ["A"],
+                },
+            ]
+        },
+    )
+    write_json(exclusions, {"schema_version": 1, "exclusions": []})
+    reports.mkdir()
+    return platform, exclusions, reports
+
+
+def run(platform: Path, exclusions: Path, reports: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            "python3",
+            str(TOOL),
+            "--platform-dir",
+            str(platform),
+            "--exclusions",
+            str(exclusions),
+            "--report-root",
+            str(reports),
+        ],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def expect(name: str, mutate, success: bool, message: str = "") -> None:
+    with tempfile.TemporaryDirectory(prefix="leaf-shader-coverage-") as temporary:
+        platform, exclusions, reports = make_fixture(Path(temporary))
+        mutate(platform, exclusions, reports)
+        result = run(platform, exclusions, reports)
+        if (result.returncode == 0) != success or message not in (
+            result.stdout + result.stderr
+        ):
+            wanted = "success" if success else "failure"
+            raise SystemExit(
+                f"{name}: expected {wanted} containing {message!r}\n"
+                f"stdout:\n{result.stdout}stderr:\n{result.stderr}"
+            )
+
+
+def no_change(*_args) -> None:
+    pass
+
+
+def remove_second(platform: Path, *_args) -> None:
+    path = platform / "shaders" / "manifest.json"
+    document = json.loads(path.read_text(encoding="utf-8"))
+    document["presets"].pop()
+    write_json(path, document)
+
+
+def misspell_system(platform: Path, *_args) -> None:
+    path = platform / "shaders" / "manifest.json"
+    document = json.loads(path.read_text(encoding="utf-8"))
+    document["presets"][0]["intended_systems"] = ["TYPO"]
+    write_json(path, document)
+
+
+def reclassify_core(platform: Path, *_args) -> None:
+    path = platform / "defaults" / "cores.json"
+    document = json.loads(path.read_text(encoding="utf-8"))
+    document["cores"][0].update({"type": "path", "supports_menu": False})
+    write_json(path, document)
+
+
+def add_exclusion(
+    platform: Path, exclusions: Path, reports: Path, create_report: bool
+) -> None:
+    remove_second(platform)
+    if create_report:
+        (reports / "approved.md").write_text("Approved test exclusion.\n", encoding="utf-8")
+    write_json(
+        exclusions,
+        {
+            "schema_version": 1,
+            "exclusions": [
+                {
+                    "system_id": "A",
+                    "reason": "Test-only approved exception",
+                    "report": "approved.md",
+                }
+            ],
+        },
+    )
+
+
+def valid_exclusion(platform: Path, exclusions: Path, reports: Path) -> None:
+    add_exclusion(platform, exclusions, reports, True)
+
+
+def orphan_exclusion(platform: Path, exclusions: Path, reports: Path) -> None:
+    add_exclusion(platform, exclusions, reports, False)
+
+
+def stale_exclusion(_platform: Path, exclusions: Path, reports: Path) -> None:
+    (reports / "approved.md").write_text("Old approval.\n", encoding="utf-8")
+    write_json(
+        exclusions,
+        {
+            "schema_version": 1,
+            "exclusions": [
+                {
+                    "system_id": "A",
+                    "reason": "No longer needed",
+                    "report": "approved.md",
+                }
+            ],
+        },
+    )
+
+
+expect("valid assembly", no_change, True, "1 eligible, 1 covered")
+expect("second mapping removed", remove_second, False, "A (1)")
+expect("unknown system typo", misspell_system, False, "unknown intended system")
+expect("path defaults are excluded", reclassify_core, True, "0 eligible")
+expect("report-linked exclusion", valid_exclusion, True, "1 excluded")
+expect("orphan report", orphan_exclusion, False, "report does not exist")
+expect("stale exclusion", stale_exclusion, False, "covered system A is stale")
+
+print("validate-shader-coverage-test: ok")

--- a/scripts/validate-shader-coverage.py
+++ b/scripts/validate-shader-coverage.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Validate shader coverage against an assembled platform catalog."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def load_object(path: Path) -> dict:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot read {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def indexed_rows(document: dict, key: str, source: Path) -> dict[str, dict]:
+    rows = document.get(key)
+    if not isinstance(rows, list):
+        raise ValueError(f"{source}: {key} must be an array")
+    indexed: dict[str, dict] = {}
+    for row in rows:
+        if not isinstance(row, dict) or not isinstance(row.get("id"), str):
+            raise ValueError(f"{source}: every {key} row must have a string id")
+        row_id = row["id"]
+        if row_id in indexed:
+            raise ValueError(f"{source}: duplicate {key} id {row_id}")
+        indexed[row_id] = row
+    return indexed
+
+
+def eligible_systems(systems: dict[str, dict], cores: dict[str, dict]) -> set[str]:
+    eligible = set()
+    for system_id, system in systems.items():
+        core = cores.get(system.get("default_core"))
+        if (
+            core
+            and core.get("type") == "retroarch"
+            and core.get("status") == "packaged"
+            and core.get("supports_menu") is True
+        ):
+            eligible.add(system_id)
+    return eligible
+
+
+def recommendation_coverage(manifest: dict, known_systems: set[str]) -> dict[str, set[str]]:
+    presets = manifest.get("presets")
+    if not isinstance(presets, list):
+        raise ValueError("shader manifest: presets must be an array")
+    coverage: dict[str, set[str]] = {system_id: set() for system_id in known_systems}
+    for preset in presets:
+        if not isinstance(preset, dict):
+            raise ValueError("shader manifest: every preset must be an object")
+        intended = preset.get("intended_systems")
+        if intended is None:
+            continue
+        if not isinstance(intended, list) or not all(
+            isinstance(system_id, str) for system_id in intended
+        ):
+            raise ValueError("shader manifest: intended_systems must be an array of strings")
+        unknown = sorted(set(intended) - known_systems)
+        if unknown:
+            raise ValueError(
+                "shader manifest: unknown intended system(s): " + ", ".join(unknown)
+            )
+        if preset.get("qualification") != "recommended":
+            continue
+        path = preset.get("path")
+        if not isinstance(path, str) or not path:
+            raise ValueError("shader manifest: recommended preset is missing its path")
+        for system_id in intended:
+            coverage[system_id].add(path)
+    return coverage
+
+
+def load_exclusions(
+    path: Path,
+    report_root: Path,
+    eligible: set[str],
+    coverage: dict[str, set[str]],
+) -> set[str]:
+    document = load_object(path)
+    if document.get("schema_version") != 1:
+        raise ValueError(f"{path}: schema_version must be 1")
+    rows = document.get("exclusions")
+    if not isinstance(rows, list):
+        raise ValueError(f"{path}: exclusions must be an array")
+
+    excluded = set()
+    report_root = report_root.resolve()
+    for row in rows:
+        if not isinstance(row, dict):
+            raise ValueError(f"{path}: every exclusion must be an object")
+        system_id = row.get("system_id")
+        reason = row.get("reason")
+        report = row.get("report")
+        if not isinstance(system_id, str) or not system_id:
+            raise ValueError(f"{path}: every exclusion needs a system_id")
+        if system_id in excluded:
+            raise ValueError(f"{path}: duplicate exclusion for {system_id}")
+        if system_id not in eligible:
+            raise ValueError(
+                f"{path}: exclusion for {system_id} is stale or not an eligible RetroArch default"
+            )
+        if len(coverage[system_id]) >= 2:
+            raise ValueError(f"{path}: exclusion for covered system {system_id} is stale")
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError(f"{path}: exclusion for {system_id} needs a reason")
+        if not isinstance(report, str) or not report:
+            raise ValueError(f"{path}: exclusion for {system_id} needs a report")
+        relative = Path(report)
+        if relative.is_absolute() or ".." in relative.parts:
+            raise ValueError(f"{path}: exclusion report must stay under the report root")
+        report_path = (report_root / relative).resolve()
+        if report_root not in report_path.parents or not report_path.is_file():
+            raise ValueError(f"{path}: exclusion report does not exist: {report}")
+        excluded.add(system_id)
+    return excluded
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--platform-dir",
+        type=Path,
+        required=True,
+        help="assembled platform directory containing defaults/ and shaders/",
+    )
+    parser.add_argument("--exclusions", type=Path, required=True)
+    parser.add_argument("--report-root", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    systems_path = args.platform_dir / "defaults" / "systems.json"
+    cores_path = args.platform_dir / "defaults" / "cores.json"
+    manifest_path = args.platform_dir / "shaders" / "manifest.json"
+    try:
+        systems = indexed_rows(load_object(systems_path), "systems", systems_path)
+        cores = indexed_rows(load_object(cores_path), "cores", cores_path)
+        coverage = recommendation_coverage(
+            load_object(manifest_path), set(systems)
+        )
+        eligible = eligible_systems(systems, cores)
+        excluded = load_exclusions(
+            args.exclusions, args.report_root, eligible, coverage
+        )
+        uncovered = sorted(
+            system_id
+            for system_id in eligible
+            if len(coverage[system_id]) < 2 and system_id not in excluded
+        )
+        if uncovered:
+            details = ", ".join(
+                f"{system_id} ({len(coverage[system_id])})"
+                for system_id in uncovered
+            )
+            raise ValueError(
+                "eligible systems need at least two recommended shaders or a "
+                f"report-linked exclusion: {details}"
+            )
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    covered = eligible - excluded
+    print(
+        f"shader coverage: {len(eligible)} eligible, {len(covered)} covered, "
+        f"{len(excluded)} excluded"
+    )
+    print("eligible systems: " + ", ".join(sorted(eligible)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/stage/mlp1.mk
+++ b/stage/mlp1.mk
@@ -15,6 +15,8 @@ MLP1_RETROARCH_BIN ?= $(RETROARCH_BUILDS_DIR)/output/mlp1/bin/retroarch
 MLP1_RETROARCH_MANIFEST ?= $(RETROARCH_BUILDS_DIR)/output/mlp1/build-manifest.json
 MLP1_SHADERS_DIR    ?= $(RETROARCH_BUILDS_DIR)/output/mlp1/shaders
 MLP1_SHADER_TOOL    ?= $(RETROARCH_BUILDS_DIR)/scripts/mlp1_shader_bundle.py
+MLP1_SHADER_COVERAGE_TOOL ?= $(LEAF_ROOT)/scripts/validate-shader-coverage.py
+MLP1_SHADER_COVERAGE_EXCLUSIONS ?= $(LEAF_ROOT)/config/mlp1-shader-coverage-exclusions.json
 MLP1_ASSETS_DIR     ?= $(RETROARCH_BUILDS_DIR)/output/mlp1/assets
 MLP1_ASSET_TOOL     ?= $(RETROARCH_BUILDS_DIR)/scripts/mlp1_asset_bundle.py
 MLP1_CORES_DIR     ?= $(CORES_SPRUCE_DIR)/output/mlp1/cores
@@ -184,6 +186,10 @@ assemble-jawaka: jawaka-build shader-bundle-mlp1
 	@mkdir -p "$(PLATFORM_PAYLOAD_DIR)/shaders"
 	@cp -Rf "$(MLP1_SHADERS_DIR)/." "$(PLATFORM_PAYLOAD_DIR)/shaders/"
 	@python3 "$(MLP1_SHADER_TOOL)" validate --output "$(PLATFORM_PAYLOAD_DIR)/shaders"
+	@python3 "$(MLP1_SHADER_COVERAGE_TOOL)" \
+		--platform-dir "$(PLATFORM_PAYLOAD_DIR)" \
+		--exclusions "$(MLP1_SHADER_COVERAGE_EXCLUSIONS)" \
+		--report-root "$(UMRK_WORKSPACE_DIR)"
 	@# RetroArch menu assets. Ozone reads every icon and font it draws from
 	@# assets_directory, which jawaka-retroarch-runner points here; without this
 	@# tree Ozone has no icons and falls back to a bitmap font that cannot draw CJK.


### PR DESCRIPTION
## Summary\n- derive shader eligibility from the assembled system and core catalogs\n- require two recommendation rows or a report-linked exclusion\n- enforce the guard during MLP1 staging and release assembly\n\n## Verification\n- make shader-coverage-policy-test\n- current assembled inputs: 34 eligible, 34 covered, 0 excluded\n- minimum coverage, known-system, eligibility, and report guards mutation-verified