### PR TITLE
Stage Fun DraStic as the second NDS emulator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ LARGE_LIBRARY_FIXTURE_ENV = \
 	REMOTE_SDCARD_PATH="$(REMOTE_SDCARD_PATH)"
 
 .DEFAULT_GOAL := help
-.PHONY: help bootstrap doctor status status-internal pakrat-local-feed-test leaf-release-policy-test shader-bundle-release-policy-test input-roster-policy-test flycast-release-policy-smoke yabasanshiro-release-policy-smoke yabasanshiro-stage-policy-smoke core-rebuild-gate-test package-quiesce-smoke adb-enable-marker adb-disable-marker adb-tail-logs adb-large-library-create adb-large-library-clean adb-large-library-status adb-install-wrapper adb-uninstall-wrapper benchmark-ppsspp
+.PHONY: help bootstrap doctor status status-internal pakrat-local-feed-test leaf-release-policy-test shader-bundle-release-policy-test input-roster-policy-test flycast-release-policy-smoke yabasanshiro-release-policy-smoke yabasanshiro-stage-policy-smoke fun-drastic-release-policy-smoke fun-drastic-stage-policy-smoke core-rebuild-gate-test package-quiesce-smoke adb-enable-marker adb-disable-marker adb-tail-logs adb-large-library-create adb-large-library-clean adb-large-library-status adb-install-wrapper adb-uninstall-wrapper benchmark-ppsspp
 
 help:
 	@echo "Leaf workspace commands (DEVICE=$(DEVICE), WORKSPACE_DIR=$(WORKSPACE_DIR)):"
@@ -41,6 +41,7 @@ help:
 	@echo "  make stage-emulator EMULATOR=mupen64plus DEVICE=mlp1 stage standalone N64"
 	@echo "  make stage-emulator EMULATOR=flycast DEVICE=mlp1 stage standalone Dreamcast"
 	@echo "  make stage-emulator EMULATOR=yabasanshiro DEVICE=mlp1 stage standalone Saturn"
+	@echo "  make stage-emulator EMULATOR=fun-drastic DEVICE=mlp1 FUN_DRASTIC_ARCHIVE=... stage Fun DraStic"
 	@echo "  make stage-emulators DEVICE=mlp1          stage standalone emulators"
 	@echo "  make stage-app APP=CentralScrutinizer DEVICE=mlp1 stage a single app repo"
 	@echo "  make stage-app APP=Leaf-Itchio-Pak DEVICE=mlp1 explicitly stage the optional Itch.io app"
@@ -65,6 +66,7 @@ help:
 	@echo "  make flycast-release-policy-smoke         test standalone Flycast release gates"
 	@echo "  make yabasanshiro-release-policy-smoke    test standalone Saturn release gates"
 	@echo "  make yabasanshiro-stage-policy-smoke      test standalone Saturn dispatch"
+	@echo "  make fun-drastic-release-policy-smoke fun-drastic-stage-policy-smoke     test the second NDS emulator release gates"
 	@echo "  make core-rebuild-gate-test               test explicit long core-rebuild authorization"
 	@echo "  make package-quiesce-smoke                test fail-closed stage-app service barrier"
 	@echo "  make adb-enable-marker                    enable Leaf launcher marker"
@@ -88,6 +90,12 @@ yabasanshiro-release-policy-smoke:
 
 yabasanshiro-stage-policy-smoke:
 	@bash scripts/yabasanshiro-stage-policy-smoke.sh
+
+fun-drastic-release-policy-smoke:
+	@python3 scripts/validate-fun-drastic-release-test.py
+
+fun-drastic-stage-policy-smoke:
+	@bash scripts/fun-drastic-stage-policy-smoke.sh
 
 doctor:
 	@LEAF_WORKSPACE_DIR="$(WORKSPACE_DIR)" TOOLCHAIN_IMAGE="$(TOOLCHAIN_IMAGE)" scripts/doctor.sh

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -22,6 +22,7 @@ url_for() {
         N64-standalone)              echo "https://github.com/Utility-Muffin-Research-Kitchen/leaf-n64-standalone.git" ;;
         Flycast-standalone)          echo "https://github.com/Utility-Muffin-Research-Kitchen/Flycast-standalone.git" ;;
         Yabasanshiro-standalone)     echo "https://github.com/Utility-Muffin-Research-Kitchen/Yabasanshiro-standalone.git" ;;
+        Fun-Drastic-standalone)      echo "https://github.com/Utility-Muffin-Research-Kitchen/Fun-Drastic-standalone.git" ;;
         retroarch-builds)            echo "https://github.com/Utility-Muffin-Research-Kitchen/retroarch-builds.git" ;;
         Cores-spruce)                echo "https://github.com/Utility-Muffin-Research-Kitchen/Cores-spruce.git" ;;
         mlp1-toolchain)              echo "https://github.com/Utility-Muffin-Research-Kitchen/mlp1-toolchain.git" ;;

--- a/scripts/fun-drastic-stage-policy-smoke.sh
+++ b/scripts/fun-drastic-stage-policy-smoke.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Leaf dispatches Fun DraStic to the product repo and never reimplements the
+# archive extraction. This proves the dispatch, the archive passthrough, and
+# the deployment directory without touching a device or a real archive.
+
+LEAF_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/leaf-fun-drastic-stage.XXXXXX")"
+trap 'rm -rf "$fixture"' EXIT
+
+repo="$fixture/Fun-Drastic-standalone"
+mkdir -p "$fixture/bin" "$repo"
+
+# The reviewed archive is supplied explicitly and must reach the product repo
+# unchanged; a dispatcher that dropped it would fail the build there, not here.
+cat >"$repo/Makefile" <<'MAKEFILE'
+.PHONY: package-mlp1
+package-mlp1:
+	@test "$(FUN_DRASTIC_ARCHIVE)" = /fixture/drastic.zip
+	@mkdir -p output/mlp1/fun-drastic/bin
+	@printf '#!/bin/sh\nexit 0\n' >output/mlp1/fun-drastic/launch.sh
+	@chmod 755 output/mlp1/fun-drastic/launch.sh
+MAKEFILE
+
+cat >"$fixture/bin/adb" <<'ADB'
+#!/bin/sh
+printf '%s\n' "$*" >>"$FAKE_ADB_LOG"
+exit 0
+ADB
+chmod 755 "$fixture/bin/adb"
+
+expected_url="https://github.com/Utility-Muffin-Research-Kitchen/Fun-Drastic-standalone.git"
+actual_url="$(bash -c 'script="$1"; set --; source "$script"; url_for Fun-Drastic-standalone' _ "$LEAF_ROOT/scripts/bootstrap.sh")"
+[ "$actual_url" = "$expected_url" ]
+
+export PATH="$fixture/bin:$PATH"
+export ADB_SERIAL="fixture-device"
+export FAKE_ADB_LOG="$fixture/adb.log"
+
+make -s -C "$LEAF_ROOT" stage-emulator \
+    DEVICE=mlp1 \
+    EMULATOR=fun-drastic \
+    LEAF_WORKSPACE_DIR="$fixture" \
+    FUN_DRASTIC_STANDALONE_DIR="$repo" \
+    FUN_DRASTIC_ARCHIVE=/fixture/drastic.zip \
+    DEVICE_OVERLAY="$fixture/no-overlay" \
+    REMOTE_SDCARD_PATH=/mnt/sdcard >/dev/null
+
+grep -Fq "push $repo/output/mlp1/fun-drastic/. /mnt/sdcard/.system/leaf/platforms/mlp1/emulators/fun-drastic/" \
+    "$FAKE_ADB_LOG"
+
+# The default emulator must not be disturbed by staging the alternate.
+if grep -Fq "emulators/drastic/" "$FAKE_ADB_LOG"; then
+    echo "staging Fun DraStic touched the primary DraStic directory" >&2
+    exit 1
+fi
+
+echo "PASS fun-drastic-stage-policy-smoke"

--- a/scripts/make-sd-release-zip.sh
+++ b/scripts/make-sd-release-zip.sh
@@ -9,7 +9,7 @@ WORKSPACE_DIR="${LEAF_WORKSPACE_DIR:-$(cd "$LEAF_ROOT/.." && pwd)}"
 
 DEVICE="${DEVICE:-mlp1}"
 STAGE_APPS="${STAGE_APPS-ssh-server Thing-File CentralScrutinizer Fugazi joes-calibrage retroarch-builds}"
-STAGE_EMULATORS="${STAGE_EMULATORS-ppsspp drastic mupen64plus flycast yabasanshiro}"
+STAGE_EMULATORS="${STAGE_EMULATORS-ppsspp drastic mupen64plus flycast yabasanshiro fun-drastic}"
 PUBLIC_ROOT_DIRS="${PUBLIC_ROOT_DIRS-Roms Images Videos Apps BIOS Saves States Cheats}"
 RELEASE_BUILD="${RELEASE_BUILD:-$LEAF_ROOT/build/release}"
 STAGE_BUILD="${STAGE_BUILD:-$LEAF_ROOT/build/stage/mlp1}"
@@ -22,6 +22,8 @@ STEWARD_NDS_DIR="${STEWARD_NDS_DIR:-$WORKSPACE_DIR/steward-fu-nds}"
 N64_STANDALONE_DIR="${N64_STANDALONE_DIR:-$WORKSPACE_DIR/N64-standalone}"
 FLYCAST_STANDALONE_DIR="${FLYCAST_STANDALONE_DIR:-$WORKSPACE_DIR/Flycast-standalone}"
 YABASANSHIRO_STANDALONE_DIR="${YABASANSHIRO_STANDALONE_DIR:-$WORKSPACE_DIR/Yabasanshiro-standalone}"
+FUN_DRASTIC_STANDALONE_DIR="${FUN_DRASTIC_STANDALONE_DIR:-$WORKSPACE_DIR/Fun-Drastic-standalone}"
+FUN_DRASTIC_ARCHIVE="${FUN_DRASTIC_ARCHIVE:-}"
 RETROARCH_BUILDS_DIR="${RETROARCH_BUILDS_DIR:-$WORKSPACE_DIR/retroarch-builds}"
 CORES_SPRUCE_DIR="${CORES_SPRUCE_DIR:-$WORKSPACE_DIR/Cores-spruce}"
 LAUNCHER_SWITCHER_DIR="${LAUNCHER_SWITCHER_DIR:-$WORKSPACE_DIR/miniloong-launcher-switcher}"
@@ -44,6 +46,7 @@ MLP1_DRASTIC_PACKAGE="${MLP1_DRASTIC_PACKAGE:-$LEAF_ROOT/build/drastic/mlp1/dras
 MLP1_MUPEN64PLUS_PACKAGE="${MLP1_MUPEN64PLUS_PACKAGE:-$N64_STANDALONE_DIR/output/mlp1/mupen64plus}"
 MLP1_FLYCAST_PACKAGE="${MLP1_FLYCAST_PACKAGE:-$FLYCAST_STANDALONE_DIR/output/mlp1/flycast}"
 MLP1_YABASANSHIRO_PACKAGE="${MLP1_YABASANSHIRO_PACKAGE:-$YABASANSHIRO_STANDALONE_DIR/output/mlp1/yabasanshiro}"
+MLP1_FUN_DRASTIC_PACKAGE="${MLP1_FUN_DRASTIC_PACKAGE:-$FUN_DRASTIC_STANDALONE_DIR/output/mlp1/fun-drastic}"
 # Read the canonical patch set rather than carrying a second copy of it. Two
 # hand-maintained defaults drifted apart twice; the file is the single source.
 MLP1_RETROARCH_PATCH_SET_FILE="${MLP1_RETROARCH_PATCH_SET_FILE:-$LEAF_ROOT/config/mlp1-retroarch-patch-set.txt}"
@@ -64,7 +67,7 @@ Environment:
   REBUILD_CORES=1  explicitly allow missing/stale stock-parity cores to compile
   FORCE_REBUILD_CORES=1  with REBUILD_CORES=1, bypass every valid core cache hit
   STAGE_APPS="ssh-server Thing-File CentralScrutinizer Fugazi joes-calibrage retroarch-builds"
-  STAGE_EMULATORS="ppsspp drastic mupen64plus flycast yabasanshiro"
+  STAGE_EMULATORS="ppsspp drastic mupen64plus flycast yabasanshiro fun-drastic"
 EOF
 }
 
@@ -165,6 +168,12 @@ configure_release_components() {
         *" yabasanshiro "*)
             RELEASE_COMPONENT_ARGS+=(--component "emulator:yabasanshiro=$YABASANSHIRO_STANDALONE_DIR")
             REQUIRED_COMPONENT_ARGS+=(--required-component "emulator:yabasanshiro")
+            ;;
+    esac
+    case " $STAGE_EMULATORS " in
+        *" fun-drastic "*)
+            RELEASE_COMPONENT_ARGS+=(--component "emulator:fun-drastic=$FUN_DRASTIC_STANDALONE_DIR")
+            REQUIRED_COMPONENT_ARGS+=(--required-component "emulator:fun-drastic")
             ;;
     esac
 }
@@ -775,6 +784,18 @@ package_emulator() {
             package_dir="$MLP1_FLYCAST_PACKAGE"
             remote_name="flycast"
             ;;
+        fun-drastic)
+            [ -d "$FUN_DRASTIC_STANDALONE_DIR" ] || die "missing Fun DraStic standalone repo: $FUN_DRASTIC_STANDALONE_DIR"
+            # The archive is authorized material with no public home, so the
+            # product repo needs it named explicitly and refuses to guess.
+            [ -n "$FUN_DRASTIC_ARCHIVE" ] || die "FUN_DRASTIC_ARCHIVE is not set.
+Fun DraStic packages from a reviewed upstream archive that is not published.
+Supply it, or drop fun-drastic from STAGE_EMULATORS for this build."
+            make -C "$FUN_DRASTIC_STANDALONE_DIR" package-mlp1 \
+                FUN_DRASTIC_ARCHIVE="$FUN_DRASTIC_ARCHIVE"
+            package_dir="$MLP1_FUN_DRASTIC_PACKAGE"
+            remote_name="fun-drastic"
+            ;;
         yabasanshiro)
             [ -d "$YABASANSHIRO_STANDALONE_DIR" ] || die "missing YabaSanshiro standalone repo: $YABASANSHIRO_STANDALONE_DIR"
             prepare_yabasanshiro_source
@@ -858,6 +879,29 @@ validate_standalone_flycast_release() {
     python3 "$LEAF_ROOT/scripts/validate-flycast-standalone-release.py" \
         "$platform_dir" ||
         die "Flycast standalone release validation failed"
+}
+
+validate_standalone_fun_drastic_release() {
+    local platform_dir="$RELEASE_ROOT/platforms/mlp1"
+    python3 "$LEAF_ROOT/scripts/validate-fun-drastic-release.py" \
+        "$platform_dir" ||
+        die "Fun DraStic standalone release validation failed"
+}
+
+# Redundant with the Fun DraStic package allowlist on purpose. The allowlist is
+# the thing a future change might loosen; this gate covers the whole assembled
+# payload and, through audit_release_zip, the finished ZIPs.
+validate_no_nintendo_bios() {
+    local scan_root="$1"
+    local label="$2"
+    local found
+    found="$(find "$scan_root" \
+        \( -name 'nds_bios_arm7.bin' -o -name 'nds_bios_arm9.bin' \
+           -o -name 'nds_firmware.bin' \) -print 2>/dev/null)"
+    if [ -n "$found" ]; then
+        printf '%s\n' "$found" >&2
+        die "Nintendo DS BIOS or firmware found in $label; it must never ship"
+    fi
 }
 
 validate_standalone_yabasanshiro_release() {
@@ -948,6 +992,20 @@ validate_install_stage_clean() {
     fi
 }
 
+# The finished archive, not the staging directory it came from: a packaging
+# change could add a file between the payload gate and the zip.
+audit_zip_no_nintendo_bios() {
+    local zip_path="$1"
+    local found
+    found="$(unzip -Z1 "$zip_path" 2>/dev/null |
+        grep -E '(^|/)(nds_bios_arm7\.bin|nds_bios_arm9\.bin|nds_firmware\.bin)$' ||
+        true)"
+    if [ -n "$found" ]; then
+        printf '%s\n' "$found" >&2
+        die "Nintendo DS BIOS or firmware found in $(basename "$zip_path")"
+    fi
+}
+
 zip_stage() {
     local stage_dir="$1"
     local zip_path="$2"
@@ -957,6 +1015,7 @@ zip_stage() {
         cd "$stage_dir"
         zip -qr "$zip_path" .
     )
+    audit_zip_no_nintendo_bios "$zip_path"
     echo "Wrote $zip_path"
 }
 
@@ -999,6 +1058,8 @@ build_install_zip() {
     validate_standalone_n64_release
     validate_standalone_flycast_release
     validate_standalone_yabasanshiro_release
+    validate_standalone_fun_drastic_release
+    validate_no_nintendo_bios "$RELEASE_ROOT" "the assembled release payload"
     validate_ppsspp_vulkan_release
 
     cp -R "$LEAF_ROOT/stage/licenses" "$RELEASE_ROOT/licenses"

--- a/scripts/validate-fun-drastic-release-test.py
+++ b/scripts/validate-fun-drastic-release-test.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Self-contained policy tests for the Fun DraStic release validator."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+VALIDATOR = SCRIPT_DIR / "validate-fun-drastic-release.py"
+
+LIBS = (
+    "libSDL2-2.0.so.0",
+    "libasound.so.2",
+    "libfundrastic.so",
+    "libwayland-cursor.so.0",
+    "libxkbcommon.so.0",
+)
+HOOK_ASSETS = (
+    "fonts/Nunito-Bold.ttf",
+    "fonts/Translate.otf",
+    "language/template.txt",
+    "themes/custom.cfg",
+    "res/cursor/1.png",
+)
+BUNDLED_BIOS = {"drastic_bios_arm7.bin": 16384, "drastic_bios_arm9.bin": 4096}
+FORBIDDEN_BIOS = ("nds_bios_arm7.bin", "nds_bios_arm9.bin", "nds_firmware.bin")
+
+BIOS_README = (
+    "Fun DraStic includes DraStic's own free replacement BIOS.\n"
+    "Put nds_bios_arm7.bin, nds_bios_arm9.bin and nds_firmware.bin in BIOS/NDS.\n"
+)
+
+LAUNCHER = """#!/usr/bin/env bash
+set -euo pipefail
+STATE_ROOT="${FUN_DRASTIC_STATE_ROOT:-$USERDATA_PATH/fun-drastic}"
+LOG_FILE="$LOGS_PATH/fun-drastic.log"
+export SDL_JOYSTICK_DISABLE_UDEV=1
+exit 0
+"""
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def fake_elf() -> bytes:
+    data = bytearray(64)
+    data[:7] = b"\x7fELF\x02\x01\x01"
+    data[18:20] = (183).to_bytes(2, "little")
+    return bytes(data)
+
+
+def write_manifest(package: Path) -> None:
+    files = [
+        {"path": path.relative_to(package).as_posix(), "sha256": sha256(path)}
+        for path in sorted(package.rglob("*"))
+        if path.is_file() and path.name != "manifest.json"
+    ]
+    manifest = {
+        "id": "fun_drastic",
+        "name": "Fun DraStic",
+        "platform": "mlp1",
+        "kind": "standalone-emulator",
+        "author": "tenlevels",
+        "package_schema_version": 1,
+        "config_schema_version": 1,
+        "source_archive": "drastic.zip",
+        "source_archive_sha256": "6" * 64,
+        "binary": "bin/drastic64",
+        "binary_sha256": sha256(package / "bin/drastic64"),
+        "entrypoint": "launch.sh",
+        "sdl_video_driver": "wayland",
+        "bundled_bios": [f"system/{name}" for name in BUNDLED_BIOS],
+        "authorization": "licenses/DISTRIBUTION-BASIS.md",
+        "distribution_status": "proprietary-used-with-permission",
+        "exceptions": [
+            {
+                "artifact": "bin/drastic64",
+                "reason": "prebuilt closed-source DraStic binary; not built by UMRK",
+            }
+        ],
+        "files": files,
+    }
+    (package / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+
+def fixture(root: Path) -> Path:
+    platform = root / "platforms/mlp1"
+    package = platform / "emulators/fun-drastic"
+    primary = platform / "emulators/drastic"
+    for directory in (
+        platform / "defaults",
+        package / "bin",
+        package / "lib",
+        package / "config",
+        package / "defaults",
+        package / "fonts",
+        package / "language",
+        package / "themes",
+        package / "res/cursor",
+        package / "system",
+        package / "licenses",
+        package / "Overlays/960x720/Template",
+        primary / "bin",
+        primary / "share/system",
+    ):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    (platform / "defaults/systems.json").write_text(
+        json.dumps(
+            {
+                "systems": [
+                    {
+                        "id": "NDS",
+                        "default_core": "drastic",
+                        "alternate_cores": ["fun_drastic"],
+                        "bios_notes": [
+                            "Both Nintendo DS emulators bundle DraStic's own free "
+                            "replacement BIOS.",
+                            "Put nds_bios_arm7.bin, nds_bios_arm9.bin and "
+                            "nds_firmware.bin in BIOS/NDS.",
+                        ],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (platform / "defaults/cores.json").write_text(
+        json.dumps(
+            {
+                "cores": [
+                    {
+                        "id": "drastic",
+                        "display_name": "DraStic",
+                        "type": "path",
+                        "path": "emulators/drastic/launch.sh",
+                        "requires_direct_drm": False,
+                        "status": "packaged",
+                    },
+                    {
+                        "id": "fun_drastic",
+                        "display_name": "Fun DraStic",
+                        "type": "path",
+                        "path": "emulators/fun-drastic/launch.sh",
+                        "requires_direct_drm": False,
+                        "status": "packaged",
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    (package / "bin/drastic64").write_bytes(fake_elf())
+    for name in LIBS:
+        (package / "lib" / name).write_bytes(
+            fake_elf() if name == "libfundrastic.so" else b"lib\n"
+        )
+    (package / "launch.sh").write_text(LAUNCHER, encoding="utf-8")
+    (package / "README.txt").write_text("Fun DraStic by tenlevels\n", encoding="utf-8")
+    (package / "defaults/config.version").write_text("1\n", encoding="utf-8")
+    (package / "config/drastic.cfg").write_text("unzip_roms = 1\n", encoding="utf-8")
+    (package / "config/usrcheat.dat").write_bytes(b"cheats\n")
+    (package / "game_database.xml").write_bytes(b"<db/>\n")
+    (package / "system/BIOS-README.txt").write_text(BIOS_README, encoding="utf-8")
+    for name in HOOK_ASSETS:
+        (package / name).write_bytes(b"asset\n")
+    for name, size in BUNDLED_BIOS.items():
+        (package / "system" / name).write_bytes(b"\x00" * size)
+    (package / "Overlays/960x720/Template/aspect_single.png").write_bytes(b"png\n")
+    for name in ("DISTRIBUTION-BASIS.md", "THIRD-PARTY-NOTICES.txt"):
+        (package / "licenses" / name).write_text(name + "\n", encoding="utf-8")
+
+    os.chmod(package / "bin/drastic64", 0o755)
+    os.chmod(package / "launch.sh", 0o755)
+    write_manifest(package)
+
+    # The primary DraStic package, which must survive alongside it.
+    (primary / "launch.sh").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    os.chmod(primary / "launch.sh", 0o755)
+    (primary / "bin/drastic64").write_bytes(fake_elf())
+    for name, size in BUNDLED_BIOS.items():
+        (primary / "share/system" / name).write_bytes(b"\x00" * size)
+
+    return platform
+
+
+def run_case(name: str, mutate, should_pass: bool) -> None:
+    with tempfile.TemporaryDirectory(prefix=f"leaf-fun-drastic-{name}-") as temp:
+        platform = fixture(Path(temp))
+        mutate(platform)
+        result = subprocess.run(
+            [sys.executable, str(VALIDATOR), str(platform)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if (result.returncode == 0) != should_pass:
+            print(result.stdout, result.stderr, file=sys.stderr)
+            raise SystemExit(f"{name}: unexpected validator result")
+
+
+def rewrite_json(path: Path, mutate) -> None:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    mutate(data)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def main() -> None:
+    package_rel = "emulators/fun-drastic"
+
+    run_case("valid", lambda platform: None, True)
+
+    # DraStic stays the Nintendo DS default; Fun DraStic is an alternate.
+    run_case(
+        "fun-drastic-as-default",
+        lambda platform: rewrite_json(
+            platform / "defaults/systems.json",
+            lambda data: data["systems"][0].update(default_core="fun_drastic"),
+        ),
+        False,
+    )
+    run_case(
+        "not-an-alternate",
+        lambda platform: rewrite_json(
+            platform / "defaults/systems.json",
+            lambda data: data["systems"][0].update(alternate_cores=[]),
+        ),
+        False,
+    )
+
+    # The Nintendo dumps must never ship, wherever they are hidden.
+    for bios_name in FORBIDDEN_BIOS:
+        run_case(
+            f"nintendo-bios-{bios_name}",
+            lambda platform, name=bios_name: (
+                platform / package_rel / "system" / name
+            ).write_bytes(b"\x00" * 16384),
+            False,
+        )
+    run_case(
+        "nintendo-bios-elsewhere",
+        lambda platform: (platform / "nds_firmware.bin").write_bytes(b"\x00"),
+        False,
+    )
+
+    # DraStic's own free BIOS must ship, in the right size, in both packages.
+    run_case(
+        "missing-free-bios",
+        lambda platform: (
+            platform / package_rel / "system/drastic_bios_arm7.bin"
+        ).unlink(),
+        False,
+    )
+    run_case(
+        "truncated-free-bios",
+        lambda platform: (
+            platform / package_rel / "system/drastic_bios_arm7.bin"
+        ).write_bytes(b"\x00" * 1024),
+        False,
+    )
+    run_case(
+        "primary-drastic-removed",
+        lambda platform: (platform / "emulators/drastic/launch.sh").unlink(),
+        False,
+    )
+
+    # The hook resolves these from disk with no fallback.
+    for asset in HOOK_ASSETS:
+        run_case(
+            f"missing-hook-asset-{Path(asset).name}",
+            lambda platform, name=asset: (platform / package_rel / name).unlink(),
+            False,
+        )
+
+    # Wrapper contract.
+    def hardcode_event(platform: Path) -> None:
+        launcher = platform / package_rel / "launch.sh"
+        launcher.write_text(
+            LAUNCHER.replace(
+                "export SDL_JOYSTICK_DISABLE_UDEV=1",
+                'export SDL_JOYSTICK_DEVICE=/dev/input/event5',
+            ),
+            encoding="utf-8",
+        )
+        write_manifest(platform / package_rel)
+
+    run_case("hardcoded-input-node", hardcode_event, False)
+
+    def state_in_control_tree(platform: Path) -> None:
+        launcher = platform / package_rel / "launch.sh"
+        launcher.write_text(
+            LAUNCHER.replace(
+                'STATE_ROOT="${FUN_DRASTIC_STATE_ROOT:-$USERDATA_PATH/fun-drastic}"',
+                'STATE_ROOT="$UMRK_INTERNAL_DATA_PATH/fundrastic"',
+            ),
+            encoding="utf-8",
+        )
+        write_manifest(platform / package_rel)
+
+    run_case("state-in-launcher-control-tree", state_in_control_tree, False)
+
+    # Provenance and integrity.
+    run_case(
+        "unpinned-archive",
+        lambda platform: rewrite_json(
+            platform / package_rel / "manifest.json",
+            lambda data: data.update(source_archive_sha256=""),
+        ),
+        False,
+    )
+    run_case(
+        "missing-authorization",
+        lambda platform: rewrite_json(
+            platform / package_rel / "manifest.json",
+            lambda data: data.update(authorization=None),
+        ),
+        False,
+    )
+    run_case(
+        "claims-umrk-built-the-binary",
+        lambda platform: rewrite_json(
+            platform / package_rel / "manifest.json",
+            lambda data: data.update(
+                exceptions=[{"artifact": "bin/drastic64", "reason": "built here"}]
+            ),
+        ),
+        False,
+    )
+    run_case(
+        "missing-license-notice",
+        lambda platform: (
+            platform / package_rel / "licenses/DISTRIBUTION-BASIS.md"
+        ).unlink(),
+        False,
+    )
+    run_case(
+        "checksum-drift",
+        lambda platform: (platform / package_rel / "config/drastic.cfg").write_text(
+            "unzip_roms = 0\n", encoding="utf-8"
+        ),
+        False,
+    )
+    run_case(
+        "unlisted-file",
+        lambda platform: (platform / package_rel / "extra.bin").write_bytes(b"x"),
+        False,
+    )
+    run_case(
+        "corrupt-binary",
+        lambda platform: (platform / package_rel / "bin/drastic64").write_bytes(b"bad"),
+        False,
+    )
+
+    print("Fun DraStic release policy checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate-fun-drastic-release.py
+++ b/scripts/validate-fun-drastic-release.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Validate the Fun DraStic catalog entry and packaged MLP1 payload.
+
+Fun DraStic is a second Nintendo DS standalone over the same closed-source
+drastic64 binary the primary DraStic package ships. Three things are easy to
+get wrong and expensive to ship, so they are gated here rather than left to
+review:
+
+  * DraStic must stay the NDS default. Fun DraStic is an ordered alternate.
+  * The Nintendo BIOS and firmware dumps must never appear, while DraStic's own
+    free replacement BIOS must. Those are different files with confusingly
+    similar names, and the gate has to tell them apart.
+  * The two packages must stay independent on disk. A wrapper that stored state
+    inside the release-managed emulator directory, or under the
+    launcher-owned control-state tree, would lose it on the next update.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import sys
+from pathlib import Path, PurePosixPath
+
+
+CORE_ID = "fun_drastic"
+CORE_PATH = "emulators/fun-drastic/launch.sh"
+PACKAGE_REL = Path("emulators/fun-drastic")
+PRIMARY_CORE_ID = "drastic"
+PRIMARY_PACKAGE_REL = Path("emulators/drastic")
+SYSTEM_ID = "NDS"
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+# Shipped in both NDS packages: DraStic's own free replacement BIOS.
+BUNDLED_BIOS = {"drastic_bios_arm7.bin": 16384, "drastic_bios_arm9.bin": 4096}
+# Never shipped, anywhere: the Nintendo dumps.
+FORBIDDEN_BIOS = ("nds_bios_arm7.bin", "nds_bios_arm9.bin", "nds_firmware.bin")
+
+REQUIRED_LIBS = (
+    "libSDL2-2.0.so.0",
+    "libasound.so.2",
+    "libfundrastic.so",
+    "libwayland-cursor.so.0",
+    "libxkbcommon.so.0",
+)
+
+# The hook resolves these from FUN_DRASTIC_DIR with no fallback, so a package
+# missing one boots to a menu that renders nothing.
+REQUIRED_HOOK_ASSETS = (
+    "fonts/Nunito-Bold.ttf",
+    "fonts/Translate.otf",
+    "language/template.txt",
+    "themes/custom.cfg",
+    "res/cursor/1.png",
+)
+
+REQUIRED_LICENSES = ("DISTRIBUTION-BASIS.md", "THIRD-PARTY-NOTICES.txt")
+
+FORBIDDEN_TOP_LEVEL = {
+    "backup",
+    "savestates",
+    "profiles",
+    "unzip_cache",
+    "input_record",
+    "cheats",
+    "slot2",
+    "roms",
+    "saves",
+    "states",
+    "bios",
+    ".userdata",
+}
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"error: {message}")
+
+
+def load_json(path: Path) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        fail(f"missing JSON file: {path}")
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        fail(f"invalid JSON file {path}: {exc}")
+
+
+def rows(data: object, key: str, path: Path) -> list[dict[str, object]]:
+    value = data.get(key) if isinstance(data, dict) else data
+    if not isinstance(value, list) or not all(isinstance(row, dict) for row in value):
+        fail(f"{path} must contain a {key} array")
+    return value
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def validate_aarch64_elf(path: Path) -> None:
+    try:
+        header = path.read_bytes()[:20]
+    except OSError as exc:
+        fail(f"could not read {path}: {exc}")
+    if (
+        len(header) < 20
+        or header[:4] != b"\x7fELF"
+        or header[4] != 2
+        or header[5] != 1
+        or int.from_bytes(header[18:20], "little") != 183
+    ):
+        fail(f"not a little-endian AArch64 ELF: {path}")
+
+
+def safe_manifest_path(value: object) -> str:
+    if not isinstance(value, str) or not value or "\\" in value:
+        fail(f"invalid package manifest path: {value!r}")
+    path = PurePosixPath(value)
+    if path.is_absolute() or "." in path.parts or ".." in path.parts:
+        fail(f"unsafe package manifest path: {value}")
+    return value
+
+
+def validate_catalog(platform_dir: Path) -> None:
+    systems_path = platform_dir / "defaults/systems.json"
+    cores_path = platform_dir / "defaults/cores.json"
+    systems = rows(load_json(systems_path), "systems", systems_path)
+    cores = rows(load_json(cores_path), "cores", cores_path)
+
+    system_rows = [row for row in systems if row.get("id") == SYSTEM_ID]
+    if len(system_rows) != 1:
+        fail(f"systems.json must contain exactly one {SYSTEM_ID} system")
+    system = system_rows[0]
+    if system.get("default_core") != PRIMARY_CORE_ID:
+        fail(f"{SYSTEM_ID} must keep {PRIMARY_CORE_ID} as its default core")
+    alternates = system.get("alternate_cores")
+    if not isinstance(alternates, list) or CORE_ID not in alternates:
+        fail(f"{SYSTEM_ID} must list {CORE_ID} in alternate_cores")
+    bios_notes = system.get("bios_notes")
+    if not isinstance(bios_notes, list) or not bios_notes:
+        fail(f"{SYSTEM_ID} must carry bios_notes naming the optional dumps")
+    notes = " ".join(str(note) for note in bios_notes)
+    for name in FORBIDDEN_BIOS:
+        if name not in notes:
+            fail(f"{SYSTEM_ID} bios_notes must name {name}")
+    if "BIOS/NDS" not in notes:
+        fail(f"{SYSTEM_ID} bios_notes must say where the dumps go (BIOS/NDS)")
+
+    for core_id, core_path in (
+        (CORE_ID, CORE_PATH),
+        (PRIMARY_CORE_ID, "emulators/drastic/launch.sh"),
+    ):
+        core_rows = [row for row in cores if row.get("id") == core_id]
+        if len(core_rows) != 1:
+            fail(f"cores.json must contain exactly one {core_id} entry")
+        core = core_rows[0]
+        if core.get("type") != "path":
+            fail(f"{core_id} must be a path core")
+        if core.get("path") != core_path:
+            fail(f"{core_id} path must be {core_path}")
+        if core.get("status") != "packaged":
+            fail(f"{core_id} must be marked packaged")
+
+    fun_core = next(row for row in cores if row.get("id") == CORE_ID)
+    if fun_core.get("requires_direct_drm"):
+        fail("fun_drastic must not require direct DRM")
+    if fun_core.get("display_name") != "Fun DraStic":
+        fail("fun_drastic display name must be Fun DraStic")
+
+
+def validate_package(platform_dir: Path) -> tuple[int, str]:
+    launcher = platform_dir / CORE_PATH
+    if not launcher.is_file() or not os.access(launcher, os.X_OK):
+        fail(f"Fun DraStic launcher is missing or not executable: {launcher}")
+
+    package_dir = platform_dir / PACKAGE_REL
+    manifest_path = package_dir / "manifest.json"
+    binary = package_dir / "bin/drastic64"
+
+    required = [
+        binary,
+        package_dir / "launch.sh",
+        package_dir / "manifest.json",
+        package_dir / "README.txt",
+        package_dir / "defaults/config.version",
+        package_dir / "config/drastic.cfg",
+        package_dir / "config/usrcheat.dat",
+        package_dir / "game_database.xml",
+        package_dir / "system/BIOS-README.txt",
+    ]
+    required += [package_dir / "lib" / name for name in REQUIRED_LIBS]
+    required += [package_dir / name for name in REQUIRED_HOOK_ASSETS]
+    required += [package_dir / "licenses" / name for name in REQUIRED_LICENSES]
+    required += [package_dir / "system" / name for name in BUNDLED_BIOS]
+    for path in required:
+        if not path.is_file():
+            fail(f"missing Fun DraStic package file: {path}")
+
+    if not os.access(binary, os.X_OK):
+        fail(f"Fun DraStic binary is not executable: {binary}")
+    validate_aarch64_elf(binary)
+    validate_aarch64_elf(package_dir / "lib/libfundrastic.so")
+
+    # An overlay pack tree has to exist; its exact contents are user-extendable.
+    if not any((package_dir / "Overlays").rglob("*.png")):
+        fail("Fun DraStic package must ship at least one screen overlay")
+
+    for name, expected_size in BUNDLED_BIOS.items():
+        actual = (package_dir / "system" / name).stat().st_size
+        if actual != expected_size:
+            fail(f"{name} is {actual} bytes, expected {expected_size}")
+
+    bios_readme = (package_dir / "system/BIOS-README.txt").read_text(encoding="utf-8")
+    for name in FORBIDDEN_BIOS:
+        if name not in bios_readme:
+            fail(f"system/BIOS-README.txt must name {name}")
+
+    for path in package_dir.rglob("*"):
+        if path.is_symlink():
+            fail(f"Fun DraStic package is not FAT32-safe; symlink found: {path}")
+        relative = path.relative_to(package_dir)
+        if relative.parts and relative.parts[0].casefold() in FORBIDDEN_TOP_LEVEL:
+            fail(f"mutable/user content found in Fun DraStic package: {relative}")
+        if path.name in {"fun-drastic.log", "fundrastic.log", "debug.txt"}:
+            fail(f"runtime file found in Fun DraStic package: {relative}")
+
+    launcher_text = launcher.read_text(encoding="utf-8")
+    if re.search(r"/dev/input/event\d", launcher_text):
+        fail("Fun DraStic launcher hardcodes a physical input node")
+    if "SDL_JOYSTICK_DISABLE_UDEV=1" not in launcher_text:
+        fail("Fun DraStic launcher must keep SDL_JOYSTICK_DISABLE_UDEV=1")
+    # State belongs under USERDATA_PATH. UMRK_INTERNAL_DATA_PATH is
+    # launcher-owned control state and may only be read, to find the primary
+    # DraStic saves the two packages share.
+    state_lines = [
+        line
+        for line in launcher_text.splitlines()
+        if line.lstrip().startswith("STATE_ROOT=")
+    ]
+    if not state_lines:
+        fail("Fun DraStic launcher must define STATE_ROOT")
+    if not all("USERDATA_PATH/fun-drastic" in line for line in state_lines):
+        fail("Fun DraStic launcher must root its state at USERDATA_PATH/fun-drastic")
+    if any("UMRK_INTERNAL_DATA_PATH" in line for line in state_lines):
+        fail(
+            "Fun DraStic launcher must not store state under "
+            "UMRK_INTERNAL_DATA_PATH, which is launcher-owned control state"
+        )
+    if "LOGS_PATH/fun-drastic.log" not in launcher_text:
+        fail("Fun DraStic launcher must log to LOGS_PATH/fun-drastic.log")
+
+    manifest = load_json(manifest_path)
+    if not isinstance(manifest, dict):
+        fail("Fun DraStic manifest must be a JSON object")
+    expected_fields = {
+        "id": CORE_ID,
+        "platform": "mlp1",
+        "kind": "standalone-emulator",
+        "binary": "bin/drastic64",
+        "entrypoint": "launch.sh",
+        "sdl_video_driver": "wayland",
+        "package_schema_version": 1,
+    }
+    for key, expected in expected_fields.items():
+        if manifest.get(key) != expected:
+            fail(f"Fun DraStic manifest {key} must be {expected!r}")
+    if not SHA256_RE.fullmatch(str(manifest.get("source_archive_sha256", ""))):
+        fail("Fun DraStic manifest must pin the source archive SHA-256")
+    if manifest.get("authorization") != "licenses/DISTRIBUTION-BASIS.md":
+        fail("Fun DraStic manifest must reference the recorded distribution basis")
+    if manifest.get("distribution_status") != "proprietary-used-with-permission":
+        fail("Fun DraStic manifest must record its proprietary distribution status")
+    exceptions = json.dumps(manifest.get("exceptions") or [])
+    if "not built by UMRK" not in exceptions:
+        fail("Fun DraStic manifest must record the prebuilt-binary exception")
+
+    config_version_path = package_dir / "defaults/config.version"
+    try:
+        config_version = int(config_version_path.read_text(encoding="utf-8").strip())
+    except (OSError, UnicodeError, ValueError) as exc:
+        fail(f"invalid Fun DraStic config version: {exc}")
+    if manifest.get("config_schema_version") != config_version:
+        fail("Fun DraStic manifest config schema does not match defaults/config.version")
+
+    file_rows = manifest.get("files")
+    if not isinstance(file_rows, list) or not file_rows:
+        fail("Fun DraStic manifest must contain a non-empty files array")
+    expected_files: dict[str, str] = {}
+    for row in file_rows:
+        if not isinstance(row, dict):
+            fail("Fun DraStic manifest file rows must be objects")
+        relative = safe_manifest_path(row.get("path"))
+        expected_sha = row.get("sha256")
+        if not isinstance(expected_sha, str) or not SHA256_RE.fullmatch(expected_sha):
+            fail(f"invalid checksum for Fun DraStic package path: {relative}")
+        if relative == "manifest.json" or relative in expected_files:
+            fail(f"duplicate or self-referential Fun DraStic path: {relative}")
+        expected_files[relative] = expected_sha
+
+    actual_files = {
+        path.relative_to(package_dir).as_posix()
+        for path in package_dir.rglob("*")
+        if path.is_file() and path != manifest_path
+    }
+    if set(expected_files) != actual_files:
+        unlisted = sorted(actual_files - set(expected_files))
+        missing = sorted(set(expected_files) - actual_files)
+        fail(
+            "Fun DraStic manifest inventory mismatch; "
+            f"unlisted={unlisted}, missing={missing}"
+        )
+    for relative, expected_sha in expected_files.items():
+        if sha256(package_dir / relative) != expected_sha:
+            fail(f"Fun DraStic package checksum mismatch: {relative}")
+
+    binary_sha = sha256(binary)
+    if manifest.get("binary_sha256") != binary_sha:
+        fail("Fun DraStic manifest binary checksum does not match bin/drastic64")
+
+    return len(expected_files), binary_sha
+
+
+def validate_coexistence(platform_dir: Path) -> None:
+    """The primary DraStic package must survive, unchanged and separate."""
+    primary_dir = platform_dir / PRIMARY_PACKAGE_REL
+    primary_launcher = primary_dir / "launch.sh"
+    if not primary_launcher.is_file() or not os.access(primary_launcher, os.X_OK):
+        fail("the primary DraStic package must remain staged and executable")
+    for name in BUNDLED_BIOS:
+        if not (primary_dir / "share/system" / name).is_file():
+            fail(f"the primary DraStic package must keep its free BIOS: {name}")
+
+    fun_binary = platform_dir / PACKAGE_REL / "bin/drastic64"
+    primary_binary = primary_dir / "bin/drastic64"
+    if primary_binary.is_file() and sha256(primary_binary) != sha256(fun_binary):
+        # Not fatal on its own, but the two packages are supposed to carry the
+        # same prebuilt binary; a divergence means one of them was rebuilt.
+        print(
+            "warning: drastic64 differs between the DraStic and Fun DraStic "
+            "packages; they are expected to be byte-identical"
+        )
+
+
+def validate_no_nintendo_bios(platform_dir: Path) -> None:
+    hits = sorted(
+        str(path.relative_to(platform_dir))
+        for name in FORBIDDEN_BIOS
+        for path in platform_dir.rglob(name)
+    )
+    if hits:
+        fail("Nintendo DS BIOS or firmware must never ship: " + ", ".join(hits))
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit(f"usage: {Path(sys.argv[0]).name} <mlp1-platform-dir>")
+    platform_dir = Path(sys.argv[1])
+    if not platform_dir.is_dir():
+        fail(f"missing MLP1 platform directory: {platform_dir}")
+
+    validate_catalog(platform_dir)
+    file_count, binary_sha = validate_package(platform_dir)
+    validate_coexistence(platform_dir)
+    validate_no_nintendo_bios(platform_dir)
+
+    print(
+        "Fun DraStic release gate: "
+        f"{CORE_PATH}, {file_count} checksummed files, binary {binary_sha}, "
+        "DraStic still the NDS default, no Nintendo BIOS"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate-input-roster-policy-test.py
+++ b/scripts/validate-input-roster-policy-test.py
@@ -206,6 +206,7 @@ def check_shipped_wrappers() -> None:
         WORKSPACE_ROOT / "PPSSPP-spruce" / "package-mlp1.sh",
         WORKSPACE_ROOT / "Flycast-standalone" / "config" / "mlp1" / "launch.sh",
         WORKSPACE_ROOT / "N64-standalone" / "config" / "mlp1" / "launch.sh",
+        WORKSPACE_ROOT / "Fun-Drastic-standalone" / "config" / "mlp1" / "launch.sh",
     ]
     for wrapper in wrappers:
         if not wrapper.exists():

--- a/scripts/validate-input-roster-policy-test.py
+++ b/scripts/validate-input-roster-policy-test.py
@@ -199,6 +199,65 @@ def check_binary_case() -> None:
             )
 
 
+def check_device_list_parser() -> None:
+    """ROSTER005. Both shapes shipped: the Handlers= miss was in all four
+    copies of this resolver, and the missing record reset was in two of them.
+    The second is the nastier one -- it returns a real event node belonging to
+    the previous device, so the caller's own [ -e ] guard passes."""
+    header = "#!/bin/sh\nresolve() {\n    awk '\n"
+    footer = "    ' /proc/bus/input/devices\n}\n"
+    name_and_sysfs = (
+        '        /^N: Name="Loong Gamepad"/ { name = 1 }\n'
+        "        /^S: Sysfs=\\/devices\\/virtual\\/input\\// { virtual = 1 }\n"
+    )
+    bare_match = (
+        "        /^H: Handlers=/ {\n"
+        "            for (i = 1; i <= NF; i++) {\n"
+        "                if ($i ~ /^event[0-9]+$/) { event = $i }\n"
+        "            }\n"
+        "        }\n"
+    )
+    stripped_match = (
+        "        /^H: Handlers=/ {\n"
+        "            for (i = 1; i <= NF; i++) {\n"
+        "                h = $i\n"
+        "                sub(/^Handlers=/, \"\", h)\n"
+        "                if (h ~ /^event[0-9]+$/) { event = h }\n"
+        "            }\n"
+        "        }\n"
+    )
+    blank_reset = '        /^$/ { name = 0; virtual = 0; event = "" }\n'
+    record_reset = '        /^I:/ { name = 0; virtual = 0; event = "" }\n'
+    tail = '        name && virtual && event != "" { print event; exit }\n'
+
+    cases = [
+        ("both defects", blank_reset + name_and_sysfs + bare_match + tail, 2),
+        ("handlers only", record_reset + name_and_sysfs + bare_match + tail, 1),
+        ("reset only", blank_reset + name_and_sysfs + stripped_match + tail, 1),
+        ("clean", record_reset + name_and_sysfs + stripped_match + tail, 0),
+    ]
+    for label, body, expected in cases:
+        with tempfile.TemporaryDirectory(prefix="leaf-roster005-") as temp:
+            wrapper = Path(temp) / "launch.sh"
+            wrapper.write_text(header + body + footer, encoding="utf-8")
+            result = run(wrapper)
+            found = result.stderr.count("ROSTER005")
+            if found != expected:
+                FAILURES.append(
+                    f"ROSTER005 {label}: expected {expected} finding(s), got "
+                    f"{found}\n{result.stderr.strip()}"
+                )
+
+    # A file that only mentions the path must not be flagged.
+    with tempfile.TemporaryDirectory(prefix="leaf-roster005-ok-") as temp:
+        wrapper = Path(temp) / "notes.sh"
+        wrapper.write_text(
+            "#!/bin/sh\n# see /proc/bus/input/devices\necho hi\n", encoding="utf-8"
+        )
+        if run(wrapper).returncode != 0:
+            FAILURES.append("ROSTER005 flagged a file that only mentions the path")
+
+
 def check_shipped_wrappers() -> None:
     """The gate must pass the wrappers currently shipped for MLP1. If this
     fails, the gate is wrong -- not the wrappers."""
@@ -220,6 +279,7 @@ def check_shipped_wrappers() -> None:
 
 
 check_binary_case()
+check_device_list_parser()
 check_shipped_wrappers()
 
 if FAILURES:

--- a/scripts/validate-input-roster-policy.py
+++ b/scripts/validate-input-roster-policy.py
@@ -14,6 +14,8 @@ or hands a player slot to the uncalibrated physical pad:
   ROSTER002  emulator code hardcoding a physical /dev/input/eventN path
   ROSTER003  a configuration enabling more player ports than a roster holds
   ROSTER004  a launch path resolving the Loong pads by display name alone
+  ROSTER005  a /proc/bus/input/devices parser that misreads the handlers line
+             or leaks state between device records
 
 Each of these has already shipped at least once, which is why they are gated
 here rather than left to review.
@@ -51,6 +53,25 @@ GUARD_WINDOW = 12
 MAX_USERS_RE = re.compile(r"input_max_users\s*=\s*\"?(\d+)\"?")
 JOYPAD_INDEX_RE = re.compile(r"input_player(\d+)_joypad_index\s*=\s*\"?(-?\d+)\"?")
 MAPLE_PORT_RE = re.compile(r"maple_sdl_joystick_(\d+)\s*=\s*(-?\d+)")
+
+# ROSTER005. Four wrappers now carry near-identical copies of the same awk
+# resolver, and they have drifted apart in two different ways -- both of which
+# fail silently and one of which returns a real-but-wrong device node.
+#
+#   * "H: Handlers=event6 dmcfreq" glues the first handler to the key, so an
+#     awk field test of /^event[0-9]+$/ never matches a device whose event node
+#     comes first. Strip "Handlers=" from the field before testing.
+#   * Per-record state must be reset on the record header (/^I:/). Resetting on
+#     the blank separator instead leaks the previous device's event node into
+#     the next record, and the result passes the caller's own [ -e ] check.
+#
+# These live in independent product repos on purpose, so the fix is gated here
+# rather than shared through a common file.
+DEVICE_LIST_SCAN = "/proc/bus/input/devices"
+HANDLERS_KEY = "Handlers="
+BARE_EVENT_FIELD_RE = re.compile(r"~\s*/\^event\[0-9\]\+\$/")
+STRIPS_HANDLERS_RE = re.compile(r"sub\(\s*/\^Handlers=/")
+RECORD_RESET_RE = re.compile(r"/\^I:/")
 
 LOONG_NAME = "Loong Gamepad"
 DEVICE_LIST_PATH = "/proc/bus/input/devices"
@@ -250,6 +271,50 @@ def check_direct_fallback(path: Path, text: str, lines: list[str]) -> list[Findi
     return findings
 
 
+def check_device_list_parser(path: Path, text: str, lines: list[str]) -> list[Finding]:
+    """ROSTER005: only fires on a file that actually parses the device list for
+    an event node, so an unrelated mention of /proc/bus/input/devices is not a
+    finding."""
+    findings = []
+    unescaped = text.replace("\\", "")
+    if DEVICE_LIST_SCAN not in unescaped or HANDLERS_KEY not in unescaped:
+        return findings
+
+    if BARE_EVENT_FIELD_RE.search(text) and not STRIPS_HANDLERS_RE.search(text):
+        line = next(
+            (n for n, l in enumerate(lines, 1) if BARE_EVENT_FIELD_RE.search(l)), 0
+        )
+        findings.append(
+            Finding(
+                "ROSTER005",
+                path,
+                line,
+                "matches an event node as a whole awk field; "
+                '"H: Handlers=event6" makes the field "Handlers=event6", so a '
+                "device whose event node comes first is silently skipped -- "
+                "strip Handlers= before testing",
+            )
+        )
+
+    if not RECORD_RESET_RE.search(text):
+        line = next(
+            (n for n, l in enumerate(lines, 1) if DEVICE_LIST_SCAN in l.replace("\\", "")),
+            0,
+        )
+        findings.append(
+            Finding(
+                "ROSTER005",
+                path,
+                line,
+                "parses the device list without resetting per-record state on "
+                "the /^I:/ record header; a blank-line reset leaks the previous "
+                "device's event node into the next record and returns a real "
+                "but wrong node that passes an [ -e ] check",
+            )
+        )
+    return findings
+
+
 def scan(root: Path) -> list[Finding]:
     findings: list[Finding] = []
     for path in iter_files(root):
@@ -270,6 +335,7 @@ def scan(root: Path) -> list[Finding]:
         if shell_like:
             findings.extend(check_roster_overwrite(path, lines))
             findings.extend(check_direct_fallback(path, text, lines))
+            findings.extend(check_device_list_parser(path, text, lines))
         if shell_like or suffix in CONFIG_SUFFIXES:
             findings.extend(check_player_ports(path, lines))
     return findings

--- a/stage/common.mk
+++ b/stage/common.mk
@@ -33,18 +33,13 @@ LAUNCHER_SWITCHER_DIR  ?= $(WORKSPACE_DIR)/miniloong-launcher-switcher
 TOOLCHAIN_IMAGE ?= ghcr.io/utility-muffin-research-kitchen/mlp1-toolchain:local
 
 # Public sibling repos required for contributor build/stage workflows.
-REQUIRED_REPOS := Catastrophe Jawaka Thing-File ssh-server CentralScrutinizer Fugazi joes-calibrage PPSSPP-spruce steward-fu-nds N64-standalone Flycast-standalone Yabasanshiro-standalone \
+REQUIRED_REPOS := Catastrophe Jawaka Thing-File ssh-server CentralScrutinizer Fugazi joes-calibrage PPSSPP-spruce steward-fu-nds N64-standalone Flycast-standalone Yabasanshiro-standalone Fun-Drastic-standalone \
                   retroarch-builds Cores-spruce mlp1-toolchain miniloong-launcher-switcher \
                   miniloong-adb-keeper
 
 # Private maintainer-only repos. Bootstrap probes these and silently skips them
 # when credentials are unavailable.
-#
-# Fun-Drastic-standalone is optional rather than required because its upstream
-# archive is authorized material with no public home: `make package-mlp1` there
-# needs an explicitly supplied reviewed copy. Listing it as required would make
-# `make stage` fail for public contributors with no way to fix it.
-OPTIONAL_PRIVATE_REPOS := umrk-workspace Fun-Drastic-standalone
+OPTIONAL_PRIVATE_REPOS := umrk-workspace
 
 # Example paks. Deliberately NOT required: each one builds from a clean clone
 # with no sibling checkout, which is the property that makes it usable as a

--- a/stage/common.mk
+++ b/stage/common.mk
@@ -23,6 +23,7 @@ STEWARD_NDS_DIR        ?= $(WORKSPACE_DIR)/steward-fu-nds
 N64_STANDALONE_DIR     ?= $(WORKSPACE_DIR)/N64-standalone
 FLYCAST_STANDALONE_DIR ?= $(WORKSPACE_DIR)/Flycast-standalone
 YABASANSHIRO_STANDALONE_DIR ?= $(WORKSPACE_DIR)/Yabasanshiro-standalone
+FUN_DRASTIC_STANDALONE_DIR ?= $(WORKSPACE_DIR)/Fun-Drastic-standalone
 RETROARCH_BUILDS_DIR   ?= $(WORKSPACE_DIR)/retroarch-builds
 CORES_SPRUCE_DIR       ?= $(WORKSPACE_DIR)/Cores-spruce
 TOOLCHAIN_DIR          ?= $(WORKSPACE_DIR)/mlp1-toolchain
@@ -38,7 +39,12 @@ REQUIRED_REPOS := Catastrophe Jawaka Thing-File ssh-server CentralScrutinizer Fu
 
 # Private maintainer-only repos. Bootstrap probes these and silently skips them
 # when credentials are unavailable.
-OPTIONAL_PRIVATE_REPOS := umrk-workspace
+#
+# Fun-Drastic-standalone is optional rather than required because its upstream
+# archive is authorized material with no public home: `make package-mlp1` there
+# needs an explicitly supplied reviewed copy. Listing it as required would make
+# `make stage` fail for public contributors with no way to fix it.
+OPTIONAL_PRIVATE_REPOS := umrk-workspace Fun-Drastic-standalone
 
 # Example paks. Deliberately NOT required: each one builds from a clean clone
 # with no sibling checkout, which is the property that makes it usable as a

--- a/stage/licenses/CORES.md
+++ b/stage/licenses/CORES.md
@@ -21,6 +21,7 @@ from the named upstream release asset.
 |---|---|---|
 | dosbox_pure | GPL-2.0 | https://github.com/libretro/dosbox-pure |
 | drastic (standalone) | LGPL-2.1 | https://github.com/steward-fu/nds |
+| fun_drastic (standalone) | Proprietary, used with permission | https://github.com/Utility-Muffin-Research-Kitchen/Fun-Drastic-standalone |
 | easyrpg | GPL-3.0 | https://github.com/EasyRPG/Player |
 | fake08 | MIT | https://github.com/jtothebell/fake-08 |
 | fbalpha2012 | FB Alpha (non-commercial) | https://github.com/libretro/fbalpha2012 |

--- a/stage/licenses/cores/fun_drastic.txt
+++ b/stage/licenses/cores/fun_drastic.txt
@@ -63,7 +63,7 @@ The package is not a single work. Each component keeps its own terms.
 | `config/usrcheat.dat`, `game_database.xml` | DraStic distribution | Redistributed as part of the DraStic data set |
 | `language/*.txt` | tenlevels and contributors | Proprietary, used with permission |
 | `fonts/Nunito-Bold.ttf` | The Nunito Project Authors | SIL Open Font License 1.1 |
-| `fonts/Translate.otf` | Bundled translation font | See `THIRD-PARTY-NOTICES.txt` |
+| `fonts/Translate.otf` | Adobe / the Noto Project (this is Noto Sans CJK SC Regular under another filename) | SIL Open Font License 1.1 |
 | `lib/libSDL2-2.0.so.0` | SDL | zlib license |
 | `lib/libasound.so.2` | ALSA project | LGPL-2.1-or-later |
 | `lib/libxkbcommon.so.0` | xkbcommon | MIT |
@@ -155,12 +155,24 @@ Licensed under the SIL Open Font License, Version 1.1. The full license text is
 available at https://openfontlicense.org/. Nunito is a Reserved Font Name; a
 modified copy may not be distributed under that name.
 
-Translate (fonts/Translate.otf)
--------------------------------
-Bundled by tenlevels as the wide-coverage font behind Fun DraStic's translation
-support. The upstream font and its license have not been identified by the
-project. Confirm its origin and terms with tenlevels before a public release
-that includes it.
+Noto Sans CJK SC (fonts/Translate.otf)
+--------------------------------------
+Copyright (c) 2014-2021 Adobe (http://www.adobe.com/).
+
+Shipped under the filename Translate.otf; the font itself is Noto Sans CJK SC
+Regular, version 2.004, unmodified. Its own name table carries the notice
+below. Renaming the file does not rename the font: the internal family name is
+still "Noto Sans CJK SC", which is what the OFL's Reserved Font Name clause
+governs.
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  This Font Software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+  CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font
+  License for the specific language, permissions and limitations governing your
+  use of this Font Software.
+
+The full license text is available at https://openfontlicense.org/ and at
+http://scripts.sil.org/OFL.
 
 DraStic (bin/drastic64, system/drastic_bios_*.bin, game_database.xml,
 config/usrcheat.dat)

--- a/stage/licenses/cores/fun_drastic.txt
+++ b/stage/licenses/cores/fun_drastic.txt
@@ -1,0 +1,176 @@
+Fun DraStic
+===========
+
+Fun DraStic is by tenlevels. It is proprietary material redistributed in Leaf
+with the author's written permission. It is not open source, and no
+open-source license applies to it. Do not treat this file as a grant of one.
+
+The package is not a single work. The frontend hook and presentation assets
+are tenlevels' own; the emulator binary, the replacement BIOS, the bundled
+libraries and the fonts each keep their own terms. tenlevels' permission is
+attributed only to the material tenlevels owns or is authorized to
+redistribute.
+
+The Nintendo DS BIOS and firmware dumps are never shipped in any form.
+
+The full distribution basis and the per-component ownership table follow,
+copied verbatim from the Fun-Drastic-standalone product repository, then the
+third-party notices the bundled libraries and fonts require.
+
+
+--------------------------------------------------------------------------
+DISTRIBUTION BASIS
+--------------------------------------------------------------------------
+
+# Fun DraStic distribution basis
+
+Fun DraStic is proprietary material redistributed with permission. It is not
+open source and no open-source license applies to it. This file records the
+basis on which the package is built and shipped.
+
+## Permission
+
+tenlevels, the author of Fun DraStic, gave the project written permission to
+use and redistribute Fun DraStic as part of Leaf. The permission was given in
+a private Discord message; a copy is preserved by the project maintainer with
+the sender identity and date. The private message itself is not published.
+
+Permission covers:
+
+- hosting the reviewed source archive or a package derived from it;
+- bundling that package in downloadable Leaf releases;
+- the packaging-only changes described in this repository (a rewritten launch
+  wrapper, an allowlisted file set, generated manifest and notices).
+
+It does not transfer ownership and it does not make the material open source.
+
+> **Release gate.** Before a public Leaf release includes Fun DraStic, confirm
+> the preserved permission still covers the list above and record the archival
+> reference in the release provenance. If it does not, Fun DraStic stays out of
+> the default release list; the same packaging still supports an explicitly
+> supplied local archive for authorized device-local use.
+
+## Component ownership
+
+The package is not a single work. Each component keeps its own terms.
+
+| Component | Owner / origin | Terms |
+| --- | --- | --- |
+| `lib/libfundrastic.so` (the Fun DraStic frontend hook) | tenlevels | Proprietary, used with permission |
+| `Overlays/`, `themes/`, `res/cursor/` (presentation assets) | tenlevels | Proprietary, used with permission |
+| `bin/drastic64` | Exophase / DraStic | Proprietary closed-source emulator; the same prebuilt binary the primary DraStic package ships |
+| `system/drastic_bios_arm7.bin`, `system/drastic_bios_arm9.bin` | DraStic | DraStic's own free replacement BIOS, distributed with DraStic |
+| `config/usrcheat.dat`, `game_database.xml` | DraStic distribution | Redistributed as part of the DraStic data set |
+| `language/*.txt` | tenlevels and contributors | Proprietary, used with permission |
+| `fonts/Nunito-Bold.ttf` | The Nunito Project Authors | SIL Open Font License 1.1 |
+| `fonts/Translate.otf` | Bundled translation font | See `THIRD-PARTY-NOTICES.txt` |
+| `lib/libSDL2-2.0.so.0` | SDL | zlib license |
+| `lib/libasound.so.2` | ALSA project | LGPL-2.1-or-later |
+| `lib/libxkbcommon.so.0` | xkbcommon | MIT |
+| `lib/libwayland-cursor.so.0` | Wayland project | MIT |
+| Packaging code in this repository | UMRK | See `LICENSE` |
+
+tenlevels' permission is attributed only to the material tenlevels owns or is
+authorized to redistribute. It is not a license for `bin/drastic64`, the
+bundled libraries, or the fonts.
+
+## Nintendo BIOS
+
+The Nintendo DS BIOS and firmware dumps (`nds_bios_arm7.bin`,
+`nds_bios_arm9.bin`, `nds_firmware.bin`) are never shipped, in any form. The
+package gate and the Leaf release gate both reject them.
+
+
+--------------------------------------------------------------------------
+THIRD-PARTY NOTICES
+--------------------------------------------------------------------------
+
+Fun DraStic - third-party notices
+=================================
+
+The Fun DraStic package bundles the components below. Each keeps its own
+terms; see DISTRIBUTION-BASIS.md for the full ownership table and for the
+permission under which the proprietary parts are redistributed.
+
+SDL2 (lib/libSDL2-2.0.so.0)
+---------------------------
+Copyright (C) 1997-2024 Sam Lantinga <slouken@libsdl.org>
+
+This software is provided 'as-is', without any express or implied warranty. In
+no event will the authors be held liable for any damages arising from the use
+of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it freely,
+subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim
+   that you wrote the original software. If you use this software in a
+   product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+
+ALSA library (lib/libasound.so.2)
+---------------------------------
+Copyright (c) the ALSA project.
+
+Licensed under the GNU Lesser General Public License, version 2.1 or (at your
+option) any later version. A copy of the LGPL-2.1 is available at
+https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html and the corresponding
+source is available from https://www.alsa-project.org/.
+
+libxkbcommon (lib/libxkbcommon.so.0)
+------------------------------------
+Copyright (c) 2008, 2009, 2012 Dan Nicholson, Ran Benita and contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY.
+
+wayland-cursor (lib/libwayland-cursor.so.0)
+-------------------------------------------
+Copyright (c) the Wayland project contributors.
+
+Released under the MIT license, on the same terms as the libxkbcommon notice
+above.
+
+Nunito (fonts/Nunito-Bold.ttf)
+------------------------------
+Copyright (c) The Nunito Project Authors (https://github.com/googlefonts/nunito).
+
+Licensed under the SIL Open Font License, Version 1.1. The full license text is
+available at https://openfontlicense.org/. Nunito is a Reserved Font Name; a
+modified copy may not be distributed under that name.
+
+Translate (fonts/Translate.otf)
+-------------------------------
+Bundled by tenlevels as the wide-coverage font behind Fun DraStic's translation
+support. The upstream font and its license have not been identified by the
+project. Confirm its origin and terms with tenlevels before a public release
+that includes it.
+
+DraStic (bin/drastic64, system/drastic_bios_*.bin, game_database.xml,
+config/usrcheat.dat)
+--------------------------------------------------------------------
+DraStic is a proprietary closed-source Nintendo DS emulator. The binary here is
+byte-identical to the one the primary DraStic package ships. The two
+system/drastic_bios_*.bin files are DraStic's own free replacement BIOS, not
+Nintendo material.
+
+Fun DraStic (lib/libfundrastic.so and the presentation assets)
+--------------------------------------------------------------
+Copyright (c) tenlevels. Proprietary, redistributed with written permission.
+See DISTRIBUTION-BASIS.md.

--- a/stage/mlp1.mk
+++ b/stage/mlp1.mk
@@ -5,6 +5,13 @@
 STAGE_APPS ?= ssh-server Thing-File CentralScrutinizer Fugazi joes-calibrage retroarch-builds
 # fun-drastic joins this list in the same change that flips the catalog entry
 # to "packaged" -- validate_packaged_cores couples the two.
+#
+# Its upstream archive is authorized material with no public home, so a
+# contributor without a copy cannot build it. `make stage-emulators` therefore
+# skips it with an explanatory note when FUN_DRASTIC_ARCHIVE is unset, rather
+# than failing the whole run; asking for it by name still fails loudly, and a
+# release build fails hard, because a release must not silently omit a core the
+# catalog marks packaged.
 STAGE_EMULATORS ?= ppsspp drastic mupen64plus flycast yabasanshiro fun-drastic
 PUBLIC_ROOT_DIRS ?= Roms Images Videos Apps BIOS Saves States Cheats
 
@@ -479,6 +486,13 @@ stage-emulators:
 	emulators="$(STAGE_EMULATORS)"; \
 	if [ -n "$$emulators" ]; then \
 		for emulator in $$emulators; do \
+			if [ "$$emulator" = "fun-drastic" ] && [ -z "$(FUN_DRASTIC_ARCHIVE)" ]; then \
+				echo "Skipping fun-drastic: FUN_DRASTIC_ARCHIVE is not set."; \
+				echo "  Fun DraStic packages from a reviewed upstream archive that is not"; \
+				echo "  published. Everything else stages normally. To include it:"; \
+				echo "    make stage-emulators DEVICE=$(DEVICE) FUN_DRASTIC_ARCHIVE=/path/to/drastic.zip"; \
+				continue; \
+			fi; \
 			$(MAKE) stage-emulator EMULATOR="$$emulator" DEVICE="$(DEVICE)"; \
 		done; \
 	fi

--- a/stage/mlp1.mk
+++ b/stage/mlp1.mk
@@ -3,7 +3,9 @@
 
 # Apps staged by `make stage`.
 STAGE_APPS ?= ssh-server Thing-File CentralScrutinizer Fugazi joes-calibrage retroarch-builds
-STAGE_EMULATORS ?= ppsspp drastic mupen64plus flycast yabasanshiro
+# fun-drastic joins this list in the same change that flips the catalog entry
+# to "packaged" -- validate_packaged_cores couples the two.
+STAGE_EMULATORS ?= ppsspp drastic mupen64plus flycast yabasanshiro fun-drastic
 PUBLIC_ROOT_DIRS ?= Roms Images Videos Apps BIOS Saves States Cheats
 
 # --- Launcher payload assembly inputs --------------------------------------
@@ -31,6 +33,11 @@ MLP1_DRASTIC_PACKAGE ?= $(LEAF_ROOT)/build/drastic/mlp1/drastic
 MLP1_MUPEN64PLUS_PACKAGE ?= $(N64_STANDALONE_DIR)/output/mlp1/mupen64plus
 MLP1_FLYCAST_PACKAGE ?= $(FLYCAST_STANDALONE_DIR)/output/mlp1/flycast
 MLP1_YABASANSHIRO_PACKAGE ?= $(YABASANSHIRO_STANDALONE_DIR)/output/mlp1/yabasanshiro
+MLP1_FUN_DRASTIC_PACKAGE ?= $(FUN_DRASTIC_STANDALONE_DIR)/output/mlp1/fun-drastic
+# The reviewed Fun DraStic archive, supplied explicitly. Empty by default: the
+# product repo refuses to package without it, which is the intended behavior
+# for a contributor who has no authorized copy.
+FUN_DRASTIC_ARCHIVE ?=
 MLP1_FFMPEG_BIN    ?= $(RETROARCH_BUILDS_DIR)/output/mlp1/ffmpeg/bin/ffmpeg
 MLP1_FFMPEG_LIBS   ?= $(RETROARCH_BUILDS_DIR)/output/mlp1/ffmpeg/flat
 MLP1_RECORD_CONVERT ?= $(RETROARCH_BUILDS_DIR)/config/mlp1/leaf-record-convert.sh
@@ -417,6 +424,12 @@ stage-emulator:
 			package_dir="$(MLP1_YABASANSHIRO_PACKAGE)"; \
 			remote_name="yabasanshiro"; \
 			;; \
+		fun-drastic) \
+			test -d "$(FUN_DRASTIC_STANDALONE_DIR)" || { echo "missing repo: $(FUN_DRASTIC_STANDALONE_DIR)" >&2; exit 1; }; \
+			$(MAKE) -C "$(FUN_DRASTIC_STANDALONE_DIR)" package-mlp1 FUN_DRASTIC_ARCHIVE="$(FUN_DRASTIC_ARCHIVE)"; \
+			package_dir="$(MLP1_FUN_DRASTIC_PACKAGE)"; \
+			remote_name="fun-drastic"; \
+			;; \
 		*) \
 			echo "unsupported emulator policy: $(EMULATOR) for DEVICE=$(DEVICE)" >&2; \
 			exit 1; \
@@ -542,6 +555,8 @@ release-zips:
 	N64_STANDALONE_DIR="$(N64_STANDALONE_DIR)" \
 	FLYCAST_STANDALONE_DIR="$(FLYCAST_STANDALONE_DIR)" \
 	YABASANSHIRO_STANDALONE_DIR="$(YABASANSHIRO_STANDALONE_DIR)" \
+	FUN_DRASTIC_STANDALONE_DIR="$(FUN_DRASTIC_STANDALONE_DIR)" \
+	FUN_DRASTIC_ARCHIVE="$(FUN_DRASTIC_ARCHIVE)" \
 	RETROARCH_BUILDS_DIR="$(RETROARCH_BUILDS_DIR)" \
 	CORES_SPRUCE_DIR="$(CORES_SPRUCE_DIR)" \
 	LAUNCHER_SWITCHER_DIR="$(LAUNCHER_SWITCHER_DIR)" \
@@ -559,6 +574,7 @@ release-zips:
 	MLP1_MUPEN64PLUS_PACKAGE="$(MLP1_MUPEN64PLUS_PACKAGE)" \
 	MLP1_FLYCAST_PACKAGE="$(MLP1_FLYCAST_PACKAGE)" \
 	MLP1_YABASANSHIRO_PACKAGE="$(MLP1_YABASANSHIRO_PACKAGE)" \
+	MLP1_FUN_DRASTIC_PACKAGE="$(MLP1_FUN_DRASTIC_PACKAGE)" \
 	MLP1_RETROARCH_PATCH_SET="$(MLP1_RETROARCH_PATCH_SET)" \
 	"$(LEAF_ROOT)/scripts/make-sd-release-zip.sh" both
 
@@ -581,6 +597,8 @@ release-sd-zip:
 	N64_STANDALONE_DIR="$(N64_STANDALONE_DIR)" \
 	FLYCAST_STANDALONE_DIR="$(FLYCAST_STANDALONE_DIR)" \
 	YABASANSHIRO_STANDALONE_DIR="$(YABASANSHIRO_STANDALONE_DIR)" \
+	FUN_DRASTIC_STANDALONE_DIR="$(FUN_DRASTIC_STANDALONE_DIR)" \
+	FUN_DRASTIC_ARCHIVE="$(FUN_DRASTIC_ARCHIVE)" \
 	RETROARCH_BUILDS_DIR="$(RETROARCH_BUILDS_DIR)" \
 	CORES_SPRUCE_DIR="$(CORES_SPRUCE_DIR)" \
 	LAUNCHER_SWITCHER_DIR="$(LAUNCHER_SWITCHER_DIR)" \
@@ -598,6 +616,7 @@ release-sd-zip:
 	MLP1_MUPEN64PLUS_PACKAGE="$(MLP1_MUPEN64PLUS_PACKAGE)" \
 	MLP1_FLYCAST_PACKAGE="$(MLP1_FLYCAST_PACKAGE)" \
 	MLP1_YABASANSHIRO_PACKAGE="$(MLP1_YABASANSHIRO_PACKAGE)" \
+	MLP1_FUN_DRASTIC_PACKAGE="$(MLP1_FUN_DRASTIC_PACKAGE)" \
 	MLP1_RETROARCH_PATCH_SET="$(MLP1_RETROARCH_PATCH_SET)" \
 	"$(LEAF_ROOT)/scripts/make-sd-release-zip.sh" install
 


### PR DESCRIPTION
Stages **Fun DraStic** as the second Nintendo DS emulator and gates it.
Companion to Fun-Drastic-standalone#1; Leaf stays a dispatcher and never
reimplements the archive extraction.

### Coupling

`validate_packaged_cores` fails a release build when a core marked `packaged`
has no staged launcher or no license file, so the catalog entry, the staged
package, `licenses/cores/fun_drastic.txt` and `STAGE_EMULATORS` have to move
together. That is why this PR carries all four.

### The BIOS gate is the part worth reviewing

Two BIOS sets have confusingly similar names and only one may ship:

| Files | What | Ships |
| --- | --- | --- |
| `drastic_bios_arm7.bin`, `drastic_bios_arm9.bin` | DraStic's own free replacement BIOS | **yes**, in both NDS packages |
| `nds_bios_arm7.bin`, `nds_bios_arm9.bin`, `nds_firmware.bin` | the Nintendo dumps | **never** |

`validate-fun-drastic-release.py` requires the first pair at their exact sizes
and rejects the second set. A second gate scans the assembled payload, and a
third scans the finished install and recovery ZIPs - deliberately redundant
with the package allowlist, because the allowlist is the thing a future change
might loosen. A gate that matched on `drastic_bios_*` would fail the release on
the existing primary DraStic package, so it does not.

The validator also holds DraStic as the NDS default, requires the hook assets
the frontend resolves from disk, and rejects a wrapper that hardcodes an input
node or stores state in the launcher-owned control tree. 26 policy test cases.

### Contributor behaviour

The upstream archive is not published, so `make stage-emulators` **skips**
fun-drastic with a note explaining why and how to include it. Asking for it by
name still fails loudly, and a release build still fails hard - a release must
not silently omit a core the catalog marks packaged. Without this, adding
fun-drastic to `STAGE_EMULATORS` would break `make stage` for everyone outside
the project.

### ROSTER005

Four wrappers now carry near-identical copies of the awk that resolves the
calibrated pad from `/proc/bus/input/devices`, and they have drifted apart in
two ways, both silent: a field test of `/^event[0-9]+$/` misses
`H: Handlers=event6` because the key is glued to the first handler, and
resetting state on the blank separator instead of the `/^I:/` record header
leaks the previous device's node into the next record - returning a real but
wrong path that passes the caller's own `[ -e ]` check.

Run against the copies as they stand on `main` this reproduces the split
exactly (N64 one finding, both ports copies two) and reports none against the
three branches that fix them. A shared snippet was the obvious alternative and
is the wrong tool here: these are independent product repos by design. Leaf
already scans every staged package, so the check belongs here.

Fixes in flight separately: leaf-n64-standalone#3,
miniloong-launcher-switcher#30, PortMaster-mlp1#5.

---

### Where this sits

Seven PRs, all on `agent/fun-drastic-mlp1`, implementing
`umrk-workspace/plans/fun-drastic-secondary-nds-emulator.md`. Merge in this
order - 2, 3 and 4 are coupled by `validate_packaged_cores`, which fails a
release build when a core marked `packaged` has no staged launcher or no
license file:

1. **Fun-Drastic-standalone#1** - the product repo. Nothing else builds without it.
2. **umrk-workspace** - catalog generator and regenerated catalogs.
3. **miniloong-launcher-switcher** and **CentralScrutinizer** - byte-for-byte catalog copies.
4. **Leaf** - staging dispatch, `STAGE_EMULATORS`, license, release gates.
5. **Jawaka** - standalone policy. Independent of the rest; safe any time.
6. **leaf-docs** - land last, so the docs never describe something that has not shipped.

Opened as drafts because of that ordering, not because the work is unfinished.

### What is not done

- Release authorization: `licenses/DISTRIBUTION-BASIS.md` records tenlevels'
  permission and its scope but names no preserved artifact. That reference has
  to go in before a public release includes the package.
- Device matrix gaps: `.7z` content, audio, fast-forward, suspend/resume,
  touch cursor, paired *wireless* controllers, and real Nintendo BIOS.
- Package size: ~35 MB, of which 13.7 MB is a `usrcheat.dat` duplicating the
  one the primary DraStic package already ships. Worth checking against the
  ZIP budget before leaving it enabled by default.

No version tag is pushed; a release stays a separate explicit request.
