### PR TITLE
Gate the global shader scope on the assembled Fugazi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ LARGE_LIBRARY_FIXTURE_ENV = \
 	REMOTE_SDCARD_PATH="$(REMOTE_SDCARD_PATH)"
 
 .DEFAULT_GOAL := help
-.PHONY: help bootstrap doctor status status-internal pakrat-local-feed-test leaf-release-policy-test shader-bundle-release-policy-test shader-coverage-policy-test input-roster-policy-test flycast-release-policy-smoke yabasanshiro-release-policy-smoke yabasanshiro-stage-policy-smoke core-rebuild-gate-test package-quiesce-smoke adb-enable-marker adb-disable-marker adb-tail-logs adb-large-library-create adb-large-library-clean adb-large-library-status adb-install-wrapper adb-uninstall-wrapper benchmark-ppsspp
+.PHONY: help bootstrap doctor status status-internal pakrat-local-feed-test leaf-release-policy-test shader-bundle-release-policy-test shader-coverage-policy-test shader-global-scope-policy-test input-roster-policy-test flycast-release-policy-smoke yabasanshiro-release-policy-smoke yabasanshiro-stage-policy-smoke core-rebuild-gate-test package-quiesce-smoke adb-enable-marker adb-disable-marker adb-tail-logs adb-large-library-create adb-large-library-clean adb-large-library-status adb-install-wrapper adb-uninstall-wrapper benchmark-ppsspp
 
 help:
 	@echo "Leaf workspace commands (DEVICE=$(DEVICE), WORKSPACE_DIR=$(WORKSPACE_DIR)):"
@@ -62,6 +62,7 @@ help:
 	@echo "  make leaf-release-policy-test             test release identity, artifacts, provenance, and gates"
 	@echo "  make shader-bundle-release-policy-test    test shader bundle integrity release gates"
 	@echo "  make shader-coverage-policy-test          test assembled shader coverage gates"
+	@echo "  make shader-global-scope-policy-test      test the assembled Fugazi resolver floor"
 	@echo "  make input-roster-policy-test             test the MLP1 paired-controller input gates"
 	@echo "  make flycast-release-policy-smoke         test standalone Flycast release gates"
 	@echo "  make yabasanshiro-release-policy-smoke    test standalone Saturn release gates"
@@ -131,6 +132,9 @@ shader-bundle-release-policy-test:
 
 shader-coverage-policy-test:
 	python3 scripts/validate-shader-coverage-test.py
+
+shader-global-scope-policy-test:
+	python3 scripts/validate-shader-global-scope-test.py
 
 input-roster-policy-test:
 	python3 scripts/validate-input-roster-policy-test.py

--- a/scripts/make-sd-release-zip.sh
+++ b/scripts/make-sd-release-zip.sh
@@ -35,6 +35,7 @@ MLP1_SHADERS_DIR="${MLP1_SHADERS_DIR:-$RETROARCH_BUILDS_DIR/output/mlp1/shaders}
 MLP1_SHADER_TOOL="${MLP1_SHADER_TOOL:-$RETROARCH_BUILDS_DIR/scripts/mlp1_shader_bundle.py}"
 MLP1_SHADER_COVERAGE_TOOL="${MLP1_SHADER_COVERAGE_TOOL:-$LEAF_ROOT/scripts/validate-shader-coverage.py}"
 MLP1_SHADER_COVERAGE_EXCLUSIONS="${MLP1_SHADER_COVERAGE_EXCLUSIONS:-$LEAF_ROOT/config/mlp1-shader-coverage-exclusions.json}"
+MLP1_SHADER_GLOBAL_SCOPE_TOOL="${MLP1_SHADER_GLOBAL_SCOPE_TOOL:-$LEAF_ROOT/scripts/validate-shader-global-scope.py}"
 MLP1_ASSETS_DIR="${MLP1_ASSETS_DIR:-$RETROARCH_BUILDS_DIR/output/mlp1/assets}"
 MLP1_ASSET_TOOL="${MLP1_ASSET_TOOL:-$RETROARCH_BUILDS_DIR/scripts/mlp1_asset_bundle.py}"
 MLP1_CORES_DIR="${MLP1_CORES_DIR:-$CORES_SPRUCE_DIR/output/mlp1/cores}"
@@ -532,6 +533,36 @@ validate_shader_bundle() {
         die "missing shader license notice: $license_root/SHADERS.md"
 }
 
+# Jawaka compiles the All RetroArch shader scope in or out and cannot see which
+# Fugazi ships beside it. A global save can replace a preset Fugazi owns, so an
+# enabled scope needs a Fugazi that can resolve the resulting conflict.
+validate_global_shader_scope() {
+    local release_root="$1"
+    local menu_binary="$release_root/platforms/$DEVICE/launcher/bin/jawaka-menu"
+    local source_args=()
+    local paks=()
+
+    [ -f "$menu_binary" ] || die "missing assembled menu binary: $menu_binary"
+    while IFS= read -r pak; do
+        paks+=("$pak")
+    done < <(find "$release_root/Apps" -maxdepth 2 -type d -name 'Fugazi.pak' 2>/dev/null | sort)
+
+    if [ "${#paks[@]}" -eq 0 ]; then
+        echo "global shader scope: no Fugazi in this release; nothing to gate"
+        return 0
+    fi
+    [ "${#paks[@]}" -eq 1 ] || die "release contains more than one Fugazi pak"
+
+    if [ -f "$JAWAKA_DIR/cmd/jawaka-menu/main.c" ]; then
+        source_args=(--jawaka-source "$JAWAKA_DIR/cmd/jawaka-menu/main.c")
+    fi
+    python3 "$MLP1_SHADER_GLOBAL_SCOPE_TOOL" \
+        --menu-binary "$menu_binary" \
+        --fugazi-pak "${paks[0]}" \
+        "${source_args[@]}" ||
+        die "assembled Fugazi does not support the enabled global shader scope"
+}
+
 validate_portmaster_integration() {
     local release_root="$1"
     python3 - "$release_root" <<'EOF' || die "PortMaster integration validation failed"
@@ -1019,6 +1050,7 @@ build_install_zip() {
     done
     sync_platform_managed_apps_manifest "$RELEASE_ROOT/platforms/mlp1/manifest.json" "$MANAGED_APPS_FILE"
     validate_pakrat_owned_apps "$RELEASE_ROOT"
+    validate_global_shader_scope "$RELEASE_ROOT"
     validate_portmaster_integration "$RELEASE_ROOT"
     audit_mlp1_build_tuning "$RELEASE_ROOT"
     finalize_component_provenance

--- a/scripts/validate-shader-global-scope-test.py
+++ b/scripts/validate-shader-global-scope-test.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Mutation fixtures for the assembled global shader scope gate."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+LEAF_ROOT = Path(__file__).resolve().parents[1]
+TOOL = Path(
+    os.environ.get(
+        "SHADER_GLOBAL_SCOPE_TOOL",
+        LEAF_ROOT / "scripts" / "validate-shader-global-scope.py",
+    )
+)
+
+DISABLED_MARKER = b"Requires Fugazi resolver"
+
+
+def make_fixture(root: Path) -> tuple[Path, Path, Path]:
+    """An assembly with the scope enabled and a resolver-carrying Fugazi."""
+    menu = root / "platforms" / "mlp1" / "launcher" / "bin" / "jawaka-menu"
+    menu.parent.mkdir(parents=True, exist_ok=True)
+    # Real menu binaries keep the runtime guard message whether or not the
+    # scope is gated; only the row hint tracks the constant.
+    menu.write_bytes(
+        b"\x7fELF fixture\x00"
+        b"All RetroArch requires a Leaf build with Fugazi's conflict resolver.\x00"
+    )
+
+    pak = root / "Apps" / "mlp1" / "Fugazi.pak"
+    pak.mkdir(parents=True, exist_ok=True)
+    (pak / "pak.json").write_text(
+        json.dumps({"name": "Fugazi", "platform": "mlp1", "pak_version": "0.2.0"}),
+        encoding="utf-8",
+    )
+
+    source = root / "jawaka" / "cmd" / "jawaka-menu" / "main.c"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        "/* comment */\n#define JW_FUGAZI_RESOLVER_ASSEMBLED true\n",
+        encoding="utf-8",
+    )
+    return menu, pak, source
+
+
+def run(menu: Path, pak: Path, source: Path | None) -> subprocess.CompletedProcess:
+    command = [
+        "python3",
+        str(TOOL),
+        "--menu-binary",
+        str(menu),
+        "--fugazi-pak",
+        str(pak),
+    ]
+    if source is not None:
+        command += ["--jawaka-source", str(source)]
+    return subprocess.run(
+        command,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def expect(name: str, mutate, success: bool, message: str = "", pass_source=True) -> None:
+    with tempfile.TemporaryDirectory(prefix="leaf-shader-global-scope-") as temporary:
+        menu, pak, source = make_fixture(Path(temporary))
+        mutate(menu, pak, source)
+        result = run(menu, pak, source if pass_source else None)
+        if (result.returncode == 0) != success or message not in (
+            result.stdout + result.stderr
+        ):
+            wanted = "success" if success else "failure"
+            raise SystemExit(
+                f"{name}: expected {wanted} containing {message!r}\n"
+                f"stdout:\n{result.stdout}stderr:\n{result.stderr}"
+            )
+
+
+def set_version(pak: Path, value: object) -> None:
+    path = pak / "pak.json"
+    document = json.loads(path.read_text(encoding="utf-8"))
+    document["pak_version"] = value
+    path.write_text(json.dumps(document), encoding="utf-8")
+
+
+def gate_off(menu: Path, source: Path) -> None:
+    menu.write_bytes(menu.read_bytes() + DISABLED_MARKER + b"\x00")
+    source.write_text(
+        "#define JW_FUGAZI_RESOLVER_ASSEMBLED false\n", encoding="utf-8"
+    )
+
+
+def no_change(*_args) -> None:
+    pass
+
+
+def older_fugazi(_menu: Path, pak: Path, _source: Path) -> None:
+    set_version(pak, "0.1.0")
+
+
+def newer_fugazi(_menu: Path, pak: Path, _source: Path) -> None:
+    set_version(pak, "0.3.1")
+
+
+def gated_off_with_older_fugazi(menu: Path, pak: Path, source: Path) -> None:
+    gate_off(menu, source)
+    set_version(pak, "0.1.0")
+
+
+def stale_binary(menu: Path, _pak: Path, _source: Path) -> None:
+    # Source enables the scope but the payload still holds a gated-off build.
+    menu.write_bytes(menu.read_bytes() + DISABLED_MARKER + b"\x00")
+
+
+def missing_pak(_menu: Path, pak: Path, _source: Path) -> None:
+    (pak / "pak.json").unlink()
+
+
+def unparsable_version(_menu: Path, pak: Path, _source: Path) -> None:
+    set_version(pak, "0.2")
+
+
+def missing_gate_define(_menu: Path, _pak: Path, source: Path) -> None:
+    source.write_text("/* the constant was renamed */\n", encoding="utf-8")
+
+
+def empty_binary(menu: Path, _pak: Path, _source: Path) -> None:
+    menu.write_bytes(b"")
+
+
+expect("resolver-carrying assembly", no_change, True, "meets the 0.2.0 resolver floor")
+expect("older Fugazi beside enabled scope", older_fugazi, False, "below the 0.2.0 floor")
+expect("newer Fugazi", newer_fugazi, True, "meets the 0.2.0 resolver floor")
+expect("scope gated off", gated_off_with_older_fugazi, True, "disabled in this build")
+expect("stale menu payload", stale_binary, False, "does not match the Jawaka source gate")
+expect("missing pak manifest", missing_pak, False, "missing assembled Fugazi pak manifest")
+expect("unparsable version", unparsable_version, False, "not a three-part numeric version")
+expect("renamed gate constant", missing_gate_define, False, "no JW_FUGAZI_RESOLVER_ASSEMBLED")
+expect("empty menu binary", empty_binary, False, "assembled menu binary is empty")
+
+# Without the source on hand the binary alone decides, and an assembled menu
+# that dropped the gated-off hint must still enforce the floor.
+expect(
+    "binary-only enabled scope",
+    older_fugazi,
+    False,
+    "below the 0.2.0 floor",
+    pass_source=False,
+)
+expect(
+    "binary-only gated off",
+    gated_off_with_older_fugazi,
+    True,
+    "disabled in this build",
+    pass_source=False,
+)
+
+print("validate-shader-global-scope-test: ok")

--- a/scripts/validate-shader-global-scope.py
+++ b/scripts/validate-shader-global-scope.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Validate the assembled Fugazi against Jawaka's global shader scope.
+
+Jawaka's in-game picker can save a shader preset at RetroArch's global scope.
+That save can replace a preset another app owns, so it is only safe when the
+assembled Leaf build also ships a Fugazi that recognizes a foreign global
+preset, keeps one recoverable predecessor, and can resolve the resulting
+current-preset-plus-backup conflict. Fugazi 0.2.0 is the first release with
+that resolver.
+
+Jawaka decides the scope at compile time with JW_FUGAZI_RESOLVER_ASSEMBLED and
+cannot see which Fugazi Leaf assembles beside it. This gate closes that gap by
+reading both assembled artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+# Fugazi 0.2.0 carries the ownership-safe conflict resolver (Fugazi PRs #1 and
+# #2). Raise this only when a newer Fugazi becomes required for the scope to
+# stay recoverable, never to paper over an older assembled app.
+RESOLVER_FLOOR = (0, 2, 0)
+
+# Jawaka draws this row hint only while the scope is gated off, so the compiled
+# menu carries the literal exactly when the constant is false.
+DISABLED_MARKER = b"Requires Fugazi resolver"
+
+GATE_PATTERN = re.compile(
+    r"^#define\s+JW_FUGAZI_RESOLVER_ASSEMBLED\s+(true|false)\s*$",
+    re.MULTILINE,
+)
+
+
+def gate_from_source(path: Path) -> bool:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        raise ValueError(f"cannot read Jawaka source {path}: {exc}") from exc
+    matches = GATE_PATTERN.findall(text)
+    if not matches:
+        raise ValueError(f"{path}: no JW_FUGAZI_RESOLVER_ASSEMBLED definition")
+    if len(set(matches)) > 1:
+        raise ValueError(f"{path}: conflicting JW_FUGAZI_RESOLVER_ASSEMBLED definitions")
+    return matches[0] == "true"
+
+
+def gate_from_binary(path: Path) -> bool:
+    try:
+        blob = path.read_bytes()
+    except OSError as exc:
+        raise ValueError(f"cannot read assembled menu binary {path}: {exc}") from exc
+    if not blob:
+        raise ValueError(f"{path}: assembled menu binary is empty")
+    return DISABLED_MARKER not in blob
+
+
+def parse_version(raw: object, source: Path) -> tuple[int, ...]:
+    if not isinstance(raw, str) or not raw.strip():
+        raise ValueError(f"{source}: pak_version must be a non-empty string")
+    parts = raw.strip().split(".")
+    if len(parts) != 3 or not all(part.isdigit() for part in parts):
+        raise ValueError(f"{source}: pak_version {raw!r} is not a three-part numeric version")
+    return tuple(int(part) for part in parts)
+
+
+def read_fugazi_version(path: Path) -> tuple[tuple[int, ...], str]:
+    manifest = path / "pak.json" if path.is_dir() else path
+    if not manifest.is_file():
+        raise ValueError(f"missing assembled Fugazi pak manifest: {manifest}")
+    try:
+        document = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot read {manifest}: {exc}") from exc
+    if not isinstance(document, dict):
+        raise ValueError(f"{manifest} must contain a JSON object")
+    raw = document.get("pak_version")
+    return parse_version(raw, manifest), str(raw).strip()
+
+
+def format_version(version: tuple[int, ...]) -> str:
+    return ".".join(str(part) for part in version)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--menu-binary",
+        type=Path,
+        required=True,
+        help="assembled jawaka-menu binary",
+    )
+    parser.add_argument(
+        "--fugazi-pak",
+        type=Path,
+        required=True,
+        help="assembled Fugazi.pak directory or its pak.json",
+    )
+    parser.add_argument(
+        "--jawaka-source",
+        type=Path,
+        help="cmd/jawaka-menu/main.c the payload was built from, when available",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        binary_gate = gate_from_binary(args.menu_binary)
+        source_gate = (
+            gate_from_source(args.jawaka_source) if args.jawaka_source else None
+        )
+        # A payload built from different source than the checkout on hand is a
+        # stale assembly. Report it rather than trusting either half.
+        if source_gate is not None and source_gate != binary_gate:
+            raise ValueError(
+                "assembled jawaka-menu does not match the Jawaka source gate: "
+                f"source says {'enabled' if source_gate else 'disabled'}, "
+                f"binary says {'enabled' if binary_gate else 'disabled'}"
+            )
+        enabled = binary_gate if source_gate is None else source_gate
+
+        version, raw = read_fugazi_version(args.fugazi_pak)
+        if enabled and version < RESOLVER_FLOOR:
+            raise ValueError(
+                f"assembled Fugazi {raw} is below the "
+                f"{format_version(RESOLVER_FLOOR)} floor required by the enabled "
+                "All RetroArch shader scope"
+            )
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if enabled:
+        print(
+            f"global shader scope: enabled; assembled Fugazi {raw} meets the "
+            f"{format_version(RESOLVER_FLOOR)} resolver floor"
+        )
+    else:
+        print(
+            f"global shader scope: disabled in this build; assembled Fugazi {raw} "
+            "is not gated"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Jawaka #111 shipped the in-game picker's **All RetroArch** scope enabled. That scope is only recoverable when the assembled Leaf build also ships Fugazi 0.2.0 or newer: a Leaf global save can replace a preset Fugazi owns, and only 0.2.0 has the resolver that can undo the resulting current-preset-plus-backup state (Decision 5 in `umrk-workspace/plans/retroarch-shader-ux-and-fugazi-ownership.md`).

Nothing enforced that. Jawaka's wiring contract only asserts the value of its own constant and cannot see what Leaf assembles beside it; Leaf builds Fugazi from whatever revision the sibling checkout happens to hold.

## What this adds

`scripts/validate-shader-global-scope.py` reads the two assembled artifacts and fails the release when an enabled scope is paired with a Fugazi below the floor. It decides whether the scope is enabled from the Jawaka source the payload was built from, cross-checks that against the compiled menu binary, and fails when they disagree rather than trusting either half — a stale payload is one of the ways this could silently go wrong. With no source on hand the binary decides alone, and an inconclusive binary enforces the floor rather than skipping it.

The binary signal is the `Requires Fugazi resolver` row hint, which Jawaka emits only while the scope is gated off. That was verified both ways on a real build rather than assumed: the same source compiled with the constant `false` carries the literal and with `true` does not, because the constant-folded ternary never emits the unused branch.

Wired into `make-sd-release-zip.sh` after the apps are packaged, which is the first point where the launcher payload and the Fugazi pak exist in one tree. A release with no Fugazi says so and passes; two Fugazi paks fail.

## Verification

`make shader-global-scope-policy-test` covers eleven fixtures: the valid assembly, an older Fugazi beside an enabled scope, a newer Fugazi, a gated-off build carrying an old Fugazi, a stale menu payload disagreeing with source, a missing pak manifest, an unparsable version, a renamed constant, an empty binary, and both binary-only paths.

Mutation-verified against the real staged artifacts as well, not only fixtures: the current assembly passes, and the same menu binary with a 0.1.0 Fugazi manifest fails with `assembled Fugazi 0.1.0 is below the 0.2.0 floor`. The release-tree path assumptions were exercised against a mimic built from the real staged payload and pak.

`shader-coverage-policy-test` and `leaf-release-policy-test` still pass.