### PR TITLE
Verify revised YabaSanshiro corresponding source

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,12 +206,18 @@ Each derives the complete identity from the tag and verifies the built artifact
 afterwards.
 
 Before building a tagged release, run the `Publish corresponding source`
-workflow in `Yabasanshiro-standalone` with the same Leaf tag. The workflow
-publishes the exact GPL source archive and checksum, but no emulator binary.
-Leaf then packages the runtime and records a direct link to that source asset.
-Tagged Leaf builds fail closed if the source tag is missing, points at a
-different standalone commit, or lacks its checksum sidecar. Untagged development
-builds record the public source repository without requiring a release asset.
+workflow in `Yabasanshiro-standalone`. Normally, use the same tag as Leaf. If
+you revise the standalone source while that Leaf release is still unpublished,
+publish an immutable source revision tag and pass it to the Leaf build as
+`YABASANSHIRO_SOURCE_TAG`. The source tag identifies corresponding source only;
+it does not change the Leaf release identity. The workflow publishes the exact
+GPL source archive and checksum, but no emulator binary. Leaf downloads and
+hashes that archive, packages the runtime, and records its tag, commit, direct
+asset URL, and SHA-256. Tagged Leaf builds fail closed if the source tag is
+missing, points at a different standalone commit, lacks its checksum sidecar,
+or serves an archive that does not match the published checksum. Untagged
+development builds record the public source repository without requiring a
+release asset.
 
 Both build the install and recovery ZIPs and verify the embedded provenance plus
 `leaf-update.json`. Release-candidate tags
@@ -320,6 +326,7 @@ Apps/
   mlp1/<Name>.pak/
   shared/<Name>.pak/
 BIOS/
+  SATURN/            # Saturn firmware for RetroArch and standalone selection
 Saves/
 States/
 Cheats/

--- a/scripts/make-sd-release-zip.sh
+++ b/scripts/make-sd-release-zip.sh
@@ -748,11 +748,23 @@ package_app() {
     printf '%s/%s\n' "$destination_platform" "$package_name" >>"$MANAGED_APPS_FILE"
 }
 
+# The Saturn corresponding source has its own immutable revision tag when the
+# wrapper changes inside an unpublished Leaf release: the old source tag and its
+# assets must never be replaced, and a source-only tag must never become the
+# Leaf release identity. YABASANSHIRO_SOURCE_TAG selects it; unset, this is
+# exactly the old matching-tag behavior. A differing source tag is not
+# permission to build from a differing source commit -- the tag-to-commit,
+# archive and checksum gates below are unchanged.
+# See umrk-workspace/plans/bios-selection-source-release.md.
 prepare_yabasanshiro_source() {
     local source_repo="https://github.com/Utility-Muffin-Research-Kitchen/Yabasanshiro-standalone"
-    local source_tag="$LEAF_RELEASE_TAG"
+    local source_tag="${YABASANSHIRO_SOURCE_TAG:-$LEAF_RELEASE_TAG}"
     local source_archive source_sha source_name source_extra remote_sha local_sha checksum_file
     local YABASANSHIRO_UPSTREAM_VERSION
+
+    case "$source_tag" in
+        */*) die "invalid YABASANSHIRO_SOURCE_TAG: $source_tag" ;;
+    esac
 
     [ -f "$YABASANSHIRO_STANDALONE_DIR/upstream.env" ] || \
         die "missing YabaSanshiro upstream metadata: $YABASANSHIRO_STANDALONE_DIR/upstream.env"
@@ -762,6 +774,8 @@ prepare_yabasanshiro_source() {
 
     YABASANSHIRO_SOURCE_URL="$source_repo"
     YABASANSHIRO_SOURCE_SHA256=""
+    YABASANSHIRO_SOURCE_TAG_RESOLVED=""
+    YABASANSHIRO_SOURCE_COMMIT=""
     [ -n "$LEAF_RELEASE_TAG" ] || return 0
     [ -n "$source_tag" ] || die "tagged Leaf release has no YabaSanshiro source tag"
     command -v curl >/dev/null 2>&1 || die "curl command not found"
@@ -789,6 +803,8 @@ prepare_yabasanshiro_source() {
     [ "$source_name" = "$source_archive" ] && [ -z "${source_extra:-}" ] || \
         die "YabaSanshiro source checksum names an unexpected asset: ${source_name:-<empty>}"
     YABASANSHIRO_SOURCE_SHA256="$source_sha"
+    YABASANSHIRO_SOURCE_TAG_RESOLVED="$source_tag"
+    YABASANSHIRO_SOURCE_COMMIT="$local_sha"
 }
 
 package_emulator() {
@@ -841,7 +857,9 @@ Clone it (make bootstrap), or drop fun-drastic from STAGE_EMULATORS for this bui
             make -C "$YABASANSHIRO_STANDALONE_DIR" package-mlp1 \
                 TOOLCHAIN_IMAGE="$TOOLCHAIN_IMAGE" \
                 YABASANSHIRO_SOURCE_URL="$YABASANSHIRO_SOURCE_URL" \
-                YABASANSHIRO_SOURCE_SHA256="$YABASANSHIRO_SOURCE_SHA256"
+                YABASANSHIRO_SOURCE_SHA256="$YABASANSHIRO_SOURCE_SHA256" \
+                YABASANSHIRO_SOURCE_TAG="$YABASANSHIRO_SOURCE_TAG_RESOLVED" \
+                YABASANSHIRO_SOURCE_COMMIT="$YABASANSHIRO_SOURCE_COMMIT"
             package_dir="$MLP1_YABASANSHIRO_PACKAGE"
             remote_name="yabasanshiro"
             ;;

--- a/scripts/make-sd-release-zip.sh
+++ b/scripts/make-sd-release-zip.sh
@@ -759,7 +759,8 @@ package_app() {
 prepare_yabasanshiro_source() {
     local source_repo="https://github.com/Utility-Muffin-Research-Kitchen/Yabasanshiro-standalone"
     local source_tag="${YABASANSHIRO_SOURCE_TAG:-$LEAF_RELEASE_TAG}"
-    local source_archive source_sha source_name source_extra remote_sha local_sha checksum_file
+    local source_archive source_sha source_name source_extra remote_sha local_sha
+    local checksum_file source_file downloaded_sha
     local YABASANSHIRO_UPSTREAM_VERSION
 
     case "$source_tag" in
@@ -802,6 +803,15 @@ prepare_yabasanshiro_source() {
     [ "${#source_sha}" -eq 64 ] || die "invalid published YabaSanshiro source checksum"
     [ "$source_name" = "$source_archive" ] && [ -z "${source_extra:-}" ] || \
         die "YabaSanshiro source checksum names an unexpected asset: ${source_name:-<empty>}"
+    source_file="$(mktemp "${TMPDIR:-/tmp}/leaf-yabasanshiro-source-archive.XXXXXX")"
+    if ! curl -fsSL "$YABASANSHIRO_SOURCE_URL" -o "$source_file"; then
+        rm -f "$source_file"
+        die "could not download published YabaSanshiro source archive: $YABASANSHIRO_SOURCE_URL"
+    fi
+    downloaded_sha="$(shasum -a 256 "$source_file" | awk '{print $1}')"
+    rm -f "$source_file"
+    [ "$downloaded_sha" = "$source_sha" ] || \
+        die "published YabaSanshiro source archive checksum mismatch: expected $source_sha, found $downloaded_sha"
     YABASANSHIRO_SOURCE_SHA256="$source_sha"
     YABASANSHIRO_SOURCE_TAG_RESOLVED="$source_tag"
     YABASANSHIRO_SOURCE_COMMIT="$local_sha"

--- a/scripts/validate-yabasanshiro-standalone-release-test.py
+++ b/scripts/validate-yabasanshiro-standalone-release-test.py
@@ -29,7 +29,12 @@ def sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def write_manifest(package: Path, published: bool = True) -> None:
+def write_manifest(
+    package: Path,
+    published: bool = True,
+    source_tag: str | None = "v1.0.0",
+    source_commit: str | None = "b" * 40,
+) -> None:
     files = [
         {"path": path.relative_to(package).as_posix(), "sha256": sha256(path)}
         for path in sorted(package.rglob("*"))
@@ -53,6 +58,8 @@ def write_manifest(package: Path, published: bool = True) -> None:
             ),
             "archive": "yabasanshiro-standalone-1.11.beta3-mlp1-source.tar.gz",
             "sha256": "a" * 64 if published else None,
+            "tag": source_tag,
+            "commit": source_commit,
         },
         "files": files,
     }
@@ -152,6 +159,54 @@ def main() -> None:
 
     run_case("missing-source-hash", missing_source_hash, False)
     run_case("development-source", missing_source_hash, True, published=False)
+
+    # The corresponding source may ship under its own revision tag while the
+    # Leaf release identity stays put, so the recorded tag has to agree with the
+    # asset URL and a tagged release has to record both tag and commit.
+    def source_revision_tag(platform: Path) -> None:
+        package = platform / "emulators/yabasanshiro"
+        manifest_path = package / "manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        source = manifest["corresponding_source"]
+        source["url"] = source["url"].replace(
+            "/download/v1.0.0/", "/download/v1.0.0-source.2/"
+        )
+        source["tag"] = "v1.0.0-source.2"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    def mismatched_source_tag(platform: Path) -> None:
+        package = platform / "emulators/yabasanshiro"
+        write_manifest(package, source_tag="v1.0.0-source.2")
+
+    def missing_source_tag(platform: Path) -> None:
+        package = platform / "emulators/yabasanshiro"
+        write_manifest(package, source_tag=None)
+
+    def missing_source_commit(platform: Path) -> None:
+        package = platform / "emulators/yabasanshiro"
+        write_manifest(package, source_commit=None)
+
+    def malformed_source_commit(platform: Path) -> None:
+        package = platform / "emulators/yabasanshiro"
+        write_manifest(package, source_commit="not-a-commit")
+
+    run_case("source-revision-tag", source_revision_tag, True)
+    run_case("mismatched-source-tag", mismatched_source_tag, False)
+    run_case("missing-source-tag", missing_source_tag, False)
+    run_case("missing-source-commit", missing_source_commit, False)
+    run_case("malformed-source-commit", malformed_source_commit, False)
+    # An untagged development build still needs no source provenance at all.
+    run_case(
+        "development-untagged-source",
+        lambda platform: write_manifest(
+            platform / "emulators/yabasanshiro",
+            published=False,
+            source_tag=None,
+            source_commit=None,
+        ),
+        True,
+        published=False,
+    )
     print("YabaSanshiro standalone release policy checks passed")
 
 

--- a/scripts/validate-yabasanshiro-standalone-release.py
+++ b/scripts/validate-yabasanshiro-standalone-release.py
@@ -20,6 +20,7 @@ SOURCE_URL_RE = re.compile(
     rf"Yabasanshiro-standalone/releases/download/[^/]+/{re.escape(ARCHIVE)}$"
 )
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 REQUIRED_LICENSES = {
     "DISTRIBUTION-BASIS.md",
     "NanoGUI-BSD-3-Clause.txt",
@@ -178,6 +179,32 @@ def validate(platform_dir: Path, require_published_source: bool) -> None:
         or not SHA256_RE.fullmatch(source_sha)
     ):
         fail("tagged release must link a checksummed UMRK source release asset")
+
+    # The corresponding source may be published under its own revision tag when
+    # the wrapper changes inside an unpublished Leaf release, so the tag and the
+    # commit are recorded explicitly rather than inferred from the URL. A tagged
+    # release must carry both and they must agree with the asset URL.
+    source_tag = source.get("tag")
+    source_commit = source.get("commit")
+    if source_tag is not None and (
+        not isinstance(source_tag, str) or not source_tag or "/" in source_tag
+    ):
+        fail("YabaSanshiro corresponding source tag is invalid")
+    if source_commit is not None and (
+        not isinstance(source_commit, str) or not COMMIT_RE.fullmatch(source_commit)
+    ):
+        fail("YabaSanshiro corresponding source commit is invalid")
+    if isinstance(source_tag, str) and SOURCE_URL_RE.fullmatch(source_url):
+        url_tag = source_url.rsplit("/", 2)[-2]
+        if url_tag != source_tag:
+            fail(
+                "YabaSanshiro corresponding source tag does not match its asset "
+                f"URL: {source_tag!r} vs {url_tag!r}"
+            )
+    if require_published_source and not (
+        isinstance(source_tag, str) and isinstance(source_commit, str)
+    ):
+        fail("tagged release must record the source release tag and commit")
 
     file_rows = manifest.get("files")
     if not isinstance(file_rows, list) or not file_rows:


### PR DESCRIPTION
## Summary
- allow an immutable YABASANSHIRO_SOURCE_TAG that does not change Leaf release identity
- verify the source tag still points to the selected standalone checkout
- download and hash the published source archive before recording provenance
- document the override and BIOS/SATURN layout

## Verification
- bash -n scripts/make-sd-release-zip.sh
- python3 scripts/validate-yabasanshiro-standalone-release-test.py