### PR TITLE
Build Fun DraStic from tenlevels' donated source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ help:
 	@echo "  make stage-emulator EMULATOR=mupen64plus DEVICE=mlp1 stage standalone N64"
 	@echo "  make stage-emulator EMULATOR=flycast DEVICE=mlp1 stage standalone Dreamcast"
 	@echo "  make stage-emulator EMULATOR=yabasanshiro DEVICE=mlp1 stage standalone Saturn"
-	@echo "  make stage-emulator EMULATOR=fun-drastic DEVICE=mlp1 FUN_DRASTIC_ARCHIVE=... stage Fun DraStic"
+	@echo "  make stage-emulator EMULATOR=fun-drastic DEVICE=mlp1 stage Fun DraStic (built from Fun-Drastic-src)"
 	@echo "  make stage-emulators DEVICE=mlp1          stage standalone emulators"
 	@echo "  make stage-app APP=CentralScrutinizer DEVICE=mlp1 stage a single app repo"
 	@echo "  make stage-app APP=Leaf-Itchio-Pak DEVICE=mlp1 explicitly stage the optional Itch.io app"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -23,6 +23,7 @@ url_for() {
         Flycast-standalone)          echo "https://github.com/Utility-Muffin-Research-Kitchen/Flycast-standalone.git" ;;
         Yabasanshiro-standalone)     echo "https://github.com/Utility-Muffin-Research-Kitchen/Yabasanshiro-standalone.git" ;;
         Fun-Drastic-standalone)      echo "https://github.com/Utility-Muffin-Research-Kitchen/Fun-Drastic-standalone.git" ;;
+        Fun-Drastic-src)             echo "https://github.com/Utility-Muffin-Research-Kitchen/Fun-Drastic-src.git" ;;
         retroarch-builds)            echo "https://github.com/Utility-Muffin-Research-Kitchen/retroarch-builds.git" ;;
         Cores-spruce)                echo "https://github.com/Utility-Muffin-Research-Kitchen/Cores-spruce.git" ;;
         mlp1-toolchain)              echo "https://github.com/Utility-Muffin-Research-Kitchen/mlp1-toolchain.git" ;;

--- a/scripts/fun-drastic-stage-policy-smoke.sh
+++ b/scripts/fun-drastic-stage-policy-smoke.sh
@@ -2,22 +2,25 @@
 set -euo pipefail
 
 # Leaf dispatches Fun DraStic to the product repo and never reimplements the
-# archive extraction. This proves the dispatch, the archive passthrough, and
-# the deployment directory without touching a device or a real archive.
+# build. This proves the dispatch, that the source checkout reaches the product
+# repo, and the deployment directory, without touching a device or compiling
+# anything.
 
 LEAF_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fixture="$(mktemp -d "${TMPDIR:-/tmp}/leaf-fun-drastic-stage.XXXXXX")"
 trap 'rm -rf "$fixture"' EXIT
 
 repo="$fixture/Fun-Drastic-standalone"
-mkdir -p "$fixture/bin" "$repo"
+src="$fixture/Fun-Drastic-src"
+mkdir -p "$fixture/bin" "$repo" "$src/src"
 
-# The reviewed archive is supplied explicitly and must reach the product repo
-# unchanged; a dispatcher that dropped it would fail the build there, not here.
-cat >"$repo/Makefile" <<'MAKEFILE'
+# The hook is cross-built from tenlevels' source, so the source checkout is what
+# has to reach the product repo; a dispatcher that dropped it would build from
+# whatever happened to sit beside the product repo instead.
+cat >"$repo/Makefile" <<MAKEFILE
 .PHONY: package-mlp1
 package-mlp1:
-	@test "$(FUN_DRASTIC_ARCHIVE)" = /fixture/drastic.zip
+	@test "\$(FUN_DRASTIC_SRC_DIR)" = "$src"
 	@mkdir -p output/mlp1/fun-drastic/bin
 	@printf '#!/bin/sh\nexit 0\n' >output/mlp1/fun-drastic/launch.sh
 	@chmod 755 output/mlp1/fun-drastic/launch.sh
@@ -30,9 +33,14 @@ exit 0
 ADB
 chmod 755 "$fixture/bin/adb"
 
-expected_url="https://github.com/Utility-Muffin-Research-Kitchen/Fun-Drastic-standalone.git"
-actual_url="$(bash -c 'script="$1"; set --; source "$script"; url_for Fun-Drastic-standalone' _ "$LEAF_ROOT/scripts/bootstrap.sh")"
-[ "$actual_url" = "$expected_url" ]
+for repo_name in Fun-Drastic-standalone Fun-Drastic-src; do
+    expected_url="https://github.com/Utility-Muffin-Research-Kitchen/$repo_name.git"
+    actual_url="$(bash -c 'script="$1"; name="$2"; set --; source "$script"; url_for "$name"' _ "$LEAF_ROOT/scripts/bootstrap.sh" "$repo_name")"
+    [ "$actual_url" = "$expected_url" ] || {
+        echo "bootstrap URL for $repo_name is $actual_url, expected $expected_url" >&2
+        exit 1
+    }
+done
 
 export PATH="$fixture/bin:$PATH"
 export ADB_SERIAL="fixture-device"
@@ -43,7 +51,7 @@ make -s -C "$LEAF_ROOT" stage-emulator \
     EMULATOR=fun-drastic \
     LEAF_WORKSPACE_DIR="$fixture" \
     FUN_DRASTIC_STANDALONE_DIR="$repo" \
-    FUN_DRASTIC_ARCHIVE=/fixture/drastic.zip \
+    FUN_DRASTIC_SRC_DIR="$src" \
     DEVICE_OVERLAY="$fixture/no-overlay" \
     REMOTE_SDCARD_PATH=/mnt/sdcard >/dev/null
 

--- a/scripts/make-sd-release-zip.sh
+++ b/scripts/make-sd-release-zip.sh
@@ -23,7 +23,7 @@ N64_STANDALONE_DIR="${N64_STANDALONE_DIR:-$WORKSPACE_DIR/N64-standalone}"
 FLYCAST_STANDALONE_DIR="${FLYCAST_STANDALONE_DIR:-$WORKSPACE_DIR/Flycast-standalone}"
 YABASANSHIRO_STANDALONE_DIR="${YABASANSHIRO_STANDALONE_DIR:-$WORKSPACE_DIR/Yabasanshiro-standalone}"
 FUN_DRASTIC_STANDALONE_DIR="${FUN_DRASTIC_STANDALONE_DIR:-$WORKSPACE_DIR/Fun-Drastic-standalone}"
-FUN_DRASTIC_ARCHIVE="${FUN_DRASTIC_ARCHIVE:-}"
+FUN_DRASTIC_SRC_DIR="${FUN_DRASTIC_SRC_DIR:-$WORKSPACE_DIR/Fun-Drastic-src}"
 RETROARCH_BUILDS_DIR="${RETROARCH_BUILDS_DIR:-$WORKSPACE_DIR/retroarch-builds}"
 CORES_SPRUCE_DIR="${CORES_SPRUCE_DIR:-$WORKSPACE_DIR/Cores-spruce}"
 LAUNCHER_SWITCHER_DIR="${LAUNCHER_SWITCHER_DIR:-$WORKSPACE_DIR/miniloong-launcher-switcher}"
@@ -825,13 +825,13 @@ package_emulator() {
             ;;
         fun-drastic)
             [ -d "$FUN_DRASTIC_STANDALONE_DIR" ] || die "missing Fun DraStic standalone repo: $FUN_DRASTIC_STANDALONE_DIR"
-            # The archive is authorized material with no public home, so the
-            # product repo needs it named explicitly and refuses to guess.
-            [ -n "$FUN_DRASTIC_ARCHIVE" ] || die "FUN_DRASTIC_ARCHIVE is not set.
-Fun DraStic packages from a reviewed upstream archive that is not published.
-Supply it, or drop fun-drastic from STAGE_EMULATORS for this build."
+            # The hook is cross-built from tenlevels' donated source, mirrored
+            # in Fun-Drastic-src; a release must not silently omit a core the
+            # catalog marks packaged, so a missing checkout fails the build.
+            [ -d "$FUN_DRASTIC_SRC_DIR" ] || die "missing Fun DraStic source repo: $FUN_DRASTIC_SRC_DIR
+Clone it (make bootstrap), or drop fun-drastic from STAGE_EMULATORS for this build."
             make -C "$FUN_DRASTIC_STANDALONE_DIR" package-mlp1 \
-                FUN_DRASTIC_ARCHIVE="$FUN_DRASTIC_ARCHIVE"
+                FUN_DRASTIC_SRC_DIR="$FUN_DRASTIC_SRC_DIR"
             package_dir="$MLP1_FUN_DRASTIC_PACKAGE"
             remote_name="fun-drastic"
             ;;

--- a/scripts/validate-fun-drastic-release-test.py
+++ b/scripts/validate-fun-drastic-release-test.py
@@ -72,14 +72,17 @@ def write_manifest(package: Path) -> None:
         "package_schema_version": 1,
         "config_schema_version": 1,
         "source_archive": "drastic.zip",
-        "source_archive_sha256": "6" * 64,
+        "source_funhook_sha256": "6" * 64,
+        "hook_built_from_source": True,
+        "source_repo": "https://github.com/Utility-Muffin-Research-Kitchen/Fun-Drastic-src",
+        "license": "PolyForm-Noncommercial-1.0.0",
         "binary": "bin/drastic64",
         "binary_sha256": sha256(package / "bin/drastic64"),
         "entrypoint": "launch.sh",
         "sdl_video_driver": "wayland",
         "bundled_bios": [f"system/{name}" for name in BUNDLED_BIOS],
         "authorization": "licenses/DISTRIBUTION-BASIS.md",
-        "distribution_status": "proprietary-used-with-permission",
+        "distribution_status": "noncommercial-license",
         "exceptions": [
             {
                 "artifact": "bin/drastic64",
@@ -176,7 +179,12 @@ def fixture(root: Path) -> Path:
     for name, size in BUNDLED_BIOS.items():
         (package / "system" / name).write_bytes(b"\x00" * size)
     (package / "Overlays/960x720/Template/aspect_single.png").write_bytes(b"png\n")
-    for name in ("DISTRIBUTION-BASIS.md", "THIRD-PARTY-NOTICES.txt"):
+    for name in (
+        "DISTRIBUTION-BASIS.md",
+        "THIRD-PARTY-NOTICES.txt",
+        "FUN-DRASTIC-LICENSE.txt",
+        "CREDITS.md",
+    ):
         (package / "licenses" / name).write_text(name + "\n", encoding="utf-8")
 
     os.chmod(package / "bin/drastic64", 0o755)
@@ -313,7 +321,7 @@ def main() -> None:
         "unpinned-archive",
         lambda platform: rewrite_json(
             platform / package_rel / "manifest.json",
-            lambda data: data.update(source_archive_sha256=""),
+            lambda data: data.update(source_funhook_sha256=""),
         ),
         False,
     )

--- a/scripts/validate-fun-drastic-release.py
+++ b/scripts/validate-fun-drastic-release.py
@@ -56,7 +56,15 @@ REQUIRED_HOOK_ASSETS = (
     "res/cursor/1.png",
 )
 
-REQUIRED_LICENSES = ("DISTRIBUTION-BASIS.md", "THIRD-PARTY-NOTICES.txt")
+REQUIRED_LICENSES = (
+    "DISTRIBUTION-BASIS.md",
+    "THIRD-PARTY-NOTICES.txt",
+    # tenlevels' own licence and credits, shipped verbatim. The PolyForm
+    # licence carries a required notice, so a release that drops it is not
+    # one we may ship.
+    "FUN-DRASTIC-LICENSE.txt",
+    "CREDITS.md",
+)
 
 FORBIDDEN_TOP_LEVEL = {
     "backup",
@@ -269,12 +277,22 @@ def validate_package(platform_dir: Path) -> tuple[int, str]:
     for key, expected in expected_fields.items():
         if manifest.get(key) != expected:
             fail(f"Fun DraStic manifest {key} must be {expected!r}")
-    if not SHA256_RE.fullmatch(str(manifest.get("source_archive_sha256", ""))):
-        fail("Fun DraStic manifest must pin the source archive SHA-256")
+    # The hook is built from source now, so the release pins the source it came
+    # from rather than a binary archive.
+    if not SHA256_RE.fullmatch(str(manifest.get("source_funhook_sha256", ""))):
+        fail("Fun DraStic manifest must pin the funhook.c it was built from")
+    if manifest.get("hook_built_from_source") is not True:
+        fail("Fun DraStic manifest must record that the hook was built from source")
+    if not str(manifest.get("source_repo", "")).startswith("http"):
+        fail("Fun DraStic manifest must record where the source came from")
     if manifest.get("authorization") != "licenses/DISTRIBUTION-BASIS.md":
         fail("Fun DraStic manifest must reference the recorded distribution basis")
-    if manifest.get("distribution_status") != "proprietary-used-with-permission":
-        fail("Fun DraStic manifest must record its proprietary distribution status")
+    if manifest.get("license") != "PolyForm-Noncommercial-1.0.0":
+        fail("Fun DraStic manifest must record the PolyForm Noncommercial licence")
+    if manifest.get("distribution_status") != "noncommercial-license":
+        fail("Fun DraStic manifest must record its noncommercial distribution status")
+    if str(manifest.get("author", "")).lower() != "tenlevels":
+        fail("Fun DraStic manifest must credit tenlevels as the author")
     exceptions = json.dumps(manifest.get("exceptions") or [])
     if "not built by UMRK" not in exceptions:
         fail("Fun DraStic manifest must record the prebuilt-binary exception")

--- a/stage/common.mk
+++ b/stage/common.mk
@@ -24,6 +24,7 @@ N64_STANDALONE_DIR     ?= $(WORKSPACE_DIR)/N64-standalone
 FLYCAST_STANDALONE_DIR ?= $(WORKSPACE_DIR)/Flycast-standalone
 YABASANSHIRO_STANDALONE_DIR ?= $(WORKSPACE_DIR)/Yabasanshiro-standalone
 FUN_DRASTIC_STANDALONE_DIR ?= $(WORKSPACE_DIR)/Fun-Drastic-standalone
+FUN_DRASTIC_SRC_DIR        ?= $(WORKSPACE_DIR)/Fun-Drastic-src
 RETROARCH_BUILDS_DIR   ?= $(WORKSPACE_DIR)/retroarch-builds
 CORES_SPRUCE_DIR       ?= $(WORKSPACE_DIR)/Cores-spruce
 TOOLCHAIN_DIR          ?= $(WORKSPACE_DIR)/mlp1-toolchain
@@ -33,7 +34,7 @@ LAUNCHER_SWITCHER_DIR  ?= $(WORKSPACE_DIR)/miniloong-launcher-switcher
 TOOLCHAIN_IMAGE ?= ghcr.io/utility-muffin-research-kitchen/mlp1-toolchain:local
 
 # Public sibling repos required for contributor build/stage workflows.
-REQUIRED_REPOS := Catastrophe Jawaka Thing-File ssh-server CentralScrutinizer Fugazi joes-calibrage PPSSPP-spruce steward-fu-nds N64-standalone Flycast-standalone Yabasanshiro-standalone Fun-Drastic-standalone \
+REQUIRED_REPOS := Catastrophe Jawaka Thing-File ssh-server CentralScrutinizer Fugazi joes-calibrage PPSSPP-spruce steward-fu-nds N64-standalone Flycast-standalone Yabasanshiro-standalone Fun-Drastic-standalone Fun-Drastic-src \
                   retroarch-builds Cores-spruce mlp1-toolchain miniloong-launcher-switcher \
                   miniloong-adb-keeper
 

--- a/stage/licenses/cores/fun_drastic.txt
+++ b/stage/licenses/cores/fun_drastic.txt
@@ -1,15 +1,23 @@
 Fun DraStic
 ===========
 
-Fun DraStic is by tenlevels. It is proprietary material redistributed in Leaf
-with the author's written permission. It is not open source, and no
-open-source license applies to it. Do not treat this file as a grant of one.
+Fun DraStic is by tenlevels. It is his project: the frontend hook, the menus,
+the themes and the overlays are his work, and Leaf packages it rather than
+authoring it. It is licensed under the PolyForm Noncommercial License 1.0.0 -
+noncommercial use only. It is not open source in the OSI sense; do not treat
+this file as a grant of an open-source licence.
 
-The package is not a single work. The frontend hook and presentation assets
-are tenlevels' own; the emulator binary, the replacement BIOS, the bundled
-libraries and the fonts each keep their own terms. tenlevels' permission is
-attributed only to the material tenlevels owns or is authorized to
+The hook Leaf ships is cross-built from tenlevels' own source, mirrored at
+https://github.com/Utility-Muffin-Research-Kitchen/Fun-Drastic-src.
+
+The package is not a single work. The hook and presentation assets are
+tenlevels'; the emulator binary, the replacement BIOS, the databases, the
+bundled libraries and the fonts each keep their own terms. The PolyForm licence
+is attributed only to the material tenlevels owns or is authorized to
 redistribute.
+
+Any Leaf release that bundles Fun DraStic inherits the noncommercial
+restriction.
 
 The Nintendo DS BIOS and firmware dumps are never shipped in any form.
 
@@ -24,31 +32,44 @@ DISTRIBUTION BASIS
 
 # Fun DraStic distribution basis
 
-Fun DraStic is proprietary material redistributed with permission. It is not
-open source and no open-source license applies to it. This file records the
-basis on which the package is built and shipped.
+**Fun DraStic is tenlevels' work.** This repository packages it for Leaf on the
+MLP1; it does not author it. The hook, the menus, the themes, the overlays and
+the MLP1 bring-up are his. This file records the terms the package is built and
+shipped under.
 
-## Permission
+## Licence
 
-tenlevels, the author of Fun DraStic, gave the project written permission to
-use and redistribute Fun DraStic as part of Leaf. The permission was given in
-a private Discord message; a copy is preserved by the project maintainer with
-the sender identity and date. The private message itself is not published.
+Fun DraStic's own code and packaging are under the **PolyForm Noncommercial
+License 1.0.0**, with the required notice:
 
-Permission covers:
+> Copyright (c) 2026 The Fun Drastic authors
 
-- hosting the reviewed source archive or a package derived from it;
-- bundling that package in downloadable Leaf releases;
-- the packaging-only changes described in this repository (a rewritten launch
-  wrapper, an allowlisted file set, generated manifest and notices).
+The full text ships in the package as `licenses/FUN-DRASTIC-LICENSE.txt`, taken
+verbatim from his source tree. Use, modification and sharing are permitted for
+**noncommercial purposes only**.
 
-It does not transfer ownership and it does not make the material open source.
+That is a change from how this package started. It was first built from a
+binary drop redistributed under written permission given in a private Discord
+message. tenlevels then donated the source under PolyForm Noncommercial, which
+supersedes that arrangement: the basis is now a published licence anyone can
+read and check, rather than a private message only the maintainer holds.
 
-> **Release gate.** Before a public Leaf release includes Fun DraStic, confirm
-> the preserved permission still covers the list above and record the archival
-> reference in the release provenance. If it does not, Fun DraStic stays out of
-> the default release list; the same packaging still supports an explicitly
-> supplied local archive for authorized device-local use.
+> **Release gate.** Any Leaf release bundling Fun DraStic inherits the
+> noncommercial restriction. Leaf must not be sold, bundled with hardware for
+> sale, or otherwise commercially exploited while this package is in the
+> release list. If that changes, Fun DraStic comes out of the default release
+> list; the packaging still supports a local build for noncommercial use.
+
+## What is built here, and what is not
+
+`lib/libfundrastic.so` is cross-compiled from tenlevels' `src/funhook.c` with
+the MLP1 toolchain — the manifest records the source repository, commit and the
+SHA-256 of the exact `funhook.c` it came from. Building it from source rather
+than shipping his binary is the only reason this repository can claim to know
+what is in it.
+
+Everything else that is not ours is redistributed unmodified and pinned by
+hash in `upstream.env`, because we do not compile it.
 
 ## Component ownership
 
@@ -56,12 +77,12 @@ The package is not a single work. Each component keeps its own terms.
 
 | Component | Owner / origin | Terms |
 | --- | --- | --- |
-| `lib/libfundrastic.so` (the Fun DraStic frontend hook) | tenlevels | Proprietary, used with permission |
-| `Overlays/`, `themes/`, `res/cursor/` (presentation assets) | tenlevels | Proprietary, used with permission |
+| `lib/libfundrastic.so` (the Fun DraStic hook) | tenlevels | PolyForm Noncommercial 1.0.0; built here from his source |
+| `Overlays/`, `themes/`, `res/cursor/`, `language/*.txt` (presentation assets) | tenlevels and contributors | PolyForm Noncommercial 1.0.0 |
 | `bin/drastic64` | Exophase / DraStic | Proprietary closed-source emulator; the same prebuilt binary the primary DraStic package ships |
 | `system/drastic_bios_arm7.bin`, `system/drastic_bios_arm9.bin` | DraStic | DraStic's own free replacement BIOS, distributed with DraStic |
-| `config/usrcheat.dat`, `game_database.xml` | DraStic distribution | Redistributed as part of the DraStic data set |
-| `language/*.txt` | tenlevels and contributors | Proprietary, used with permission |
+| `game_database.xml` | DraStic distribution | Redistributed as part of the DraStic data set |
+| `config/usrcheat.dat` | the DS cheat scene | Community-maintained cheat database, assembled over many years |
 | `fonts/Nunito-Bold.ttf` | The Nunito Project Authors | SIL Open Font License 1.1 |
 | `fonts/Translate.otf` | Adobe / the Noto Project (this is Noto Sans CJK SC Regular under another filename) | SIL Open Font License 1.1 |
 | `lib/libSDL2-2.0.so.0` | SDL | zlib license |
@@ -70,9 +91,12 @@ The package is not a single work. Each component keeps its own terms.
 | `lib/libwayland-cursor.so.0` | Wayland project | MIT |
 | Packaging code in this repository | UMRK | See `LICENSE` |
 
-tenlevels' permission is attributed only to the material tenlevels owns or is
-authorized to redistribute. It is not a license for `bin/drastic64`, the
-bundled libraries, or the fonts.
+The PolyForm licence covers what tenlevels owns. It is not a licence for
+`bin/drastic64`, the DraStic databases, the bundled libraries, or the fonts —
+`licenses/CREDITS.md`, which is his own credits file, is the authoritative list
+of what Fun DraStic is built on.
+
+Fun DraStic is not affiliated with or endorsed by Exophase or Nintendo.
 
 ## Nintendo BIOS
 
@@ -184,5 +208,10 @@ Nintendo material.
 
 Fun DraStic (lib/libfundrastic.so and the presentation assets)
 --------------------------------------------------------------
-Copyright (c) tenlevels. Proprietary, redistributed with written permission.
-See DISTRIBUTION-BASIS.md.
+Copyright (c) 2026 The Fun Drastic authors.
+
+Fun DraStic is tenlevels' work, licensed under the PolyForm Noncommercial
+License 1.0.0 - noncommercial use only. The hook shipped here is cross-built
+from his own source; the full licence text is in FUN-DRASTIC-LICENSE.txt and
+his credits file in CREDITS.md, both verbatim from his source tree. See
+DISTRIBUTION-BASIS.md.

--- a/stage/mlp1.mk
+++ b/stage/mlp1.mk
@@ -6,12 +6,10 @@ STAGE_APPS ?= ssh-server Thing-File CentralScrutinizer Fugazi joes-calibrage ret
 # fun-drastic joins this list in the same change that flips the catalog entry
 # to "packaged" -- validate_packaged_cores couples the two.
 #
-# Its upstream archive is authorized material with no public home, so a
-# contributor without a copy cannot build it. `make stage-emulators` therefore
-# skips it with an explanatory note when FUN_DRASTIC_ARCHIVE is unset, rather
-# than failing the whole run; asking for it by name still fails loudly, and a
-# release build fails hard, because a release must not silently omit a core the
-# catalog marks packaged.
+# It builds like every other emulator now: tenlevels donated the Fun DraStic
+# source, it is mirrored in the Fun-Drastic-src sibling checkout, and the hook
+# is cross-built from it. There is no unpublished archive to supply and so no
+# special case here any more.
 STAGE_EMULATORS ?= ppsspp drastic mupen64plus flycast yabasanshiro fun-drastic
 PUBLIC_ROOT_DIRS ?= Roms Images Videos Apps BIOS Saves States Cheats
 
@@ -439,7 +437,8 @@ stage-emulator:
 			;; \
 		fun-drastic) \
 			test -d "$(FUN_DRASTIC_STANDALONE_DIR)" || { echo "missing repo: $(FUN_DRASTIC_STANDALONE_DIR)" >&2; exit 1; }; \
-			$(MAKE) -C "$(FUN_DRASTIC_STANDALONE_DIR)" package-mlp1 FUN_DRASTIC_ARCHIVE="$(FUN_DRASTIC_ARCHIVE)"; \
+			test -d "$(FUN_DRASTIC_SRC_DIR)" || { echo "missing repo: $(FUN_DRASTIC_SRC_DIR) (run: make bootstrap)" >&2; exit 1; }; \
+			$(MAKE) -C "$(FUN_DRASTIC_STANDALONE_DIR)" package-mlp1 FUN_DRASTIC_SRC_DIR="$(FUN_DRASTIC_SRC_DIR)"; \
 			package_dir="$(MLP1_FUN_DRASTIC_PACKAGE)"; \
 			remote_name="fun-drastic"; \
 			;; \
@@ -492,13 +491,6 @@ stage-emulators:
 	emulators="$(STAGE_EMULATORS)"; \
 	if [ -n "$$emulators" ]; then \
 		for emulator in $$emulators; do \
-			if [ "$$emulator" = "fun-drastic" ] && [ -z "$(FUN_DRASTIC_ARCHIVE)" ]; then \
-				echo "Skipping fun-drastic: FUN_DRASTIC_ARCHIVE is not set."; \
-				echo "  Fun DraStic packages from a reviewed upstream archive that is not"; \
-				echo "  published. Everything else stages normally. To include it:"; \
-				echo "    make stage-emulators DEVICE=$(DEVICE) FUN_DRASTIC_ARCHIVE=/path/to/drastic.zip"; \
-				continue; \
-			fi; \
 			$(MAKE) stage-emulator EMULATOR="$$emulator" DEVICE="$(DEVICE)"; \
 		done; \
 	fi


### PR DESCRIPTION
tenlevels donated the Fun DraStic source. [`Fun-Drastic-src`](https://github.com/Utility-Muffin-Research-Kitchen/Fun-Drastic-src) joins the required siblings, and the product repo is dispatched to with `FUN_DRASTIC_SRC_DIR` instead of an archive path — the hook is cross-built from it exactly as `steward-fu-nds` is for the primary DraStic package.

**This deletes a special case rather than adding one.** `stage-emulators` used to skip fun-drastic with an explanation whenever `FUN_DRASTIC_ARCHIVE` was unset, because the archive was authorized material with no public home and a contributor simply could not get it. There is no unpublished archive any more, so it stages like every other emulator, and a release build fails loudly if the checkout is missing rather than silently omitting a core the catalog marks packaged.

**Licensing.** The donation came under **PolyForm Noncommercial 1.0.0** with a required notice, superseding the permission held in a private Discord message. `validate-fun-drastic-release.py` now gates on that licence, on tenlevels' authorship, on `hook_built_from_source`, on a pinned `source_funhook_sha256`, and on his `LICENSE` and `CREDITS.md` being present in the package — a build that loses his attribution does not ship. The noncommercial restriction reaches any Leaf release bundling Fun DraStic, and `stage/licenses/cores/fun_drastic.txt` says so plainly.

Pairs with [Fun-Drastic-standalone#5](https://github.com/Utility-Muffin-Research-Kitchen/Fun-Drastic-standalone/pull/5); merge that one first.

Verified: `fun-drastic-release-policy-smoke`, `fun-drastic-stage-policy-smoke`, `leaf-release-policy-test` (24 tests) and `verify-release-identity-test` (10 tests) all pass. Package built from source and staged to a real MLP1; the running `drastic64` has the source-built hook mapped in.