### PR TITLE
Fix release validation from a clean workspace worktree

### DIFF
--- a/scripts/make-sd-release-zip.sh
+++ b/scripts/make-sd-release-zip.sh
@@ -487,6 +487,7 @@ validate_retroarch_contract() {
     local report="$platform_dir/cores/build-report.json"
     [ -f "$report" ] || die "missing MLP1 core build report: $report"
     python3 "$UMRK_WORKSPACE_DIR/scripts/retroarch_validate_package.py" \
+        --umrk-root "$WORKSPACE_DIR" \
         --metadata-dir "$UMRK_WORKSPACE_DIR/plans/retroarch/generated/mlp1" \
         --build-report "$report" \
         --package-root "$platform_dir" \


### PR DESCRIPTION
Release packaging fails when UMRK_WORKSPACE_DIR points at a clean worktree: the RetroArch validator infers the wrong sibling root and reports missing cores and RetroArch even though they are present in the assembled package.

Pass the configured WORKSPACE_DIR explicitly, as the staging validator already does. Validation remains fully enabled.

Validation: bash syntax check; reproduced the release failure, then ran the corrected invocation against the exact failed candidate's assembled platform and canonical 30-core report. RetroArch package validation passed.
